### PR TITLE
Unsupported platforms no-op

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,12 +14,18 @@ end
 # Ruby Extension
 # ==========================================================
 
-require 'rake/extensiontask'
-Rake::ExtensionTask.new('semian', GEMSPEC) do |ext|
-  ext.ext_dir = 'ext/semian'
-  ext.lib_dir = 'lib/semian'
+$:.unshift File.expand_path("../lib", __FILE__)
+require 'semian/platform'
+if Semian.supported_platform?
+  require 'rake/extensiontask'
+  Rake::ExtensionTask.new('semian', GEMSPEC) do |ext|
+    ext.ext_dir = 'ext/semian'
+    ext.lib_dir = 'lib/semian'
+  end
+  task :build => :compile
+else
+  task :build do; end
 end
-task :build => :compile
 
 # ==========================================================
 # Testing
@@ -27,7 +33,11 @@ task :build => :compile
 
 require 'rake/testtask'
 Rake::TestTask.new 'test' do |t|
-  t.test_files = FileList['test/test_*.rb']
+  t.test_files = if Semian.supported_platform?
+    FileList['test/test_semian.rb']
+  else
+    FileList['test/test_unsupported.rb']
+  end
 end
 task :test => :build
 

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -1,5 +1,3 @@
-require 'semian/semian'
-
 #
 # === Overview
 #
@@ -85,4 +83,11 @@ class Semian
   end
 end
 
+require 'semian/platform'
+if Semian.supported_platform?
+  require 'semian/semian'
+else
+  require 'semian/unsupported'
+  $stderr.puts "Semian is not supported on #{RUBY_PLATFORM} - all operations will no-op"
+end
 require 'semian/version'

--- a/lib/semian/platform.rb
+++ b/lib/semian/platform.rb
@@ -1,0 +1,6 @@
+class Semian
+  # Determines if Semian supported on the current platform.
+  def self.supported_platform?
+    RUBY_PLATFORM.end_with?('-linux')
+  end
+end

--- a/lib/semian/unsupported.rb
+++ b/lib/semian/unsupported.rb
@@ -1,0 +1,21 @@
+class Semian
+  MAX_TICKETS = 0
+
+  class Resource #:nodoc:
+    def initialize(name, tickets, permissions, timeout); end
+
+    def destroy; end
+
+    def acquire
+      yield self
+    end
+
+    def count
+      0
+    end
+
+    def semid
+      0
+    end
+  end
+end

--- a/test/test_unsupported.rb
+++ b/test/test_unsupported.rb
@@ -1,0 +1,11 @@
+require 'test/unit'
+require 'semian'
+
+class TestSemian < Test::Unit::TestCase
+  def test_unsupported_acquire_yields
+    acquired = false
+    Semian.register :testing, tickets: 1
+    Semian[:testing].acquire { acquired = true }
+    assert acquired
+  end
+end


### PR DESCRIPTION
@Sirupsen, @byroot, @jeromecornet 

This is a re-work of #7.

This adds a stub for the `Resource` class that effectively no-ops on non-Linux platforms (which is all we currently support). When calling `Resource#acquire` it simply yields.

The code currently prints a warning to STDERR when running on an unsupported platform. I think it's useful, but wouldn't be entirely opposed to removing it, if people think it's too noisy.
