### PR TITLE
Cast resource names to symbols

### DIFF
--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -280,9 +280,7 @@ semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE permission
   semian_resource_t *res = NULL;
   const char *id_str = NULL;
 
-  if (TYPE(id) != T_SYMBOL && TYPE(id) != T_STRING) {
-    rb_raise(rb_eTypeError, "id must be a symbol or string");
-  }
+  Check_Type(id, T_SYMBOL);
   Check_Type(tickets, T_FIXNUM);
   Check_Type(permissions, T_FIXNUM);
   if (TYPE(default_timeout) != T_FIXNUM && TYPE(default_timeout) != T_FLOAT) {

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -67,13 +67,14 @@ class Semian
     #
     # Returns the registered resource.
     def register(name, tickets: 0, permissions: 0660, timeout: 1)
-      resource = Resource.new(name, tickets, permissions, timeout)
-      resources[name] = resource
+      raise ArgumentError.new("Name (#{name.inspect}) must be able to be cast to a symbol (#to_sym)") unless name.respond_to?(:to_sym)
+      resource = Resource.new(name.to_sym, tickets, permissions, timeout)
+      resources[name.to_sym] = resource
     end
 
     # Retrieves a resource by name.
     def [](name)
-      resources[name]
+      resources[name.to_sym]
     end
 
     # Retrieves a hash of all registered resources.

--- a/test/test_semian.rb
+++ b/test/test_semian.rb
@@ -9,7 +9,7 @@ class TestSemian < Test::Unit::TestCase
   end
 
   def test_register_invalid_args
-    assert_raises TypeError do
+    assert_raises ArgumentError do
       Semian.register 123
     end
     assert_raises ArgumentError do
@@ -294,6 +294,16 @@ class TestSemian < Test::Unit::TestCase
     ensure
       f.close!
     end
+  end
+
+  def test_register_casts_to_symbol
+    Semian.register("testing", tickets: 10)
+    assert_instance_of Semian::Resource, Semian[:testing]
+  end
+
+  def test_resource_indexing_casts_to_symbol
+    Semian.register(:testing, tickets: 10)
+    assert_instance_of Semian::Resource, Semian["testing"]
   end
 
 end


### PR DESCRIPTION
Usually the resource name will be indexed by a symbol when accessed directly, however, initialized with a string. Instead of forcing people to initialize as a symbol and run into errors that the resource doesn't exist, let's just enforce symbols.

This does make it impossible to use an object as a resource name, but I think that's cool.

@csfrancis @fw42 
