### PR TITLE
Create an empty Makefile from extconf.rb on unsupported platforms.

### DIFF
--- a/ext/semian/extconf.rb
+++ b/ext/semian/extconf.rb
@@ -1,3 +1,16 @@
+$:.unshift File.expand_path("../../../lib", __FILE__)
+
+require 'semian/platform'
+
+unless Semian.supported_platform?
+  File.write "Makefile", <<MAKEFILE
+all:
+clean:
+install:
+MAKEFILE
+  exit
+end
+
 require 'mkmf'
 
 abort 'openssl is missing. please install openssl.' unless find_header('openssl/sha.h')

--- a/semian.gemspec
+++ b/semian.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.files = `git ls-files`.split("\n")
-  s.extensions = ['ext/semian/extconf.rb'] if Semian.supported_platform?
+  s.extensions = ['ext/semian/extconf.rb']
   s.add_development_dependency 'rake-compiler', '~> 0.9'
 end


### PR DESCRIPTION
@csfrancis & @byroot for review
## Problem

Doing `gem install semian` still fails on unsupported platforms, since it still tries to build the extensions.  Pull #11 tried avoid building the extensions by setting the extensions attribute conditionally in the gemspec, but this gets read at build time.
## Solution

Create a Makefile from extconf.rb that does nothing for the [targets rubygems uses](https://github.com/rubygems/rubygems/blob/3e365282d1fa4210011b3095d685c10483a7a62c/lib/rubygems/ext/builder.rb#L43-L55).  Nothing needs to be written, since rubygems just [moves the contents of the destination directory without looking for any specific files](https://github.com/rubygems/rubygems/blob/3e365282d1fa4210011b3095d685c10483a7a62c/lib/rubygems/ext/ext_conf_builder.rb#L48-L58).
