### PR TITLE
Acquire take one argument

### DIFF
--- a/lib/semian/unsupported.rb
+++ b/lib/semian/unsupported.rb
@@ -11,7 +11,7 @@ class Semian
 
     def destroy; end
 
-    def acquire
+    def acquire(options)
       yield self
     end
 


### PR DESCRIPTION
```
/Users/byroot/.rvm/gems/ruby-2.1.3/gems/semian-0.0.7/lib/semian/unsupported.rb:14:in `acquire': wrong number of arguments (1 for 0) (ArgumentError)
    from /Users/byroot/workspace/shopify/shopify/lib/resiliency/semian.rb:30:in `acquire_with_circuit'
    from /Users/byroot/workspace/shopify/shopify/lib/resiliency/semian/mysql_adapter.rb:77:in `initialize_with_semian'
```

@Sirupsen, @csfrancis for review please.
