### PR TITLE
Refactor Semian to have more control on the ruby side

### DIFF
--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -449,10 +449,10 @@ semian_resource_id(VALUE self)
 
 void Init_semian()
 {
-  VALUE cSemian, cResource, eBaseError;
+  VALUE cSemian, cResource;
   struct seminfo info_buf;
 
-  cSemian = rb_define_class("Semian", rb_cObject);
+  cSemian = rb_const_get(rb_cObject, rb_intern("Semian"));
 
   /*
    * Document-class: Semian::Resource
@@ -462,25 +462,19 @@ void Init_semian()
    *
    *  You should not create this class directly, it will be created indirectly via Semian.register.
    */
-  cResource = rb_define_class_under(cSemian, "Resource", rb_cObject);
-
-  /* Document-class: Semian::BaseError
-   *
-   * Base error class for all other Semian errors.
-   */
-  eBaseError = rb_define_class_under(cSemian, "BaseError", rb_eStandardError);
+  cResource = rb_const_get(cSemian, rb_intern("Resource"));
 
   /* Document-class: Semian::SyscallError
    *
    * Represents a Semian error that was caused by an underlying syscall failure.
    */
-  eSyscall = rb_define_class_under(cSemian, "SyscallError", eBaseError);
+  eSyscall = rb_const_get(cSemian, rb_intern("SyscallError"));
 
   /* Document-class: Semian::TimeoutError
    *
    * Raised when a Semian operation timed out.
    */
-  eTimeout = rb_define_class_under(cSemian, "TimeoutError", eBaseError);
+  eTimeout = rb_const_get(cSemian, rb_intern("TimeoutError"));
 
   /* Document-class: Semian::InternalError
    *
@@ -492,7 +486,7 @@ void Init_semian()
    * using the <code>ipcrm</code> command line tool. Semian will re-initialize
    * the semaphore in this case.
    */
-  eInternal = rb_define_class_under(cSemian, "InternalError", eBaseError);
+  eInternal = rb_const_get(cSemian, rb_intern("InternalError"));
 
   rb_define_alloc_func(cResource, semian_resource_alloc);
   rb_define_method(cResource, "initialize", semian_resource_initialize, 4);

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -83,11 +83,12 @@ class Semian
   end
 end
 
+require 'semian/resource'
 require 'semian/platform'
 if Semian.supported_platform?
   require 'semian/semian'
 else
-  require 'semian/unsupported'
+  Semian::MAX_TICKETS = 0
   $stderr.puts "Semian is not supported on #{RUBY_PLATFORM} - all operations will no-op"
 end
 require 'semian/version'

--- a/lib/semian/resource.rb
+++ b/lib/semian/resource.rb
@@ -1,15 +1,15 @@
 class Semian
-  MAX_TICKETS = 0
-
   BaseError = Class.new(StandardError)
   SyscallError = Class.new(BaseError)
   TimeoutError = Class.new(BaseError)
   InternalError = Class.new(BaseError)
 
   class Resource #:nodoc:
-    def initialize(name, tickets, permissions, timeout); end
+    def initialize(name, tickets, permissions, timeout)
+    end
 
-    def destroy; end
+    def destroy
+    end
 
     def acquire(*)
       yield self


### PR DESCRIPTION
This is just some simple preparatory work to bring circuit breaker in Semian.

Just to have more control about the API etc, I make the C use the Ruby constants instead of the other way around.

@csfrancis @Sirupsen for review please.