### PR TITLE
Initial attempt at Semian::Mysql2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,10 @@ language: ruby
 
 sudo: false
 
+before_install:
+  - wget -O toxiproxy-1.0.0.deb https://github.com/Shopify/toxiproxy/releases/download/v1.0.0/toxiproxy_1.0.0_amd64.deb
+  - sudo dpkg -i toxiproxy-1.0.0.deb
+  - sudo service start toxiproxy
+
 rvm:
   - 2.1.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: ruby
 
-sudo: false
+sudo: true
 
 before_install:
-  - wget -O toxiproxy-1.0.0.deb https://github.com/Shopify/toxiproxy/releases/download/v1.0.0/toxiproxy_1.0.0_amd64.deb
-  - sudo dpkg -i toxiproxy-1.0.0.deb
-  - sudo service start toxiproxy
+  - scripts/install_toxiproxy.sh
 
 rvm:
   - 2.1.1

--- a/Rakefile
+++ b/Rakefile
@@ -29,6 +29,11 @@ else
   task :build do; end
 end
 
+task :populate_proxy do
+  require 'toxiproxy'
+  Toxiproxy.populate(File.expand_path('../test/fixtures/toxiproxy.json', __FILE__))
+end
+
 # ==========================================================
 # Testing
 # ==========================================================
@@ -42,7 +47,7 @@ Rake::TestTask.new 'test' do |t|
     t.test_files = all_files - FileList['test/test_semian.rb']
   end
 end
-task :test => :build
+task :test => [:build, :populate_proxy]
 
 # ==========================================================
 # Documentation

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -56,6 +56,11 @@ require 'logger'
 module Semian
   extend self
 
+  BaseError = Class.new(StandardError)
+  SyscallError = Class.new(BaseError)
+  TimeoutError = Class.new(BaseError)
+  InternalError = Class.new(BaseError)
+
   attr_accessor :logger
 
   self.logger = Logger.new(nil)

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -105,5 +105,3 @@ else
   $stderr.puts "Semian is not supported on #{RUBY_PLATFORM} - all operations will no-op"
 end
 require 'semian/version'
-
-require 'semian/mysql2' if defined?(Mysql2)

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -105,3 +105,5 @@ else
   $stderr.puts "Semian is not supported on #{RUBY_PLATFORM} - all operations will no-op"
 end
 require 'semian/version'
+
+require 'semian/mysql2' if defined?(Mysql2)

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -83,9 +83,19 @@ module Semian
     resources[name] = ProtectedResource.new(resource, circuit_breaker)
   end
 
+  def retrieve_or_register(name, **args)
+    self[name] || register(name, **args)
+  end
+
   # Retrieves a resource by name.
   def [](name)
     resources[name]
+  end
+
+  def destroy(name)
+    if resource = resources.delete(name)
+      resource.destroy
+    end
   end
 
   # Retrieves a hash of all registered resources.

--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -37,7 +37,7 @@ module Semian
     end
 
     def semian_resource
-      @semian_resource ||= ::Semian.register(semian_identifier, **semian_options)
+      @semian_resource ||= ::Semian.retrieve_or_register(semian_identifier, **semian_options)
     end
 
     def semian_options

--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -23,7 +23,7 @@ module Semian
     end
 
     def query(*)
-      semian_resource.acquire { super }
+      semian_resource.with_fallback(-> { raise ::Semian::BaseError }) { super }
     rescue ::Semian::BaseError => error
       raise ::Mysql2::SemianError.new(semian_identifier, error)
     end
@@ -31,7 +31,7 @@ module Semian
     private
 
     def connect(*)
-      semian_resource.acquire { super }
+      semian_resource.with_fallback(-> { raise ::Semian::BaseError }) { super }
     rescue Semian::BaseError => error
       raise ::Mysql2::SemianError.new(semian_identifier, error)
     end

--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -1,0 +1,57 @@
+class Mysql2::SemianError < Mysql2::Error
+  def initialize(semian_identifier, *args)
+    super(*args)
+    @semian_identifier = semian_identifier
+  end
+
+  def to_s
+    "[#{@semian_identifier}] #{super}"
+  end
+end
+
+module Semian
+  module Mysql2
+    class << self
+      attr_accessor :default_options
+
+      def enable!(default_options = {})
+        self.default_options = default_options
+        ::Mysql2::Client.prepend(self)
+      end
+    end
+
+    def semian_identifier
+      @semian_identifier ||= begin
+        name = query_options[:semian_resource]
+        name ||= [query_options[:host] || 'localhost', query_options[:port] || 3306].join(':')
+        :"mysql_#{name}"
+      end
+    end
+
+    def query(*)
+      semian_resource.acquire { super }
+    rescue ::Semian::BaseError => error
+      raise ::Mysql2::SemianError.new(semian_identifier, error)
+    end
+
+    private
+
+    def connect(*)
+      semian_resource.acquire { super }
+    rescue Semian::BaseError => error
+      raise ::Mysql2::SemianError.new(semian_identifier, error)
+    end
+
+    def semian_resource
+      @semian_resource ||= ::Semian.register(semian_identifier, **semian_options)
+    end
+
+    def semian_options
+      options = ::Semian::Mysql2.default_options.dup
+      if query_options.key?(:semian)
+        options.merge!(query_options[:semian].map { |k, v| [k.to_sym, v] }.to_h)
+      end
+      options
+    end
+  end
+end

--- a/lib/semian/protected_resource.rb
+++ b/lib/semian/protected_resource.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 module Semian
   class ProtectedResource
     extend Forwardable

--- a/lib/semian/protected_resource.rb
+++ b/lib/semian/protected_resource.rb
@@ -4,7 +4,7 @@ module Semian
   class ProtectedResource
     extend Forwardable
 
-    def_delegators :@resource, :acquire, :destroy, :count, :semid
+    def_delegators :@resource, :destroy, :count, :semid
     def_delegators :@circuit_breaker, :reset
 
     def initialize(resource, circuit_breaker)
@@ -12,8 +12,12 @@ module Semian
       @circuit_breaker = circuit_breaker
     end
 
+    def acquire(*args, &block)
+      @circuit_breaker.acquire { @resource.acquire(*args, &block) }
+    end
+
     def with_fallback(fallback, &block)
-      @circuit_breaker.with_fallback(fallback) { acquire(&block) }
+      @circuit_breaker.with_fallback(fallback) { @resource.acquire(&block) }
     end
   end
 end

--- a/lib/semian/resource.rb
+++ b/lib/semian/resource.rb
@@ -1,9 +1,4 @@
 module Semian
-  BaseError = Class.new(StandardError)
-  SyscallError = Class.new(BaseError)
-  TimeoutError = Class.new(BaseError)
-  InternalError = Class.new(BaseError)
-
   class Resource #:nodoc:
     def initialize(name, tickets, permissions, timeout)
     end

--- a/scripts/install_toxiproxy.sh
+++ b/scripts/install_toxiproxy.sh
@@ -1,0 +1,25 @@
+set -e
+
+if which toxiproxy > /dev/null; then
+  echo "Toxiproxy is already installed."
+  exit 0
+fi
+
+if which apt-get > /dev/null; then
+  echo "Installing toxiproxy-1.0.0.deb"
+  wget -O /tmp/toxiproxy-1.0.0.deb https://github.com/Shopify/toxiproxy/releases/download/v1.0.0/toxiproxy_1.0.0_amd64.deb
+  sudo dpkg -i /tmp/toxiproxy-1.0.0.deb
+  sudo service toxiproxy start
+  exit 0
+fi
+
+if which brew > /dev/null; then
+  echo "Installing toxiproxy from homebrew."
+  brew tap shopify/shopify
+  brew install toxiproxy
+  brew info toxiproxy
+  exit 0
+fi
+
+echo "Sorry, there is no toxiproxy package available for your system. You might need to build it from source."
+exit 1

--- a/semian.gemspec
+++ b/semian.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.extensions = ['ext/semian/extconf.rb']
   s.add_development_dependency 'rake-compiler', '~> 0.9'
   s.add_development_dependency 'timecop'
+  s.add_development_dependency 'mysql2'
 end

--- a/semian.gemspec
+++ b/semian.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake-compiler', '~> 0.9'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'mysql2'
+  s.add_development_dependency 'toxiproxy'
 end

--- a/test/fixtures/toxiproxy.json
+++ b/test/fixtures/toxiproxy.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": "semian_test_mysql",
+    "upstream": "localhost:3306",
+    "listen": "localhost:43306"
+  }
+]

--- a/test/fixtures/toxiproxy.json
+++ b/test/fixtures/toxiproxy.json
@@ -2,6 +2,6 @@
   {
     "name": "semian_test_mysql",
     "upstream": "localhost:3306",
-    "listen": "localhost:43306"
+    "listen": "localhost:13306"
   }
 ]

--- a/test/test_circuit_breaker.rb
+++ b/test/test_circuit_breaker.rb
@@ -40,6 +40,19 @@ class TestCircuitBreaker < Test::Unit::TestCase
     assert_equal 42, result
   end
 
+  def test_acquire_yield_when_the_circuit_is_closed
+    block_called = false
+    @resource.acquire { block_called = true }
+    assert_equal true, block_called
+  end
+
+  def test_acquire_raises_circuit_open_error_when_the_circuit_is_open
+    open_circuit!
+    assert_raises Semian::CircuitBreaker::OpenCircuitError do
+      @resource.acquire { 1 + 1 }
+    end
+  end
+
   def test_after_error_threshold_the_circuit_is_open
     open_circuit!
     assert_circuit_opened

--- a/test/test_mysql2.rb
+++ b/test/test_mysql2.rb
@@ -26,7 +26,7 @@ class TestMysql2 < Test::Unit::TestCase
 
     Semian[:mysql_testing].acquire do
       assert_raises Mysql2::SemianError do
-        Mysql2::Client.new(semian: {name: :testing, tickets: 1, timeout: 0})
+        connect_to_mysql!
       end
     end
   end

--- a/test/test_mysql2.rb
+++ b/test/test_mysql2.rb
@@ -36,7 +36,7 @@ class TestMysql2 < Test::Unit::TestCase
     client = connect_to_mysql!
 
     Semian[:mysql_testing].acquire do
-      assert_raises Mysql2::SemianError do
+      assert_raises Mysql2::ResourceOccupiedError do
         connect_to_mysql!
       end
     end
@@ -46,7 +46,7 @@ class TestMysql2 < Test::Unit::TestCase
     @proxy.downstream(:latency, latency: 500).apply do
       background { connect_to_mysql! }
 
-      assert_raises Mysql2::SemianError do
+      assert_raises Mysql2::ResourceOccupiedError do
         connect_to_mysql!
       end
     end
@@ -57,7 +57,7 @@ class TestMysql2 < Test::Unit::TestCase
       background { connect_to_mysql! }
 
       ERROR_THRESHOLD.times do
-        assert_raises Mysql2::SemianError do
+        assert_raises Mysql2::ResourceOccupiedError do
           connect_to_mysql!
         end
       end
@@ -65,7 +65,7 @@ class TestMysql2 < Test::Unit::TestCase
 
     yield_to_background
 
-    assert_raises Mysql2::SemianError do
+    assert_raises Mysql2::CircuitOpenError do
       connect_to_mysql!
     end
 
@@ -78,7 +78,7 @@ class TestMysql2 < Test::Unit::TestCase
     client = connect_to_mysql!
 
     Semian[:mysql_testing].acquire do
-      assert_raises Mysql2::SemianError do
+      assert_raises Mysql2::ResourceOccupiedError do
         client.query('SELECT 1 + 1;')
       end
     end
@@ -91,7 +91,7 @@ class TestMysql2 < Test::Unit::TestCase
     @proxy.downstream(:latency, latency: 500).apply do
       background { client2.query('SELECT 1 + 1;') }
 
-      assert_raises Mysql2::SemianError do
+      assert_raises Mysql2::ResourceOccupiedError do
         client.query('SELECT 1 + 1;')
       end
     end
@@ -105,7 +105,7 @@ class TestMysql2 < Test::Unit::TestCase
       background { client2.query('SELECT 1 + 1;') }
 
       ERROR_THRESHOLD.times do
-        assert_raises Mysql2::SemianError do
+        assert_raises Mysql2::ResourceOccupiedError do
           client.query('SELECT 1 + 1;')
         end
       end
@@ -113,7 +113,7 @@ class TestMysql2 < Test::Unit::TestCase
 
     yield_to_background
 
-    assert_raises Mysql2::SemianError do
+    assert_raises Mysql2::CircuitOpenError do
       client.query('SELECT 1 + 1;')
     end
 

--- a/test/test_mysql2.rb
+++ b/test/test_mysql2.rb
@@ -15,6 +15,7 @@ class TestMysql2 < Test::Unit::TestCase
     error_timeout: ERROR_TIMEOUT,
   }
 
+  attr_writer :threads
   def setup
     @proxy = Toxiproxy[:semian_test_mysql]
     Semian.destroy(:mysql_testing)
@@ -22,7 +23,7 @@ class TestMysql2 < Test::Unit::TestCase
 
   def teardown
     threads.each { |t| t.kill }
-    @threads = []
+    self.threads = []
   end
 
   def test_semian_identifier

--- a/test/test_mysql2.rb
+++ b/test/test_mysql2.rb
@@ -140,7 +140,7 @@ class TestMysql2 < Test::Unit::TestCase
   end
 
   def connect_to_mysql!(semian_options = {})
-    Mysql2::Client.new(host: '127.0.0.1', port: '43306', semian: SEMIAN_OPTIONS.merge(semian_options))
+    Mysql2::Client.new(host: '127.0.0.1', port: '13306', semian: SEMIAN_OPTIONS.merge(semian_options))
   end
 
   class FakeMysql < Mysql2::Client

--- a/test/test_mysql2.rb
+++ b/test/test_mysql2.rb
@@ -1,7 +1,19 @@
 require 'test/unit'
 require 'semian/mysql2'
+require 'toxiproxy'
+require 'timecop'
 
 class TestMysql2 < Test::Unit::TestCase
+  def setup
+    @proxy = Toxiproxy[:semian_test_mysql]
+    Semian.destroy(:mysql_testing)
+  end
+
+  def teardown
+    threads.each { |t| t.kill }
+    @threads = []
+  end
+
   def test_semian_identifier
     assert_equal :mysql_foo, FakeMysql.new(semian: {name: 'foo'}).semian_identifier
     assert_equal :'mysql_localhost:3306', FakeMysql.new.semian_identifier
@@ -9,18 +21,8 @@ class TestMysql2 < Test::Unit::TestCase
     assert_equal :'mysql_example.com:42', FakeMysql.new(host: 'example.com', port: 42).semian_identifier
   end
 
-  def test_resource_acquisition_for_query
-    client = Mysql2::Client.new(semian: {name: :testing, tickets: 1, timeout: 0})
-
-    Semian[:mysql_testing].acquire do
-      assert_raises Mysql2::SemianError do
-        client.query('SELECT 1 + 1;')
-      end
-    end
-  end
-
-  def test_resource_acquisition_for_query
-    client = Mysql2::Client.new(semian: {name: :testing, tickets: 1, timeout: 0})
+  def test_resource_acquisition_for_connect
+    client = connect_to_mysql!
 
     Semian[:mysql_testing].acquire do
       assert_raises Mysql2::SemianError do
@@ -29,7 +31,114 @@ class TestMysql2 < Test::Unit::TestCase
     end
   end
 
+  def test_resource_timeout_on_connect
+    @proxy.downstream(:latency, latency: 500).apply do
+      background { connect_to_mysql! }
+
+      assert_raises Mysql2::SemianError do
+        connect_to_mysql!
+      end
+    end
+  end
+
+  def test_circuit_breaker_on_connect
+    @proxy.downstream(:latency, latency: 500).apply do
+      background { connect_to_mysql! }
+
+      3.times do
+        assert_raises Mysql2::SemianError do
+          connect_to_mysql!
+        end
+      end
+    end
+
+    yield_to_background
+
+    assert_raises Mysql2::SemianError do
+      connect_to_mysql!
+    end
+
+    Timecop.travel(10) do
+      connect_to_mysql!
+    end
+  end
+
+  def test_resource_acquisition_for_query
+    client = connect_to_mysql!
+
+    Semian[:mysql_testing].acquire do
+      assert_raises Mysql2::SemianError do
+        client.query('SELECT 1 + 1;')
+      end
+    end
+  end
+
+  def test_resource_timeout_on_query
+    client = connect_to_mysql!
+    client2 = connect_to_mysql!
+
+    @proxy.downstream(:latency, latency: 500).apply do
+      background { client2.query('SELECT 1 + 1;') }
+
+      assert_raises Mysql2::SemianError do
+        client.query('SELECT 1 + 1;')
+      end
+    end
+  end
+
+  def test_circuit_breaker_on_query
+    client = connect_to_mysql!
+    client2 = connect_to_mysql!
+
+    @proxy.downstream(:latency, latency: 1000).apply do
+      background { client2.query('SELECT 1 + 1;') }
+
+      3.times do
+        assert_raises Mysql2::SemianError do
+          client.query('SELECT 1 + 1;')
+        end
+      end
+    end
+
+    yield_to_background
+
+    assert_raises Mysql2::SemianError do
+      client.query('SELECT 1 + 1;')
+    end
+
+    Timecop.travel(10) do
+      assert_equal 2, client.query('SELECT 1 + 1 as sum;').to_a.first['sum']
+    end
+  end
+
   private
+
+  def background(&block)
+    thread = Thread.new(&block)
+    threads << thread
+    thread.join(0.1)
+    thread
+  end
+
+  def threads
+    @threads ||= []
+  end
+
+  def yield_to_background
+    threads.each(&:join)
+  end
+
+  def connect_to_mysql!(semian_options = {})
+    options = {
+      name: :testing,
+      tickets: 1,
+      timeout: 0.05,
+      error_threshold: 1,
+      success_threshold: 2,
+      error_timeout: 5,
+    }.merge(semian_options)
+    Mysql2::Client.new(host: '127.0.0.1', port: '43306', semian: options)
+  end
 
   class FakeMysql < Mysql2::Client
     private

--- a/test/test_mysql2.rb
+++ b/test/test_mysql2.rb
@@ -1,0 +1,39 @@
+require 'test/unit'
+require 'semian/mysql2'
+
+class TestMysql2 < Test::Unit::TestCase
+  def test_semian_identifier
+    assert_equal :mysql_foo, FakeMysql.new(semian: {name: 'foo'}).semian_identifier
+    assert_equal :'mysql_localhost:3306', FakeMysql.new.semian_identifier
+    assert_equal :'mysql_127.0.0.1:3306', FakeMysql.new(host: '127.0.0.1').semian_identifier
+    assert_equal :'mysql_example.com:42', FakeMysql.new(host: 'example.com', port: 42).semian_identifier
+  end
+
+  def test_resource_acquisition_for_query
+    client = Mysql2::Client.new(semian: {name: :testing, tickets: 1, timeout: 0})
+
+    Semian[:mysql_testing].acquire do
+      assert_raises Mysql2::SemianError do
+        client.query('SELECT 1 + 1;')
+      end
+    end
+  end
+
+  def test_resource_acquisition_for_query
+    client = Mysql2::Client.new(semian: {name: :testing, tickets: 1, timeout: 0})
+
+    Semian[:mysql_testing].acquire do
+      assert_raises Mysql2::SemianError do
+        Mysql2::Client.new(semian: {name: :testing, tickets: 1, timeout: 0})
+      end
+    end
+  end
+
+  private
+
+  class FakeMysql < Mysql2::Client
+    private
+    def connect(*)
+    end
+  end
+end

--- a/test/test_semian.rb
+++ b/test/test_semian.rb
@@ -5,7 +5,7 @@ require 'fileutils'
 
 class TestSemian < Test::Unit::TestCase
   def setup
-    Semian[:testing].destroy rescue Semian::BaseError
+    Semian.destroy(:testing) rescue nil
   end
 
   def test_register_invalid_args


### PR DESCRIPTION
For the fun I integrated it in Shipit: https://github.com/Shopify/shipit2/commit/10ee2cc8d0eec39f7c882b47b6e8693adcac998c

If must be manually enabled via:

```ruby
Semian::Mysql2.enable!([optional global settings])
```

And then individual connections can have their settings defined when the client is instanciated:

```ruby
Mysql2::Client.new(semian: {timeout: 42, ...})
```

Which mean that for rails app, it can be done from the `database.yml`

```ruby
production:
  ...
  semian:
    timeout: 42
```

A couple things:

  - Again no more StatsD. I believe it's the integration application responsibility. However I'll see if Semian can provide a couple hooks to make it easier.
  - I simply ported our custom code, but I think `connect` and `query` should be using the circuit breaker. The fallback would be to raise a `Mysql2::SemianError`.


@fw42 @Sirupsen @csfrancis thoughts? (I know it's an holiday for you so feel free to pospone the review until tomorrow)