### PR TITLE
Monitoring api

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -40,12 +40,7 @@ end
 
 require 'rake/testtask'
 Rake::TestTask.new 'test' do |t|
-  all_files = FileList['test/test_*.rb']
-  if Semian.supported_platform?
-    t.test_files = all_files
-  else
-    t.test_files = all_files - FileList['test/test_semian.rb']
-  end
+  t.pattern = "test/test_*.rb"
 end
 task :test => [:build, :populate_proxy]
 

--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -489,7 +489,7 @@ void Init_semian()
   eInternal = rb_const_get(cSemian, rb_intern("InternalError"));
 
   rb_define_alloc_func(cResource, semian_resource_alloc);
-  rb_define_method(cResource, "initialize", semian_resource_initialize, 4);
+  rb_define_method(cResource, "_initialize", semian_resource_initialize, 4);
   rb_define_method(cResource, "acquire", semian_resource_acquire, -1);
   rb_define_method(cResource, "count", semian_resource_count, 0);
   rb_define_method(cResource, "semid", semian_resource_id, 0);

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -1,4 +1,6 @@
 require 'logger'
+require 'semian/instrumentable'
+
 #
 # === Overview
 #
@@ -55,11 +57,13 @@ require 'logger'
 #
 module Semian
   extend self
+  extend Instrumentable
 
   BaseError = Class.new(StandardError)
   SyscallError = Class.new(BaseError)
   TimeoutError = Class.new(BaseError)
   InternalError = Class.new(BaseError)
+  OpenCircuitError = Class.new(BaseError)
 
   attr_accessor :logger
 

--- a/lib/semian/circuit_breaker.rb
+++ b/lib/semian/circuit_breaker.rb
@@ -1,8 +1,5 @@
 module Semian
   class CircuitBreaker
-    BaseError = Class.new(StandardError)
-    OpenCircuitError = Class.new(BaseError)
-
     attr_reader :state
 
     def initialize(exceptions:, success_threshold:, error_threshold:, error_timeout:)

--- a/lib/semian/instrumentable.rb
+++ b/lib/semian/instrumentable.rb
@@ -1,0 +1,22 @@
+module Semian
+  module Instrumentable
+    def subscribe(name = rand, &block)
+      subscribers[name] = block
+      name
+    end
+
+    def unsubscribe(name)
+      subscribers.delete(name)
+    end
+
+    def notify(*args)
+      subscribers.values.each { |subscriber| subscriber.call(*args) }
+    end
+
+    private
+
+    def subscribers
+      @subscribers ||= {}
+    end
+  end
+end

--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -36,7 +36,7 @@ module Semian
 
     def query(*)
       semian_resource.acquire { super }
-    rescue ::Semian::CircuitBreaker::OpenCircuitError => error
+    rescue ::Semian::OpenCircuitError => error
       raise ::Mysql2::CircuitOpenError.new(semian_identifier, error)
     rescue ::Semian::BaseError => error
       raise ::Mysql2::ResourceOccupiedError.new(semian_identifier, error)
@@ -46,7 +46,7 @@ module Semian
 
     def connect(*)
       semian_resource.acquire { super }
-    rescue ::Semian::CircuitBreaker::OpenCircuitError => error
+    rescue ::Semian::OpenCircuitError => error
       raise ::Mysql2::CircuitOpenError.new(semian_identifier, error)
     rescue ::Semian::BaseError => error
       raise ::Mysql2::ResourceOccupiedError.new(semian_identifier, error)

--- a/lib/semian/resource.rb
+++ b/lib/semian/resource.rb
@@ -1,6 +1,11 @@
 module Semian
   class Resource #:nodoc:
+    attr_reader :tickets, :name
+
     def initialize(name, tickets, permissions, timeout)
+      _initialize(name, tickets, permissions, timeout)
+      @name = name
+      @tickets = tickets
     end
 
     def destroy

--- a/test/test_circuit_breaker.rb
+++ b/test/test_circuit_breaker.rb
@@ -1,12 +1,12 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'semian'
 require 'timecop'
 
-class TestCircuitBreaker < Test::Unit::TestCase
+class TestCircuitBreaker < MiniTest::Unit::TestCase
   SomeError = Class.new(StandardError)
 
   def setup
-    Semian[:testing].destroy rescue nil
+    Semian.destroy(:testing) rescue nil
     Semian.register(:testing, tickets: 1, exceptions: [SomeError], error_threshold: 2, error_timeout: 5)
     @resource = Semian[:testing]
   end
@@ -48,7 +48,7 @@ class TestCircuitBreaker < Test::Unit::TestCase
 
   def test_acquire_raises_circuit_open_error_when_the_circuit_is_open
     open_circuit!
-    assert_raises Semian::CircuitBreaker::OpenCircuitError do
+    assert_raises Semian::OpenCircuitError do
       @resource.acquire { 1 + 1 }
     end
   end

--- a/test/test_instrumentation.rb
+++ b/test/test_instrumentation.rb
@@ -1,0 +1,62 @@
+require 'minitest/autorun'
+require 'semian'
+
+class TestInstrumentation < MiniTest::Unit::TestCase
+  def setup
+    Semian.destroy(:testing) if Semian[:testing]
+    Semian.register(:testing, tickets: 1, error_threshold: 1)
+  end
+
+  def test_occupied_instrumentation
+    assert_notify(:success, :occupied) do
+      Semian[:testing].acquire do
+        assert_raises Semian::TimeoutError do
+          Semian[:testing].acquire {}
+        end
+      end
+    end
+  end
+
+  def test_circuit_open_instrumentation
+    assert_notify(:success, :occupied) do
+      Semian[:testing].acquire do
+        assert_raises Semian::TimeoutError do
+          Semian[:testing].acquire {}
+        end
+      end
+    end
+
+    assert_notify(:circuit_open) do
+      assert_raises Semian::OpenCircuitError do
+        Semian[:testing].acquire {}
+      end
+    end
+  end
+
+  def test_success_instrumentation
+    assert_notify(:success) do
+      Semian[:testing].acquire {}
+    end
+  end
+
+  def test_success_instrumentation_when_unknown_exceptions_occur
+    assert_notify(:success) do
+      assert_raises RuntimeError do
+        Semian[:testing].acquire { raise "Some error" }
+      end
+    end
+  end
+
+  private
+
+  def assert_notify(*expected_events)
+    events = []
+    subscription = Semian.subscribe do |event, resource|
+      events << event
+    end
+    yield
+    assert_equal expected_events, events, "The timeline of events was not as expected"
+  ensure
+    Semian.unsubscribe(subscription)
+  end
+end

--- a/test/test_mysql2.rb
+++ b/test/test_mysql2.rb
@@ -1,9 +1,9 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'semian/mysql2'
 require 'toxiproxy'
 require 'timecop'
 
-class TestMysql2 < Test::Unit::TestCase
+class TestMysql2 < MiniTest::Unit::TestCase
   ERROR_TIMEOUT = 5
   ERROR_THRESHOLD = 1
   SEMIAN_OPTIONS = {

--- a/test/test_semian.rb
+++ b/test/test_semian.rb
@@ -1,9 +1,9 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'semian'
 require 'tempfile'
 require 'fileutils'
 
-class TestSemian < Test::Unit::TestCase
+class TestSemian < MiniTest::Unit::TestCase
   def setup
     Semian.destroy(:testing) rescue nil
   end
@@ -33,7 +33,7 @@ class TestSemian < Test::Unit::TestCase
 
   def test_register_with_no_tickets_raises
     assert_raises Semian::SyscallError do
-      Semian.register :testing
+      Semian.register :testing, tickets: 0
     end
   end
 
@@ -160,6 +160,7 @@ class TestSemian < Test::Unit::TestCase
     Semian[:testing].acquire do
       acquired = true
       assert_equal 1, Semian[:testing].count
+      assert_equal 2, Semian[:testing].tickets
     end
 
     assert acquired

--- a/test/test_unsupported.rb
+++ b/test/test_unsupported.rb
@@ -1,7 +1,11 @@
-require 'test/unit'
+require 'minitest/autorun'
 require 'semian'
 
-class TestSemian < Test::Unit::TestCase
+class TestSemian < MiniTest::Unit::TestCase
+  def setup
+    Semian.destroy(:testing) rescue nil
+  end
+
   def test_unsupported_acquire_yields
     acquired = false
     Semian.register :testing, tickets: 1


### PR DESCRIPTION
Here a very simple monitoring API for semian resources:

Usage example:
```ruby
Semian[:mysql_master].listen(:occupied) do |resource|
  StatsD.increment('Shopify.mysql.semian.timeout', 1, sample_rate: 1, tags: ["resource:#{resource.name}", "total_tickets:#{resource.tickets}"])
end
```

The 3 events are:
  - `:occupied`
  - `:circuit_open`
  - `:success`

@Sirupsen @fw42 @csfrancis for review please.