### PR TITLE
circuit_breaker: use sliding window

### DIFF
--- a/lib/semian/circuit_breaker.rb
+++ b/lib/semian/circuit_breaker.rb
@@ -40,7 +40,7 @@ module Semian
     end
 
     def mark_failed(error)
-      increment_recent_errors
+      push_time(@errors, @error_count_threshold, duration: @error_timeout)
 
       if closed?
         open if error_threshold_reached?
@@ -51,14 +51,13 @@ module Semian
 
     def mark_success
       return unless half_open?
-      @success_count += 1
+      @successes += 1
       close if success_threshold_reached?
     end
 
     def reset
-      @success_count = 0
-      @error_count = 0
-      @error_last_at = nil
+      @errors    = []
+      @successes = 0
       close
     end
 
@@ -98,35 +97,32 @@ module Semian
     def half_open
       log_state_transition(:half_open)
       @state = :half_open
-      @success_count = 0
-    end
-
-    def increment_recent_errors
-      if error_timeout_expired?
-        @error_count = 0
-      end
-
-      @error_count += 1
-      @error_last_at = Time.now
+      @successes = 0
     end
 
     def success_threshold_reached?
-      @success_count >= @success_count_threshold
+      @successes >= @success_count_threshold
     end
 
     def error_threshold_reached?
-      @error_count >= @error_count_threshold
+      @errors.count == @error_count_threshold
     end
 
     def error_timeout_expired?
-      @error_last_at && (@error_last_at + @error_timeout < Time.now)
+      @errors.last && (@errors.last + @error_timeout < Time.now)
+    end
+
+    def push_time(window, max_size, duration:, time: Time.now)
+      window.shift while window.first && window.first + duration < time
+      window.shift if window.size == max_size
+      window << time
     end
 
     def log_state_transition(new_state)
       return if @state.nil? || new_state == @state
 
       str = "[#{self.class.name}] State transition from #{@state} to #{new_state}."
-      str << " success_count=#{@success_count} error_count=#{@error_count}"
+      str << " success_count=#{@successes} error_count=#{@errors.count}"
       str << " success_count_threshold=#{@success_count_threshold} error_count_threshold=#{@error_count_threshold}"
       str << " error_timeout=#{@error_timeout} error_last_at=\"#{@error_last_at}\""
       Semian.logger.info(str)

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -82,31 +82,60 @@ class TestCircuitBreaker < MiniTest::Unit::TestCase
     assert_circuit_closed
   end
 
-  private
+  def test_errors_more_than_duration_apart_doesnt_open_circuit
+    Timecop.travel(Time.now - 6) do
+      trigger_error!
+      assert_circuit_closed
+    end
 
-  def open_circuit!
-    2.times { trigger_error! }
+    trigger_error!
+    assert_circuit_closed
   end
 
-  def half_open_cicuit!
+  def test_sparse_errors_dont_open_circuit
+    resource = Semian.register(:three, tickets: 1, exceptions: [SomeError], error_threshold: 3, error_timeout: 5, success_threshold: 1)
+
+    Timecop.travel(-6) do
+      trigger_error!(resource)
+      assert_circuit_closed(resource)
+    end
+
+    Timecop.travel(-1) do
+      trigger_error!(resource)
+      assert_circuit_closed(resource)
+    end
+
+    trigger_error!(resource)
+    assert_circuit_closed(resource)
+  ensure
+    Semian.destroy(:three)
+  end
+
+  private
+
+  def open_circuit!(resource = @resource)
+    2.times { trigger_error!(resource) }
+  end
+
+  def half_open_cicuit!(resource = @resource)
     Timecop.travel(Time.now - 10) do
-      open_circuit!
+      open_circuit!(resource)
     end
   end
 
-  def trigger_error!
-    @resource.with_fallback(42) { raise SomeError }
+  def trigger_error!(resource = @resource)
+    resource.with_fallback(42) { raise SomeError }
   end
 
-  def assert_circuit_closed
+  def assert_circuit_closed(resource = @resource)
     block_called = false
-    @resource.with_fallback(42) { block_called = true }
+    resource.with_fallback(42) { block_called = true }
     assert block_called, 'Expected the circuit to be closed, but it was open'
   end
 
-  def assert_circuit_opened
+  def assert_circuit_opened(resource = @resource)
     block_called = false
-    @resource.with_fallback(42) { block_called = true }
+    resource.with_fallback(42) { block_called = true }
     refute block_called, 'Expected the circuit to be open, but it was closed'
   end
 end


### PR DESCRIPTION
## Problem

Imagine the following circuit breaker scenario with `error_count=3` and `error_timeout=5s`:

Time     | Circuit  | Errors within duration
-----------|-----------|-----------------------------
t-6         | closed  | [t-6]
t-1            | closed  | [t-6, t-1]
t        | **closed**          | [~~t-6~~, t-1, t]

The **expected outcome at time `t` is that the circuit remains closed** because only one error at that time has happened within the past 5s. In the current implementation **the circuit would open**. See `test_sparse_errors_dont_open_circuit`.

## Current solution

In the current implementation we keep track of errors with counts:

```ruby
    def increment_recent_errors
      if error_timeout_expired?
        @error_count = 0
      end

      @error_count += 1
      @error_last_at = Time.now
    end

    def error_timeout_expired?
      @error_last_at && (@error_last_at + @error_timeout < Time.now)
    end
```

That means if the last event stays recent, we'll continue to grow the duration of the current window—eventually sparse errors will open the circuit.

## Solution

The solution is a proper sliding window based on time and size.

## Concerns

I do not slide the window on reads. It's a reasonable thing to expect it to do, and I did it in my initial attempt. However, the implementation is more convoluted and the tests harder to read because it means passing in `time` to `#size`, `#first` and `#last`.

**Why the fuck are you doing this on a Friday night Simon?** In routing we've seen intermittent circuit openings, which has been bothering me.. so I was reading the implementation and thinking. It's extremely non-obvious to determine whether this has ever caused any real problems for us, but it does mean that e.g. an intermittent failure every `n` seconds (where `n` just has to be less than `error_timeout`) can eventually lead to the circuit opening, even if they don't happen within a time frame of `error_timeout`. This may explain why we se the circuits opening somewhat randomly in Lua, which uses the same implementation (in Lua syntax, \cc @Shopify/routing).

You can definitely argue that this is more complex than the current solution. However, I think this is the mental model people will have and what they'll expect from the implementation. It certainly stumbles me every time I read the current implementation that doesn't map to my model. I've implemented it in a way that'd be easy to duplicate in our Go and Lua implementations and kept the code style consistent.

@fw42 @byroot @csfrancis @eapache 