### PR TITLE
Rename :occupied to :busy

### DIFF
--- a/lib/semian/protected_resource.rb
+++ b/lib/semian/protected_resource.rb
@@ -20,7 +20,7 @@ module Semian
             yield self
           end
         rescue ::Semian::TimeoutError
-          Semian.notify(:occupied, self, scope, adapter)
+          Semian.notify(:busy, self, scope, adapter)
           raise
         end
       end

--- a/test/instrumentation_test.rb
+++ b/test/instrumentation_test.rb
@@ -6,8 +6,8 @@ class TestInstrumentation < MiniTest::Unit::TestCase
     Semian.register(:testing, tickets: 1, error_threshold: 1, error_timeout: 5, success_threshold: 1)
   end
 
-  def test_occupied_instrumentation
-    assert_notify(:success, :occupied) do
+  def test_busy_instrumentation
+    assert_notify(:success, :busy) do
       Semian[:testing].acquire do
         assert_raises Semian::TimeoutError do
           Semian[:testing].acquire {}
@@ -17,7 +17,7 @@ class TestInstrumentation < MiniTest::Unit::TestCase
   end
 
   def test_circuit_open_instrumentation
-    assert_notify(:success, :occupied) do
+    assert_notify(:success, :busy) do
       Semian[:testing].acquire do
         assert_raises Semian::TimeoutError do
           Semian[:testing].acquire {}


### PR DESCRIPTION
@byroot, @Sirupsen 

I was discussing this with @Sirupsen, and I find `occupied` to be kind of an awkward word to use when there are no tickets available. This renames `:occupied` to `:busy`.
