### PR TITLE
Adds a disable env var

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ end
 
 $:.unshift File.expand_path("../lib", __FILE__)
 require 'semian/platform'
-if Semian.supported_platform?
+if Semian.sysv_semaphores_supported?
   require 'rake/extensiontask'
   Rake::ExtensionTask.new('semian', GEMSPEC) do |ext|
     ext.ext_dir = 'ext/semian'

--- a/ext/semian/extconf.rb
+++ b/ext/semian/extconf.rb
@@ -2,7 +2,7 @@ $:.unshift File.expand_path("../../../lib", __FILE__)
 
 require 'semian/platform'
 
-unless Semian.supported_platform?
+unless Semian.sysv_semaphores_supported?
   File.write "Makefile", <<MAKEFILE
 all:
 clean:

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -77,8 +77,8 @@ module Semian
   InternalError = Class.new(BaseError)
   OpenCircuitError = Class.new(BaseError)
 
-  def enabled?
-    !ENV['SEMIAN_DISABLED']
+  def semaphores_enabled?
+    !ENV['SEMIAN_SEMAPHORES_DISABLED']
   end
 
   module AdapterError
@@ -153,11 +153,11 @@ require 'semian/circuit_breaker'
 require 'semian/protected_resource'
 require 'semian/unprotected_resource'
 require 'semian/platform'
-if Semian.sysv_semaphores_supported? && Semian.enabled?
+if Semian.sysv_semaphores_supported? && Semian.semaphores_enabled?
   require 'semian/semian'
 else
   Semian::MAX_TICKETS = 0
   Semian.logger.info("Semian is not supported on #{RUBY_PLATFORM} - all operations will no-op") unless Semian.sysv_semaphores_supported?
-  Semian.logger.info("Semian is disabled, is this what you really want? - all operations will no-op") unless Semian.enabled?
+  Semian.logger.info("Semian is disabled, is this what you really want? - all operations will no-op") unless Semian.semaphores_enabled?
 end
 require 'semian/version'

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -157,7 +157,7 @@ if Semian.sysv_semaphores_supported? && Semian.semaphores_enabled?
   require 'semian/semian'
 else
   Semian::MAX_TICKETS = 0
-  Semian.logger.info("Semian is not supported on #{RUBY_PLATFORM} - all operations will no-op") unless Semian.sysv_semaphores_supported?
-  Semian.logger.info("Semian is disabled, is this what you really want? - all operations will no-op") unless Semian.semaphores_enabled?
+  Semian.logger.info("Semian sysv semaphores are not supported on #{RUBY_PLATFORM} - all operations will no-op") unless Semian.sysv_semaphores_supported?
+  Semian.logger.info("Semian semaphores are disabled, is this what you really want? - all operations will no-op") unless Semian.semaphores_enabled?
 end
 require 'semian/version'

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -153,11 +153,11 @@ require 'semian/circuit_breaker'
 require 'semian/protected_resource'
 require 'semian/unprotected_resource'
 require 'semian/platform'
-if Semian.supported_platform? && Semian.enabled?
+if Semian.sysv_semaphores_supported? && Semian.enabled?
   require 'semian/semian'
 else
   Semian::MAX_TICKETS = 0
-  Semian.logger.info("Semian is not supported on #{RUBY_PLATFORM} - all operations will no-op") unless Semian.supported_platform?
+  Semian.logger.info("Semian is not supported on #{RUBY_PLATFORM} - all operations will no-op") unless Semian.sysv_semaphores_supported?
   Semian.logger.info("Semian is disabled, is this what you really want? - all operations will no-op") unless Semian.enabled?
 end
 require 'semian/version'

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -77,6 +77,10 @@ module Semian
   InternalError = Class.new(BaseError)
   OpenCircuitError = Class.new(BaseError)
 
+  def enabled?
+    !ENV['SEMIAN_DISABLED']
+  end
+
   module AdapterError
     def initialize(semian_identifier, *args)
       super(*args)
@@ -149,10 +153,11 @@ require 'semian/circuit_breaker'
 require 'semian/protected_resource'
 require 'semian/unprotected_resource'
 require 'semian/platform'
-if Semian.supported_platform?
+if Semian.supported_platform? && Semian.enabled?
   require 'semian/semian'
 else
   Semian::MAX_TICKETS = 0
-  Semian.logger.info("Semian is not supported on #{RUBY_PLATFORM} - all operations will no-op")
+  Semian.logger.info("Semian is not supported on #{RUBY_PLATFORM} - all operations will no-op") unless Semian.supported_platform?
+  Semian.logger.info("Semian is disabled, is this what you really want? - all operations will no-op") unless Semian.enabled?
 end
 require 'semian/version'

--- a/lib/semian/platform.rb
+++ b/lib/semian/platform.rb
@@ -1,6 +1,6 @@
 module Semian
   # Determines if Semian supported on the current platform.
-  def self.supported_platform?
+  def self.sysv_semaphores_supported?
     /linux/.match(RUBY_PLATFORM)
   end
 end

--- a/test/semian_test.rb
+++ b/test/semian_test.rb
@@ -19,4 +19,13 @@ class TestSemian < MiniTest::Unit::TestCase
     assert defined?(Semian::InternalError)
     assert defined?(Semian::Resource)
   end
+
+  def test_disabled_via_env_var
+    ENV['SEMIAN_DISABLED'] = '1'
+
+    refute Semian.enabled?
+  ensure
+    ENV.delete('SEMIAN_DISABLED')
+  end
+
 end

--- a/test/semian_test.rb
+++ b/test/semian_test.rb
@@ -21,11 +21,11 @@ class TestSemian < MiniTest::Unit::TestCase
   end
 
   def test_disabled_via_env_var
-    ENV['SEMIAN_DISABLED'] = '1'
+    ENV['SEMIAN_SEMAPHORES_DISABLED'] = '1'
 
-    refute Semian.enabled?
+    refute Semian.semaphores_enabled?
   ensure
-    ENV.delete('SEMIAN_DISABLED')
+    ENV.delete('SEMIAN_SEMAPHORES_DISABLED')
   end
 
 end


### PR DESCRIPTION
Some processes that run offline actually don't benefit from semian, for instance processes that do maintenance by just moving a ton of resources around concurrently, they pretty much occupy  all the available tickets by design.

For those cases  I'm providing a way of disabling semian.