### PR TITLE
Get rid of with_fallback

### DIFF
--- a/lib/semian/circuit_breaker.rb
+++ b/lib/semian/circuit_breaker.rb
@@ -25,14 +25,6 @@ module Semian
       result
     end
 
-    def with_fallback(fallback, &block)
-      acquire(&block)
-    rescue *@exceptions
-      evaluate_fallback(fallback)
-    rescue OpenCircuitError
-      evaluate_fallback(fallback)
-    end
-
     def request_allowed?
       return true if closed?
       half_open if error_timeout_expired?
@@ -62,14 +54,6 @@ module Semian
     end
 
     private
-
-    def evaluate_fallback(fallback_value_or_block)
-      if fallback_value_or_block.respond_to?(:call)
-        fallback_value_or_block.call
-      else
-        fallback_value_or_block
-      end
-    end
 
     def closed?
       state == :closed

--- a/lib/semian/protected_resource.rb
+++ b/lib/semian/protected_resource.rb
@@ -28,9 +28,5 @@ module Semian
       Semian.notify(:circuit_open, self, scope, adapter)
       raise
     end
-
-    def with_fallback(fallback, &block)
-      @circuit_breaker.with_fallback(fallback) { @resource.acquire(&block) }
-    end
   end
 end


### PR DESCRIPTION
@fw42 @Sirupsen for review please.

I don't think it belongs to Semian. Semian is for protecting datastore drivers etc, with_fallback can only be used at an higher level.