### PR TITLE
Consider Redis::BaseConnectionError in the circuit breaker errors count

### DIFF
--- a/lib/semian/adapter.rb
+++ b/lib/semian/adapter.rb
@@ -14,6 +14,8 @@ module Semian
       else
         options = semian_options.dup
         options.delete(:name)
+        options[:exceptions] ||= []
+        options[:exceptions] += resource_exceptions
         ::Semian.retrieve_or_register(semian_identifier, **options)
       end
     end
@@ -39,6 +41,10 @@ module Semian
 
     def raw_semian_options
       raise NotImplementedError.new("Semian adapters must implement a `raw_semian_options` method")
+    end
+
+    def resource_exceptions
+      []
     end
 
     def resource_already_acquired?

--- a/lib/semian/redis.rb
+++ b/lib/semian/redis.rb
@@ -45,6 +45,10 @@ module Semian
 
     private
 
+    def resource_exceptions
+      [::Redis::BaseConnectionError]
+    end
+
     def raw_semian_options
       return options[:semian] if options.key?(:semian)
       return options['semian'.freeze] if options.key?('semian'.freeze)


### PR DESCRIPTION
@Sirupsen @fw42 

I feel bad about that one. I should have done it way earlier. Connection and query timeout should increment the circuit breaker count.

