### PR TITLE
Expose the semian identifier in AdapterExceptions

### DIFF
--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -78,6 +78,8 @@ module Semian
   OpenCircuitError = Class.new(BaseError)
 
   module AdapterError
+    attr_reader :semian_identifier
+
     def initialize(semian_identifier, *args)
       super(*args)
       @semian_identifier = semian_identifier

--- a/test/mysql2_test.rb
+++ b/test/mysql2_test.rb
@@ -50,9 +50,10 @@ class TestMysql2 < MiniTest::Unit::TestCase
     client = connect_to_mysql!
 
     Semian[:mysql_testing].acquire do
-      assert_raises Mysql2::ResourceBusyError do
+      error = assert_raises Mysql2::ResourceBusyError do
         connect_to_mysql!
       end
+      assert_equal :mysql_testing, error.semian_identifier
     end
   end
 

--- a/test/redis_test.rb
+++ b/test/redis_test.rb
@@ -50,9 +50,10 @@ class TestRedis < MiniTest::Unit::TestCase
     client = connect_to_redis!
 
     Semian[:redis_testing].acquire do
-      assert_raises Redis::ResourceBusyError do
+      error = assert_raises Redis::ResourceBusyError do
         connect_to_redis!
       end
+      assert_equal :redis_testing, error.semian_identifier
     end
   end
 


### PR DESCRIPTION
@fw42 @Sirupsen for review please.

The idea is to be able to discriminate semian errors based on which resource fired it.

