### PR TITLE
Also tag natvie adapter errors with the resource identifier

### DIFF
--- a/lib/semian/adapter.rb
+++ b/lib/semian/adapter.rb
@@ -31,6 +31,9 @@ module Semian
       raise self.class::CircuitOpenError.new(semian_identifier, error)
     rescue ::Semian::BaseError => error
       raise self.class::ResourceBusyError.new(semian_identifier, error)
+    rescue => error
+      error.semian_identifier = semian_identifier if error.respond_to?(:semian_identifier=)
+      raise
     end
 
     def semian_options

--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -3,6 +3,8 @@ require 'semian/adapter'
 require 'mysql2'
 
 module Mysql2
+  Mysql2::Error.class_exec { attr_accessor :semian_identifier }
+
   class SemianError < Mysql2::Error
     include ::Semian::AdapterError
   end

--- a/lib/semian/redis.rb
+++ b/lib/semian/redis.rb
@@ -3,6 +3,8 @@ require 'semian/adapter'
 require 'redis'
 
 class Redis
+  Redis::BaseConnectionError.class_exec { attr_accessor :semian_identifier }
+
   class SemianError < Redis::BaseConnectionError
     include ::Semian::AdapterError
   end

--- a/test/mysql2_test.rb
+++ b/test/mysql2_test.rb
@@ -80,6 +80,15 @@ class TestMysql2 < MiniTest::Unit::TestCase
     end
   end
 
+  def test_mysql_error_are_tagged_with_the_resource_identifier
+    client = connect_to_mysql!
+
+    error = assert_raises Mysql2::Error do
+      client.query('SYNTAX ERROR!')
+    end
+    assert_equal :mysql_testing, error.semian_identifier
+  end
+
   def test_resource_timeout_on_connect
     @proxy.downstream(:latency, latency: 500).apply do
       background { connect_to_mysql! }

--- a/test/redis_test.rb
+++ b/test/redis_test.rb
@@ -83,6 +83,15 @@ class TestRedis < MiniTest::Unit::TestCase
     end
   end
 
+  def test_redis_connection_errors_are_tagged_with_the_resource_identifier
+    @proxy.downstream(:latency, latency: 600).apply do
+      error = assert_raises ::Redis::TimeoutError do
+        connect_to_redis!
+      end
+      assert_equal :redis_testing, error.semian_identifier
+    end
+  end
+
   def test_resource_timeout_on_connect
     @proxy.downstream(:latency, latency: 500).apply do
       background { connect_to_redis! }


### PR DESCRIPTION
Followup to: https://github.com/Shopify/semian/pull/38

This will allow to discriminate errors coming from different Redises or MySQLs

@Sirupsen @fw42 for review.

