### PR TITLE
Style guide enforced on CI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,113 @@
+AllCops:
+  Exclude:
+    - Gemfile
+    - lib/snippets/**/*
+    - vendor/**/*
+    - data/**/*
+    - db/schema.rb
+    - db/migrate/*
+    - test/dummy/**/*
+    - bin/rails
+    - lib/shipit-engine.rb
+    - tmp/**/*
+
+Style/GuardClause:
+  Enabled: false
+
+Lint/AssignmentInCondition:
+  Enabled: false
+
+Lint/HandleExceptions:
+  Enabled: false
+
+Lint/EndAlignment:
+  Enabled: false
+
+Style/NumericLiterals:
+  Exclude:
+    - db/schema.rb
+
+Style/SingleSpaceBeforeFirstArg:
+  Exclude:
+    - db/schema.rb
+
+Style/DoubleNegation:
+  Enabled: false
+
+Metrics/LineLength:
+  Max: 135
+
+Metrics/MethodLength:
+  Max: 40
+
+Metrics/ClassLength:
+  Max: 500
+
+Metrics/AbcSize:
+  Max: 50
+
+Metrics/CyclomaticComplexity:
+  Max: 10
+
+Style/Documentation:
+  Enabled: false
+
+Style/SingleLineBlockParams:
+  Enabled: false
+
+Style/SignalException:
+  Enabled: false
+
+Style/RaiseArgs:
+  Enabled: false
+
+Style/ModuleFunction:
+  Enabled: false
+
+Style/RedundantReturn:
+  AllowMultipleReturnValues: true
+
+Style/IndentHash:
+  Enabled: false
+
+Style/TrailingComma:
+  EnforcedStyleForMultiline: comma
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/PredicateName:
+  Exclude:
+    - app/serializers/**/*
+
+Style/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+
+Style/StringLiterals:
+  Enabled: false
+
+Style/PerlBackrefs:
+  Enabled: false
+
+Style/TrivialAccessors:
+  AllowPredicates: true
+
+Style/ExtraSpacing:
+  AllowForAlignment: false
+
+Style/GlobalVars:
+  Exclude:
+    - 'ext/semian/extconf.rb'
+
+Lint/Eval:
+  Exclude:
+    - 'Rakefile'
+
+Metrics/ParameterLists:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/CaseIndentation:
+  IndentWhenRelativeTo: end

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ sudo: true
 before_install:
   - scripts/install_toxiproxy.sh
 
+script:
+  - bundle exec rake
+  - bundle exec rubocop
+
 rvm:
   - 2.1.1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ sudo: true
 before_install:
   - scripts/install_toxiproxy.sh
 
-script:
-  - bundle exec rake
-  - bundle exec rubocop
-
 rvm:
   - 2.1.1
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,7 @@ gemspec
 group :debug do
   gem 'byebug'
 end
+
+group :development, :test do
+  gem 'rubocop', '~> 0.34.2'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require 'bundler/gem_tasks'
 
-task :default => :test
+task default: :test
 
 # ==========================================================
 # Packaging
@@ -9,14 +9,14 @@ task :default => :test
 GEMSPEC = eval(File.read('semian.gemspec'))
 
 require 'rubygems/package_task'
-Gem::PackageTask.new(GEMSPEC) do |pkg|
+Gem::PackageTask.new(GEMSPEC) do |_pkg|
 end
 
 # ==========================================================
 # Ruby Extension
 # ==========================================================
 
-$:.unshift File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
 require 'semian/platform'
 if Semian.sysv_semaphores_supported?
   require 'rake/extensiontask'
@@ -24,9 +24,10 @@ if Semian.sysv_semaphores_supported?
     ext.ext_dir = 'ext/semian'
     ext.lib_dir = 'lib/semian'
   end
-  task :build => :compile
+  task build: :compile
 else
-  task :build do; end
+  task :build do
+  end
 end
 
 # ==========================================================
@@ -35,10 +36,10 @@ end
 
 require 'rake/testtask'
 Rake::TestTask.new 'test' do |t|
-  t.libs = ['lib', 'test']
+  t.libs = %w(lib test)
   t.pattern = "test/*_test.rb"
 end
-task :test => :build
+task test: :build
 
 # ==========================================================
 # Documentation

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,9 @@
 require 'bundler/gem_tasks'
-
-task default: :test
+begin
+  require 'rubocop/rake_task'
+  RuboCop::RakeTask.new
+rescue LoadError
+end
 
 # ==========================================================
 # Packaging
@@ -48,3 +51,6 @@ require 'rdoc/task'
 RDoc::Task.new do |rdoc|
   rdoc.rdoc_files.include("lib/*.rb", "ext/semian/*.c")
 end
+
+task default: :test
+task default: :rubocop

--- a/ext/semian/extconf.rb
+++ b/ext/semian/extconf.rb
@@ -1,4 +1,4 @@
-$:.unshift File.expand_path("../../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../../../lib", __FILE__)
 
 require 'semian/platform'
 
@@ -24,7 +24,7 @@ have_func 'rb_thread_blocking_region'
 have_func 'rb_thread_call_without_gvl'
 
 $CFLAGS = "-D_GNU_SOURCE -Werror -Wall "
-if ENV.has_key?('DEBUG')
+if ENV.key?('DEBUG')
   $CFLAGS << "-O0 -g"
 else
   $CFLAGS << "-O3"

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -31,7 +31,7 @@ require 'semian/instrumentable'
 # Resources also integrate a circuit breaker in order to fail faster and to let the
 # resource the time to recover. If `error_threshold` errors happen in the span of `error_timeout`
 # then the circuit will be opened and every attempt to acquire the resource will immediately fail.
-# 
+#
 # Once in open state, after `error_timeout` is elapsed, the ciruit will transition in the half-open state.
 # In that state a single error will fully re-open the circuit, and the circuit will transition back to the closed
 # state only after the resource is acquired `success_threshold` consecutive times.
@@ -158,7 +158,12 @@ if Semian.sysv_semaphores_supported? && Semian.semaphores_enabled?
   require 'semian/semian'
 else
   Semian::MAX_TICKETS = 0
-  Semian.logger.info("Semian sysv semaphores are not supported on #{RUBY_PLATFORM} - all operations will no-op") unless Semian.sysv_semaphores_supported?
-  Semian.logger.info("Semian semaphores are disabled, is this what you really want? - all operations will no-op") unless Semian.semaphores_enabled?
+  unless Semian.sysv_semaphores_supported?
+    Semian.logger.info("Semian sysv semaphores are not supported on #{RUBY_PLATFORM} - all operations will no-op")
+  end
+
+  unless Semian.semaphores_enabled?
+    Semian.logger.info("Semian semaphores are disabled, is this what you really want? - all operations will no-op")
+  end
 end
 require 'semian/version'

--- a/lib/semian/circuit_breaker.rb
+++ b/lib/semian/circuit_breaker.rb
@@ -10,7 +10,7 @@ module Semian
       reset
     end
 
-    def acquire(&block)
+    def acquire
       raise OpenCircuitError unless request_allowed?
 
       result = nil
@@ -31,7 +31,7 @@ module Semian
       !open?
     end
 
-    def mark_failed(error)
+    def mark_failed(_error)
       push_time(@errors, @error_count_threshold, duration: @error_timeout)
 
       if closed?
@@ -48,7 +48,7 @@ module Semian
     end
 
     def reset
-      @errors    = []
+      @errors = []
       @successes = 0
       close
     end

--- a/lib/semian/protected_resource.rb
+++ b/lib/semian/protected_resource.rb
@@ -12,7 +12,7 @@ module Semian
       @circuit_breaker = circuit_breaker
     end
 
-    def acquire(timeout: nil, scope: nil, adapter: nil, &block)
+    def acquire(timeout: nil, scope: nil, adapter: nil)
       @circuit_breaker.acquire do
         begin
           @resource.acquire(timeout: timeout) do

--- a/lib/semian/resource.rb
+++ b/lib/semian/resource.rb
@@ -2,7 +2,7 @@ module Semian
   class Resource #:nodoc:
     attr_reader :tickets, :name
 
-    def initialize(name, tickets: , permissions: 0660, timeout: 0)
+    def initialize(name, tickets:, permissions: 0660, timeout: 0)
       _initialize(name, tickets, permissions, timeout) if respond_to?(:_initialize)
       @name = name
       @tickets = tickets

--- a/lib/semian/unprotected_resource.rb
+++ b/lib/semian/unprotected_resource.rb
@@ -34,7 +34,7 @@ module Semian
       true
     end
 
-    def mark_failed(error)
+    def mark_failed(_error)
     end
   end
 end

--- a/semian.gemspec
+++ b/semian.gemspec
@@ -1,4 +1,4 @@
-$:.unshift File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
 
 require 'semian/version'
 require 'semian/platform'
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   DOC
   s.homepage = 'https://github.com/csfrancis/semian'
   s.authors = ['Scott Francis', 'Simon Eskildsen']
-  s.email   = 'scott.francis@shopify.com'
+  s.email = 'scott.francis@shopify.com'
   s.license = 'MIT'
 
   s.files = `git ls-files`.split("\n")

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -4,7 +4,11 @@ class TestCircuitBreaker < MiniTest::Unit::TestCase
   SomeError = Class.new(StandardError)
 
   def setup
-    Semian.destroy(:testing) rescue nil
+    begin
+      Semian.destroy(:testing)
+    rescue
+      nil
+    end
     Semian.register(:testing, tickets: 1, exceptions: [SomeError], error_threshold: 2, error_timeout: 5, success_threshold: 1)
     @resource = Semian[:testing]
   end
@@ -108,7 +112,7 @@ class TestCircuitBreaker < MiniTest::Unit::TestCase
   def assert_circuit_opened(resource = @resource)
     open = false
     begin
-      resource.acquire { }
+      resource.acquire {}
     rescue Semian::OpenCircuitError
       open = true
     end

--- a/test/helpers/background_helper.rb
+++ b/test/helpers/background_helper.rb
@@ -2,7 +2,7 @@ module BackgroundHelper
   attr_writer :threads
 
   def teardown
-    threads.each { |t| t.kill }
+    threads.each(&:kill)
     self.threads = []
   end
 

--- a/test/instrumentation_test.rb
+++ b/test/instrumentation_test.rb
@@ -50,7 +50,7 @@ class TestInstrumentation < MiniTest::Unit::TestCase
 
   def assert_notify(*expected_events)
     events = []
-    subscription = Semian.subscribe do |event, resource|
+    subscription = Semian.subscribe do |event, _resource|
       events << event
     end
     yield

--- a/test/mysql2_test.rb
+++ b/test/mysql2_test.rb
@@ -70,7 +70,7 @@ class TestMysql2 < MiniTest::Unit::TestCase
   end
 
   def test_resource_acquisition_for_connect
-    client = connect_to_mysql!
+    connect_to_mysql!
 
     Semian[:mysql_testing].acquire do
       error = assert_raises Mysql2::ResourceBusyError do
@@ -216,6 +216,7 @@ class TestMysql2 < MiniTest::Unit::TestCase
 
   class FakeMysql < Mysql2::Client
     private
+
     def connect(*)
     end
   end

--- a/test/redis_test.rb
+++ b/test/redis_test.rb
@@ -79,7 +79,7 @@ class TestRedis < MiniTest::Unit::TestCase
   end
 
   def test_resource_acquisition_for_connect
-    client = connect_to_redis!
+    connect_to_redis!
 
     Semian[:redis_testing].acquire do
       error = assert_raises Redis::ResourceBusyError do
@@ -213,11 +213,11 @@ class TestRedis < MiniTest::Unit::TestCase
   def connect_to_redis!(semian_options = {})
     redis = Redis.new(
       host: '127.0.0.1',
-      port: 16379,
+      port: 16_379,
       reconnect_attempts: 0,
       db: 1,
       timeout: 0.5,
-      semian: SEMIAN_OPTIONS.merge(semian_options)
+      semian: SEMIAN_OPTIONS.merge(semian_options),
     )
     redis.client.connect
     redis

--- a/test/semian_test.rb
+++ b/test/semian_test.rb
@@ -2,7 +2,9 @@ require 'test_helper'
 
 class TestSemian < MiniTest::Unit::TestCase
   def setup
-    Semian.destroy(:testing) rescue nil
+    Semian.destroy(:testing)
+  rescue
+    nil
   end
 
   def test_unsupported_acquire_yields
@@ -27,5 +29,4 @@ class TestSemian < MiniTest::Unit::TestCase
   ensure
     ENV.delete('SEMIAN_SEMAPHORES_DISABLED')
   end
-
 end

--- a/test/unprotected_resource_test.rb
+++ b/test/unprotected_resource_test.rb
@@ -15,7 +15,7 @@ class UnprotectedResourceTest < MiniTest::Unit::TestCase
   end
 
   def test_resource_tickets
-    assert_equal -1, @resource.tickets
+    assert_equal(-1, @resource.tickets)
   end
 
   def test_resource_count


### PR DESCRIPTION
No offense but @kyewei PRs have been ridded with totally non idiomatic code formatting and syntax (which is totally understandable for a Ruby newcomer).

I know it's not what is important, but it's hard to focus on real problems when it gets in the way.
The idea here is to enforce basic rules automatically, so that we don't have to waste time on PRs.

I took the rules from shipit-engine, with a couple changes. 

@fw42 @Sirupsen thoughts? I'm gonna be honest I don't want to debate any single rule, it's more a "take it or leave it" PR.

