### PR TITLE
Net::HTTP Semian Adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,7 @@ SEMIAN_PARAMETERS = { tickets: 1,
 Semian::NetHTTP.semian_configuration = proc do |host, port|
   # Let's make it only active for github.com
   if host == "github.com" && port == "80"
-    SEMIAN_PARAMETERS.dup.tap do |options|
-      options[:identifier] = nethttp_github.com_80
+    SEMIAN_PARAMETERS.merge(identifier: "nethttp_github.com_80")
     end
   else
     nil

--- a/README.md
+++ b/README.md
@@ -141,11 +141,11 @@ SEMIAN_PARAMETERS = { tickets: 1,
                       success_threshold: 1,
                       error_threshold: 3,
                       error_timeout: 10 }
-Semian::NetHTTP.raw_semian_options = proc do |host, port|
+Semian::NetHTTP.semian_configuration = proc do |host, port|
   # Let's make it only active for github.com
   if host == "github.com" && port == "80"
     SEMIAN_PARAMETERS.dup.tap do |options|
-      options[:name] = nethttp_github.com_80
+      options[:identifier] = nethttp_github.com_80
     end
   else
     nil
@@ -154,8 +154,8 @@ end
 
 # Called from within API:
 # configuration = Semian::NetHTTP.semian_configuration("github.com", 80)
-# semian_identifier = configuration[:name]
-# semian_options = configuration.delete(:name) || configuration
+# semian_identifier = configuration[:identifier]
+# semian_options = configuration.delete(:identifier) || configuration
 ```
 
 It is important to carefully choose the `name` provided, since it is used to identify,
@@ -174,12 +174,13 @@ the use of returning `nil`.
 
 Since we envision this particular adapter can be used in combination with many
 external libraries, we added functionality to expand the Exceptions that can be
-tracked as part of Semian's circuit breaker. Add exceptions and reset to the
-[`default`][nethttp-default-errors] list using the following:
+tracked as part of Semian's circuit breaker. This may be necessary for libraries
+that introduce new exceptions that want to be tracked. Add exceptions and reset
+to the [`default`][nethttp-default-errors] list using the following:
 
 ```ruby
 # assert_equal(Semian::NetHTTP.exceptions, Semian::NetHTTP::DEFAULT_ERRORS)
-Semian::NetHTTP.concat_exceptions([::OpenSSL::SSL::SSLError])
+Semian::NetHTTP.exceptions += [::OpenSSL::SSL::SSLError]
 
 Semian::NetHTTP.reset_exceptions
 # assert_equal(Semian::NetHTTP.exceptions, Semian::NetHTTP::DEFAULT_ERRORS)

--- a/lib/semian/net_http.rb
+++ b/lib/semian/net_http.rb
@@ -22,8 +22,12 @@ module Semian
     ResourceBusyError = ::Net::ResourceBusyError
     CircuitOpenError = ::Net::CircuitOpenError
 
+    def semian_configuration
+      Semian::NetHTTP.retrieve_semian_configuration(address, port)
+    end
+
     def semian_identifier
-      Semian::NetHTTP.retrieve_semian_configuration(address, port)[:identifier]
+      "nethttp_#{semian_configuration[:name]}"
     end
 
     DEFAULT_ERRORS = [
@@ -54,11 +58,8 @@ module Semian
     Semian::NetHTTP.reset_exceptions
 
     def raw_semian_options
-      options = Semian::NetHTTP.retrieve_semian_configuration(address, port)
-      unless options.nil?
-        options = options.dup
-        options.delete(:identifier)
-      end
+      options = semian_configuration
+      options = options.dup unless options.nil?
       options
     end
 
@@ -67,7 +68,7 @@ module Semian
     end
 
     def disabled?
-      raw_semian_options.nil?
+      semian_configuration.nil?
     end
 
     def connect

--- a/lib/semian/net_http.rb
+++ b/lib/semian/net_http.rb
@@ -55,8 +55,10 @@ module Semian
       ::SystemCallError, # includes ::Errno::EINVAL, ::Errno::ECONNRESET, ::Errno::ECONNREFUSED, ::Errno::ETIMEDOUT, and more
     ].freeze # Net::HTTP can throw many different errors, this tries to capture most of them
 
+    Semian::NetHTTP.exceptions = Semian::NetHTTP::DEFAULT_ERRORS.dup
+
     def resource_exceptions
-      Semian::NetHTTP.exceptions ||= Semian::NetHTTP::DEFAULT_ERRORS.dup
+      Semian::NetHTTP.exceptions
     end
 
     def enabled?

--- a/lib/semian/net_http.rb
+++ b/lib/semian/net_http.rb
@@ -1,0 +1,85 @@
+require 'semian'
+require 'semian/adapter'
+require 'net/https'
+require 'open-uri'
+
+module Net
+  ::Net::ProtocolError.include(::Semian::AdapterError)
+
+  class SemianError < ::Net::ProtocolError
+    def initialize(semian_identifier, *args)
+      super(*args)
+      @semian_identifier = semian_identifier
+    end
+  end
+
+  Net::ResourceBusyError = Class.new(SemianError)
+  Net::CircuitOpenError = Class.new(SemianError)
+end
+
+module Semian
+  module NetHTTP
+    include Semian::Adapter
+
+    ResourceBusyError = ::Net::ResourceBusyError
+    CircuitOpenError = ::Net::CircuitOpenError
+
+    DEFAULT_SEMIAN_OPTIONS = @raw_semian_options = {
+      tickets: 3,
+      success_threshold: 1,
+      error_threshold: 3,
+      error_timeout: 10,
+    }
+
+    def semian_identifier
+      "http_#{address.tr('.', '_')}_#{port}"
+    end
+
+    def self.raw_semian_options(semian_identifier = "http_default".freeze)
+      if @raw_semian_options.respond_to?(:call)
+        @raw_semian_options.call(semian_identifier)
+      else
+        @raw_semian_options ||= DEFAULT_SEMIAN_OPTIONS
+      end
+    end
+
+    def self.raw_semian_options=(options)
+      @raw_semian_options = options
+    end
+
+    def raw_semian_options
+      Semian::NetHTTP.raw_semian_options(semian_identifier)
+    end
+
+    def resource_exceptions
+      @exceptions ||= [
+        ::Timeout::Error, # includes ::Net::ReadTimeout and ::Net::OpenTimeout
+        ::TimeoutError,
+        ::Net::ProtocolError,
+        ::Net::HTTPBadResponse,
+        ::Net::HTTPHeaderSyntaxError,
+        ::SocketError,
+        ::IOError,
+        ::EOFError,
+        ::Resolv::ResolvError,
+        ::OpenURI::HTTPError,
+        ::OpenSSL::SSL::SSLError,
+        ::SystemCallError, # includes ::Errno::EINVAL, ::Errno::ECONNRESET, ::Errno::ECONNREFUSED, ::Errno::ETIMEDOUT, and more
+      ]
+    end
+
+    def connect
+      acquire_semian_resource(adapter: :nethttp, scope: :connection) do
+        super
+      end
+    end
+
+    def request(*req)
+      acquire_semian_resource(adapter: :nethttp, scope: :query) do
+        super
+      end
+    end
+  end
+end
+
+Net::HTTP.send(:prepend, Semian::NetHTTP)

--- a/lib/semian/net_http.rb
+++ b/lib/semian/net_http.rb
@@ -23,7 +23,8 @@ module Semian
     CircuitOpenError = ::Net::CircuitOpenError
 
     def semian_identifier
-      "http_#{address.tr('.', '_')}_#{port}"
+      @configuration ||= Semian::NetHTTP.retrieve_semian_configuration_by_host_port(address, port)
+      @configuration[0]
     end
 
     DEFAULT_ERRORS = [
@@ -39,14 +40,14 @@ module Semian
     ].freeze # Net::HTTP can throw many different errors, this tries to capture most of them
 
     class << self
-      attr_accessor :raw_semian_options
+      attr_accessor :semian_configuration
       attr_accessor :exceptions
 
-      def retrieve_semian_options_by_identifier(semian_identifier)
-        if @raw_semian_options.respond_to?(:call)
-          @raw_semian_options.call(semian_identifier)
+      def retrieve_semian_configuration_by_host_port(host, port)
+        if @semian_configuration.respond_to?(:call)
+          @semian_configuration.call(host, port) || ["nethttp_#{host}_#{port}", nil]
         else
-          @raw_semian_options ||= nil # disabled by default
+          ["nethttp_#{host}_#{port}", nil] # adapter is disabled by default
         end
       end
 
@@ -62,7 +63,8 @@ module Semian
     Semian::NetHTTP.reset_exceptions
 
     def raw_semian_options
-      Semian::NetHTTP.retrieve_semian_options_by_identifier(semian_identifier)
+      @configuration ||= Semian::NetHTTP.retrieve_semian_configuration_by_host_port(address, port)
+      @configuration[1]
     end
 
     def resource_exceptions

--- a/lib/semian/net_http.rb
+++ b/lib/semian/net_http.rb
@@ -56,7 +56,7 @@ module Semian
     ].freeze # Net::HTTP can throw many different errors, this tries to capture most of them
 
     def resource_exceptions
-      Semian::NetHTTP.exceptions ||= DEFAULT_ERRORS.dup
+      Semian::NetHTTP.exceptions ||= Semian::NetHTTP::DEFAULT_ERRORS.dup
     end
 
     def enabled?
@@ -65,14 +65,14 @@ module Semian
 
     def connect
       return super unless enabled?
-      acquire_semian_resource(adapter: :nethttp, scope: :connection) do
+      acquire_semian_resource(adapter: :http, scope: :connection) do
         super
       end
     end
 
     def request(*req)
       return super unless enabled?
-      acquire_semian_resource(adapter: :nethttp, scope: :query) do
+      acquire_semian_resource(adapter: :http, scope: :query) do
         super
       end
     end

--- a/lib/semian/net_http.rb
+++ b/lib/semian/net_http.rb
@@ -26,23 +26,6 @@ module Semian
       "http_#{address.tr('.', '_')}_#{port}"
     end
 
-    class << self
-      attr_accessor :raw_semian_options
-      attr_accessor :exceptions
-
-      def retrieve_semian_options_by_identifier(semian_identifier)
-        if @raw_semian_options.respond_to?(:call)
-          @raw_semian_options.call(semian_identifier)
-        else
-          @raw_semian_options ||= nil # disabled by default
-        end
-      end
-    end
-
-    def raw_semian_options
-      Semian::NetHTTP.retrieve_semian_options_by_identifier(semian_identifier)
-    end
-
     DEFAULT_ERRORS = [
       ::Timeout::Error, # includes ::Net::ReadTimeout and ::Net::OpenTimeout
       ::TimeoutError, # alias for above
@@ -55,7 +38,32 @@ module Semian
       ::SystemCallError, # includes ::Errno::EINVAL, ::Errno::ECONNRESET, ::Errno::ECONNREFUSED, ::Errno::ETIMEDOUT, and more
     ].freeze # Net::HTTP can throw many different errors, this tries to capture most of them
 
-    Semian::NetHTTP.exceptions = Semian::NetHTTP::DEFAULT_ERRORS.dup
+    class << self
+      attr_accessor :raw_semian_options
+      attr_accessor :exceptions
+
+      def retrieve_semian_options_by_identifier(semian_identifier)
+        if @raw_semian_options.respond_to?(:call)
+          @raw_semian_options.call(semian_identifier)
+        else
+          @raw_semian_options ||= nil # disabled by default
+        end
+      end
+
+      def reset_exceptions
+        self.exceptions = Semian::NetHTTP::DEFAULT_ERRORS.dup
+      end
+
+      def concat_exceptions(exceptions)
+        self.exceptions.concat(exceptions)
+      end
+    end
+
+    Semian::NetHTTP.reset_exceptions
+
+    def raw_semian_options
+      Semian::NetHTTP.retrieve_semian_options_by_identifier(semian_identifier)
+    end
 
     def resource_exceptions
       Semian::NetHTTP.exceptions

--- a/semian.gemspec
+++ b/semian.gemspec
@@ -22,4 +22,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'mysql2'
   s.add_development_dependency 'redis'
+  s.add_development_dependency 'thin'
+  s.add_development_dependency 'toxiproxy'
 end

--- a/test/net_http_test.rb
+++ b/test/net_http_test.rb
@@ -245,6 +245,16 @@ class TestNetHTTP < MiniTest::Unit::TestCase
     end
   end
 
+  def test_adding_extra_errors_and_resetting_affects_exceptions_list
+    orig_errors = Semian::NetHTTP.exceptions.dup
+    Semian::NetHTTP.concat_exceptions([::OpenSSL::SSL::SSLError])
+    assert_equal(orig_errors + [::OpenSSL::SSL::SSLError], Semian::NetHTTP.exceptions)
+    Semian::NetHTTP.reset_exceptions
+    assert_equal(Semian::NetHTTP::DEFAULT_ERRORS, Semian::NetHTTP.exceptions)
+  ensure
+    Semian::NetHTTP.exceptions = orig_errors
+  end
+
   def test_adding_custom_errors_do_trip_circuit
     with_semian_options do
       with_custom_errors([::OpenSSL::SSL::SSLError]) do
@@ -316,8 +326,8 @@ class TestNetHTTP < MiniTest::Unit::TestCase
   end
 
   def with_custom_errors(errors)
-    orig_errors = Semian::NetHTTP.exceptions
-    Semian::NetHTTP.exceptions = Semian::NetHTTP::DEFAULT_ERRORS.dup + errors
+    orig_errors = Semian::NetHTTP.exceptions.dup
+    Semian::NetHTTP.concat_exceptions(errors)
     yield
   ensure
     Semian::NetHTTP.exceptions = orig_errors

--- a/test/net_http_test.rb
+++ b/test/net_http_test.rb
@@ -1,0 +1,218 @@
+require 'test_helper'
+require 'semian/net_http'
+require 'thin'
+
+class TestNetHTTP < MiniTest::Unit::TestCase
+  class RackServer
+    def self.call(env)
+      response_code = env['REQUEST_URI'].delete("/")
+      response_code = '200' if response_code == ""
+      [response_code, {'Content-Type' => 'text/html'}, ['Success']]
+    end
+  end
+
+  def setup
+    # create a simple rack server so we can use toxiproxy
+    start_server_singleton
+    Semian["http_localhost_41234"].reset if Semian["http_localhost_41234"]
+    Semian["http_localhost_41235"].reset if Semian["http_localhost_41235"]
+    Semian.destroy('http_localhost_41234')
+    Semian.destroy('http_localhost_41235')
+    @proxy = Toxiproxy[:semian_test_net_http]
+  end
+
+  def test_server_up_and_toxiproxy_working
+    uri = URI('http://localhost:41234/200')
+    assert_equal "Success", Net::HTTP.get(uri)
+
+    uri = URI('http://localhost:41235/200')
+    @proxy.downstream(:latency, latency: 300).apply do
+      time = Time.now
+      Net::HTTP.get(uri)
+
+      time_diff = Time.now - time
+      assert time_diff >= 0.3
+    end
+  end
+
+  def test_semian_identifier
+    Net::HTTP.start("localhost", 41_235) do |http|
+      assert_equal "http_localhost_41235", http.semian_identifier
+    end
+  end
+
+  def test_trigger_open
+    open_circuit!
+    uri = URI('http://localhost:41235/200')
+    assert_raises Net::CircuitOpenError do
+      Net::HTTP.get(uri)
+    end
+  end
+
+  def test_trigger_close_after_open
+    open_circuit!
+    close_circuit!
+  end
+
+  def test_blockheads_tickets_are_working
+    threads = []
+    ticket_count = Net::HTTP.new("localhost", 41_235).raw_semian_options[:tickets]
+
+    @proxy.downstream(:latency, latency: 500).apply do
+      uri = URI('http://localhost:41235/200')
+      (ticket_count).times do
+        threads << Thread.new do
+          Net::HTTP.get(uri)
+        end
+      end
+      sleep 0.3
+      assert_raises Net::ResourceBusyError do
+        Net::HTTP.get(uri)
+      end
+
+      threads.each(&:join)
+    end
+  end
+
+  def test_get_type_1_is_protected
+    open_circuit!
+    assert_raises Net::CircuitOpenError do
+      Net::HTTP.get(URI('http://localhost:41235/200'))
+    end
+  end
+
+  def test_get_type_2_is_protected
+    open_circuit!
+    assert_raises Net::CircuitOpenError do
+      http = Net::HTTP.new("localhost", "41235")
+      http.get("/")
+    end
+  end
+
+  def test_get_type_3_is_protected
+    open_circuit!
+    assert_raises Net::CircuitOpenError do
+      uri = URI('http://localhost:41235/200')
+      Net::HTTP.get_response(uri)
+    end
+  end
+
+  def test_post_type_1_is_protected
+    open_circuit!
+    assert_raises Net::CircuitOpenError do
+      uri = URI('http://localhost:41235/200')
+      Net::HTTP.post_form(uri, 'q' => 'ruby', 'max' => '50')
+    end
+  end
+
+  def test_http_start_and_inner_methods_are_protected
+    open_circuit!
+
+    uri = URI('http://localhost:41235/200')
+    assert_raises Net::CircuitOpenError do
+      Net::HTTP.start(uri.host, uri.port) do |_|
+      end
+    end
+
+    close_circuit!
+    Net::HTTP.start(uri.host, uri.port) do |http|
+      open_circuit!
+      assert_raises Net::CircuitOpenError do
+        request = Net::HTTP::Get.new uri
+        http.request(request)
+      end
+      assert_raises Net::CircuitOpenError do
+        request = Net::HTTP::Post.new uri
+        http.request(request)
+      end
+      # and so on...
+    end
+  end
+
+  def test_custom_raw_semian_options_work
+    orig_semian_options = Semian::NetHTTP.raw_semian_options
+    yaml_sample_config = {}
+    yaml_sample_config["development"] = {}
+    yaml_sample_config["development"]["http_default"] = {"tickets" => 1,
+                                                         "success_threshold" => 1,
+                                                         "error_threshold" => 3,
+                                                         "error_timeout" => 10}
+    yaml_sample_config["development"]["http_localhost_41235"] = {"tickets" => 1,
+                                                                 "success_threshold" => 1,
+                                                                 "error_threshold" => 3,
+                                                                 "error_timeout" => 10}
+    sample_env = "development"
+    Semian::NetHTTP.raw_semian_options = proc do |semian_identifier|
+      if !yaml_sample_config[sample_env].key?(semian_identifier)
+        yaml_sample_config[sample_env]["http_default"]
+      else
+        yaml_sample_config[sample_env][semian_identifier]
+      end
+    end
+    Net::HTTP.start("localhost", 41_235) do |http|
+      assert_equal yaml_sample_config["development"][http.semian_identifier], http.raw_semian_options
+    end
+    Net::HTTP.start("localhost", 41_234) do |http|
+      assert_equal yaml_sample_config["development"]["http_default"], http.raw_semian_options
+    end
+    assert_equal yaml_sample_config["development"]["http_default"], Semian::NetHTTP.raw_semian_options
+  ensure
+    Semian::NetHTTP.raw_semian_options = orig_semian_options
+  end
+
+  def open_circuit!
+    Net::HTTP.start("localhost", 41_235) do |http|
+      http.read_timeout = 0.1
+      uri = URI('http://localhost:41235/200')
+
+      http.raw_semian_options[:error_threshold].times do
+        # Cause error error_threshold times so circuit opens
+        @proxy.downstream(:latency, latency: 150).apply do
+          request = Net::HTTP::Get.new(uri)
+          assert_raises Net::ReadTimeout do
+            http.request(request)
+          end
+        end
+      end
+    end
+  end
+
+  def close_circuit!
+    http = Net::HTTP.new("localhost", 41_235)
+    Timecop.travel(http.raw_semian_options[:error_timeout] + 1)
+    # Cause successes success_threshold times so circuit closes
+    http.raw_semian_options[:success_threshold].times do
+      http.get("/200")
+    end
+  end
+
+  class << self
+    attr_accessor :server_thread
+  end
+
+  def start_server_singleton
+    return if self.class.server_thread
+    self.class.server_thread = Thread.new do
+      Thin::Logging.silent = true
+      Thin::Server.start('localhost', 41_234, RackServer)
+    end
+    poll_until_ready(port: 41_234, time_to_wait: 1)
+  end
+
+  def poll_until_ready(port: 41_234, time_to_wait: 1)
+    start_time = Time.now.to_i
+    begin
+      TCPSocket.new('127.0.0.1', port).close
+    rescue Errno::ECONNREFUSED, Errno::ECONNRESET
+      if Time.now.to_i > start_time + time_to_wait
+        raise "Couldn't reach the service on port #{port} after #{time_to_wait}s"
+      else
+        retry
+      end
+    end
+  end
+
+  def after_tests
+    self.class.server_thread.kill
+  end
+end

--- a/test/net_http_test.rb
+++ b/test/net_http_test.rb
@@ -21,7 +21,7 @@ class TestNetHTTP < MiniTest::Unit::TestCase
     error_timeout: 10,
   }.freeze
   DEFAULT_SEMIAN_CONFIGURATION = proc do |host, port|
-    DEFAULT_SEMIAN_OPTIONS.dup.tap { |o| o[:identifier] = "nethttp_#{host}_#{port}" }
+    DEFAULT_SEMIAN_OPTIONS.merge(identifier: "nethttp_#{host}_#{port}")
   end
 
   def test_with_server_raises_if_binding_fails
@@ -179,7 +179,7 @@ class TestNetHTTP < MiniTest::Unit::TestCase
 
       semian_options_proc = proc do |host, port|
         semian_identifier = "nethttp_#{host}_#{port}"
-        semian_config[sample_env][semian_identifier].dup.tap { |o| o[:identifier] = "nethttp_#{host}_#{port}" }
+        semian_config[sample_env][semian_identifier].merge(identifier: "nethttp_#{host}_#{port}")
       end
 
       with_semian_options(semian_options_proc) do
@@ -200,9 +200,10 @@ class TestNetHTTP < MiniTest::Unit::TestCase
       semian_options_proc = proc do |host, port|
         semian_identifier = "nethttp_#{host}_#{port}"
         semian_identifier = "nethttp_default" unless semian_config[sample_env].key?(semian_identifier)
-        semian_config[sample_env][semian_identifier].dup.tap { |o| o[:identifier] = "nethttp_default" }
+        semian_config[sample_env][semian_identifier].merge(identifier: "nethttp_default")
       end
-
+      Semian["nethttp_default"].reset if Semian["nethttp_default"]
+      Semian.destroy("nethttp_default")
       with_semian_options(semian_options_proc) do
         Net::HTTP.start(HOSTNAME, PORT) do |http|
           expected_config = semian_config["development"]["nethttp_default"].dup
@@ -230,7 +231,7 @@ class TestNetHTTP < MiniTest::Unit::TestCase
 
     semian_options_proc = proc do
       semian_identifier = "nethttp_default"
-      semian_config[sample_env][semian_identifier].dup.tap { |o| o[:identifier] = "nethttp_default" }
+      semian_config[sample_env][semian_identifier].merge(identifier: "nethttp_default")
     end
 
     with_semian_options(semian_options_proc) do

--- a/test/net_http_test.rb
+++ b/test/net_http_test.rb
@@ -11,6 +11,7 @@ class TestNetHTTP < MiniTest::Unit::TestCase
     end
   end
 
+  HOSTNAME = "localhost"
   PORT = 31_050
   TOXIC_PORT = PORT + 1
 
@@ -21,19 +22,32 @@ class TestNetHTTP < MiniTest::Unit::TestCase
     error_timeout: 10,
   }
 
+  def test_with_server_raises_if_binding_fails
+    # Occurs when trying to bind to invalid addresses, like non-private
+    # addresses, or when the address is already bound to something else
+    with_server do
+      assert_raises RuntimeError do
+        with_server {}
+      end
+    end
+  end
+
   def test_semian_identifier
     with_server do
-      Net::HTTP.start("localhost", TOXIC_PORT) do |http|
-        assert_equal "http_localhost_#{TOXIC_PORT}", http.semian_identifier
+      Net::HTTP.start(HOSTNAME, TOXIC_PORT) do |http|
+        assert_equal "http_#{HOSTNAME.tr('.', '_')}_#{TOXIC_PORT}", http.semian_identifier
+      end
+      Net::HTTP.start("127.0.0.1", TOXIC_PORT) do |http|
+        assert_equal "http_127_0_0_1_#{TOXIC_PORT}", http.semian_identifier
       end
     end
   end
 
   def test_trigger_open
-    with_semian_options(DEFAULT_SEMIAN_OPTIONS) do
+    with_semian_options do
       with_server do
         open_circuit!
-        uri = URI("http://localhost:#{TOXIC_PORT}/200")
+        uri = URI("http://#{HOSTNAME}:#{TOXIC_PORT}/200")
         assert_raises Net::CircuitOpenError do
           Net::HTTP.get(uri)
         end
@@ -42,7 +56,7 @@ class TestNetHTTP < MiniTest::Unit::TestCase
   end
 
   def test_trigger_close_after_open
-    with_semian_options(DEFAULT_SEMIAN_OPTIONS) do
+    with_semian_options do
       with_server do
         open_circuit!
         close_circuit!
@@ -51,52 +65,40 @@ class TestNetHTTP < MiniTest::Unit::TestCase
   end
 
   def test_bulkheads_tickets_are_working
-    with_semian_options(DEFAULT_SEMIAN_OPTIONS) do
+    options = DEFAULT_SEMIAN_OPTIONS.dup
+    options[:tickets] = 2
+    with_semian_options(options) do
       with_server do
-        ticket_count = Net::HTTP.new("localhost", TOXIC_PORT).raw_semian_options[:tickets]
-        m = Monitor.new
-        acquired_count = 0
-        ticket_count.times do
-          threads << Thread.new do
-            http = Net::HTTP.new("localhost", "#{TOXIC_PORT}")
-            http.acquire_semian_resource(adapter: :nethttp, scope: :connection) do
-              m.synchronize do
-                acquired_count += 1
-              end
-              sleep
+        http_1 = Net::HTTP.new(HOSTNAME, TOXIC_PORT)
+        http_1.semian_resource.acquire do
+          http_2 = Net::HTTP.new(HOSTNAME, TOXIC_PORT)
+          http_2.semian_resource.acquire do
+            assert_raises Net::ResourceBusyError do
+              Net::HTTP.get(URI("http://#{HOSTNAME}:#{TOXIC_PORT}/"))
             end
           end
-        end
-
-        Thread.new do
-          sleep(1) until acquired_count == ticket_count
-          http = Net::HTTP.new("localhost", "#{TOXIC_PORT}")
-          assert_raises Net::ResourceBusyError do
-            http.get("/")
-          end
-          threads.each(&:join)
         end
       end
     end
   end
 
   def test_get_is_protected
-    with_semian_options(DEFAULT_SEMIAN_OPTIONS) do
+    with_semian_options do
       with_server do
         open_circuit!
         assert_raises Net::CircuitOpenError do
-          Net::HTTP.get(URI("http://localhost:#{TOXIC_PORT}/200"))
+          Net::HTTP.get(URI("http://#{HOSTNAME}:#{TOXIC_PORT}/200"))
         end
       end
     end
   end
 
   def test_instance_get_is_protected
-    with_semian_options(DEFAULT_SEMIAN_OPTIONS) do
+    with_semian_options do
       with_server do
         open_circuit!
         assert_raises Net::CircuitOpenError do
-          http = Net::HTTP.new("localhost", "#{TOXIC_PORT}")
+          http = Net::HTTP.new(HOSTNAME, TOXIC_PORT)
           http.get("/")
         end
       end
@@ -104,40 +106,46 @@ class TestNetHTTP < MiniTest::Unit::TestCase
   end
 
   def test_get_response_is_protected
-    with_semian_options(DEFAULT_SEMIAN_OPTIONS) do
+    with_semian_options do
       with_server do
         open_circuit!
         assert_raises Net::CircuitOpenError do
-          uri = URI("http://localhost:#{TOXIC_PORT}/200")
+          uri = URI("http://#{HOSTNAME}:#{TOXIC_PORT}/200")
           Net::HTTP.get_response(uri)
         end
       end
     end
   end
 
-  def test_post_type_1_is_protected
-    with_semian_options(DEFAULT_SEMIAN_OPTIONS) do
+  def test_post_form_is_protected
+    with_semian_options do
       with_server do
         open_circuit!
         assert_raises Net::CircuitOpenError do
-          uri = URI("http://localhost:#{TOXIC_PORT}/200")
+          uri = URI("http://#{HOSTNAME}:#{TOXIC_PORT}/200")
           Net::HTTP.post_form(uri, 'q' => 'ruby', 'max' => '50')
         end
       end
     end
   end
 
-  def test_http_start_and_inner_methods_are_protected
-    with_semian_options(DEFAULT_SEMIAN_OPTIONS) do
+  def test_http_start_method_is_protected
+    with_semian_options do
       with_server do
         open_circuit!
-
-        uri = URI("http://localhost:#{TOXIC_PORT}/200")
+        uri = URI("http://#{HOSTNAME}:#{TOXIC_PORT}/200")
         assert_raises Net::CircuitOpenError do
           Net::HTTP.start(uri.host, uri.port) {}
         end
-
         close_circuit!
+      end
+    end
+  end
+
+  def test_http_action_request_inside_start_methods_are_protected
+    with_semian_options do
+      with_server do
+        uri = URI("http://#{HOSTNAME}:#{TOXIC_PORT}/200")
         Net::HTTP.start(uri.host, uri.port) do |http|
           open_circuit!
           get_subclasses(Net::HTTPRequest).each do |action|
@@ -151,16 +159,34 @@ class TestNetHTTP < MiniTest::Unit::TestCase
     end
   end
 
-  def test_custom_raw_semian_options_work
+  def test_custom_raw_semian_options_work_with_lookup
     with_server do
       semian_config = {}
       semian_config["development"] = {}
-      semian_config["development"]["http_default"] =
+      semian_config["development"]["http_#{HOSTNAME.tr('.', '_')}_#{TOXIC_PORT}"] =
         {"tickets" => 1,
          "success_threshold" => 1,
          "error_threshold" => 3,
          "error_timeout" => 10}
-      semian_config["development"]["http_localhost_#{TOXIC_PORT}"] =
+      sample_env = "development"
+
+      semian_options_proc = proc do |semian_identifier|
+        semian_config[sample_env][semian_identifier]
+      end
+
+      with_semian_options(semian_options_proc) do
+        Net::HTTP.start(HOSTNAME, TOXIC_PORT) do |http|
+          assert_equal semian_config["development"][http.semian_identifier], http.raw_semian_options
+        end
+      end
+    end
+  end
+
+  def test_custom_raw_semian_options_work_with_default_fallback
+    with_server do
+      semian_config = {}
+      semian_config["development"] = {}
+      semian_config["development"]["http_default"] =
         {"tickets" => 1,
          "success_threshold" => 1,
          "error_threshold" => 3,
@@ -176,31 +202,30 @@ class TestNetHTTP < MiniTest::Unit::TestCase
       end
 
       with_semian_options(semian_options_proc) do
-        Net::HTTP.start("localhost", TOXIC_PORT) do |http|
-          assert_equal semian_config["development"][http.semian_identifier], http.raw_semian_options
-        end
-        Net::HTTP.start("localhost", PORT) do |http|
+        Net::HTTP.start(HOSTNAME, PORT) do |http|
           assert_equal semian_config["development"]["http_default"], http.raw_semian_options
+          assert_equal semian_config["development"]["http_default"],
+                       Semian::NetHTTP.retrieve_semian_options_by_identifier(http.semian_identifier)
         end
-        assert_equal semian_config["development"]["http_default"],
-                     Semian::NetHTTP.retrieve_semian_options_by_identifier("http_default")
       end
     end
   end
 
-  def test_custom_raw_semian_options_can_disable
-    with_server do # disabled if nil
+  def test_custom_raw_semian_options_can_disable_using_nil
+    with_server do
       semian_options_proc = proc { nil }
       with_semian_options(semian_options_proc) do
-        http = Net::HTTP.new("localhost", "#{TOXIC_PORT}")
+        http = Net::HTTP.new(HOSTNAME, TOXIC_PORT)
         assert_equal false, http.enabled?
       end
     end
+  end
 
-    with_server do # disabled if key not found
+  def test_custom_raw_semian_options_can_disable_with_invalid_key
+    with_server do
       semian_config = {}
       semian_config["development"] = {}
-      semian_config["development"]["http_localhost_#{TOXIC_PORT}"] =
+      semian_config["development"]["http_#{HOSTNAME.tr('.', '_')}_#{TOXIC_PORT}"] =
         {"tickets" => 1,
          "success_threshold" => 1,
          "error_threshold" => 3,
@@ -211,58 +236,67 @@ class TestNetHTTP < MiniTest::Unit::TestCase
         semian_config[sample_env][semian_identifier]
       end
       with_semian_options(semian_options_proc) do
-        http = Net::HTTP.new("localhost", "#{TOXIC_PORT}")
+        http = Net::HTTP.new(HOSTNAME, TOXIC_PORT)
         assert_equal true, http.enabled?
 
-        http = Net::HTTP.new("localhost", "#{TOXIC_PORT + 100}")
+        http = Net::HTTP.new(HOSTNAME, TOXIC_PORT + 100)
         assert_equal false, http.enabled?
       end
     end
   end
 
-  def test_adding_custom_errors_work
-    with_semian_options(DEFAULT_SEMIAN_OPTIONS) do
-      with_server do
-        with_custom_errors([::OpenSSL::SSL::SSLError]) do
-          http = Net::HTTP.new("localhost", TOXIC_PORT)
-          assert http.resource_exceptions.include?(::OpenSSL::SSL::SSLError)
+  def test_adding_custom_errors_do_trip_circuit
+    with_semian_options do
+      with_custom_errors([::OpenSSL::SSL::SSLError]) do
+        with_server do
+          http = Net::HTTP.new(HOSTNAME, TOXIC_PORT)
+          http.use_ssl = true
+          http.raw_semian_options[:error_threshold].times do
+            assert_raises ::OpenSSL::SSL::SSLError do
+              http.get("/200")
+            end
+          end
+          assert_raises Net::CircuitOpenError do
+            http.get("/200")
+          end
         end
       end
     end
   end
 
   def test_multiple_different_endpoints_and_ports_are_tracked_differently
-    with_semian_options(DEFAULT_SEMIAN_OPTIONS) do
-      ports = [PORT + 100, PORT + 200]
-      ports.each do |port|
-        Semian["http_localhost_#{port}"].reset if Semian["http_localhost_#{port}"]
-        Semian["http_localhost_#{port + 1}"].reset if Semian["http_localhost_#{port + 1}"]
-        Semian.destroy('http_localhost_#{port}')
-        Semian.destroy('http_localhost_#{port + 1}')
-        with_server(port: port, reset_semian_state: false) do
-          with_toxic(upstream_port: port, toxic_port: port + 1) do |name|
-            open_circuit!(toxic_port: port + 1, toxic_name: name)
-            close_circuit!(toxic_port: port + 1)
+    with_semian_options do
+      addresses = ["#{HOSTNAME}:#{PORT}", "#{HOSTNAME}:#{PORT + 100}"]
+      addresses.each do |address|
+        hostname, port = address.split(":")
+        port = port.to_i
+        reset_semian_resource(hostname: hostname, port: port)
+      end
+      with_server(addresses: addresses, reset_semian_state: false) do |hostname, port|
+        with_toxic(hostname: hostname, upstream_port: port, toxic_port: port + 1) do |name|
+          Net::HTTP.get(URI("http://#{hostname}:#{port + 1}/"))
+          open_circuit!(hostname: hostname, toxic_port: port + 1, toxic_name: name)
+          assert_raises Net::CircuitOpenError do
+            Net::HTTP.get(URI("http://#{hostname}:#{port + 1}/"))
           end
         end
       end
-      with_server(port: PORT, reset_semian_state: false) do
-        open_circuit!
-        Net::HTTP.get(URI("http://127.0.0.1:#{PORT}/")) # different endpoint, should not raise errors
+      with_server(addresses: ["127.0.0.1:#{PORT}"], reset_semian_state: false) do
+        # different endpoint, should not raise errors even though localhost == 127.0.0.1
+        Net::HTTP.get(URI("http://127.0.0.1:#{PORT + 1}/"))
       end
     end
   end
 
   def test_persistent_state_after_server_restart
-    with_semian_options(DEFAULT_SEMIAN_OPTIONS) do
-      port = PORT + 100
-      with_server(port: port) do
-        with_toxic(upstream_port: port, toxic_port: port + 1) do |name|
-          open_circuit!(toxic_port: port + 1, toxic_name: name)
+    with_semian_options do
+      with_server(addresses: ["#{HOSTNAME}:#{PORT + 100}"]) do |hostname, port|
+        with_toxic(hostname: hostname, upstream_port: port, toxic_port: port + 1) do |name|
+          open_circuit!(hostname: hostname, toxic_port: port + 1, toxic_name: name)
         end
       end
-      with_server(port: port, reset_semian_state: false) do
-        with_toxic(upstream_port: port, toxic_port: port + 1) do |_|
+      with_server(addresses: ["#{HOSTNAME}:#{PORT + 100}"], reset_semian_state: false) do |hostname, port|
+        with_toxic(hostname: hostname, upstream_port: port, toxic_port: port + 1) do |_|
           assert_raises Net::CircuitOpenError do
             Net::HTTP.get(URI("http://localhost:#{port + 1}/200"))
           end
@@ -273,7 +307,7 @@ class TestNetHTTP < MiniTest::Unit::TestCase
 
   private
 
-  def with_semian_options(options)
+  def with_semian_options(options = DEFAULT_SEMIAN_OPTIONS)
     orig_semian_options = Semian::NetHTTP.raw_semian_options
     Semian::NetHTTP.raw_semian_options = options
     yield
@@ -283,9 +317,7 @@ class TestNetHTTP < MiniTest::Unit::TestCase
 
   def with_custom_errors(errors)
     orig_errors = Semian::NetHTTP.exceptions
-    errors.each do |error|
-      Semian::NetHTTP.exceptions << error
-    end
+    Semian::NetHTTP.exceptions = Semian::NetHTTP::DEFAULT_ERRORS.dup + errors
     yield
   ensure
     Semian::NetHTTP.exceptions = orig_errors
@@ -295,10 +327,10 @@ class TestNetHTTP < MiniTest::Unit::TestCase
     ObjectSpace.each_object(klass.singleton_class).to_a - [klass]
   end
 
-  def open_circuit!(toxic_port: TOXIC_PORT, toxic_name: "semian_test_net_http")
-    Net::HTTP.start("localhost", toxic_port) do |http|
+  def open_circuit!(hostname: HOSTNAME, toxic_port: TOXIC_PORT, toxic_name: "semian_test_net_http")
+    Net::HTTP.start(hostname, toxic_port) do |http|
       http.read_timeout = 0.1
-      uri = URI("http://localhost:#{toxic_port}/200")
+      uri = URI("http://#{hostname}:#{toxic_port}/200")
       http.raw_semian_options[:error_threshold].times do
         # Cause error error_threshold times so circuit opens
         Toxiproxy[toxic_name].downstream(:latency, latency: 150).apply do
@@ -311,8 +343,8 @@ class TestNetHTTP < MiniTest::Unit::TestCase
     end
   end
 
-  def close_circuit!(toxic_port: TOXIC_PORT)
-    http = Net::HTTP.new("localhost", toxic_port)
+  def close_circuit!(hostname: HOSTNAME, toxic_port: TOXIC_PORT)
+    http = Net::HTTP.new(hostname, toxic_port)
     Timecop.travel(http.raw_semian_options[:error_timeout])
     # Cause successes success_threshold times so circuit closes
     http.raw_semian_options[:success_threshold].times do
@@ -321,66 +353,91 @@ class TestNetHTTP < MiniTest::Unit::TestCase
     end
   end
 
-  def with_server(port: PORT, reset_semian_state: true)
-    server_thread = Thread.new do
-      Thin::Logging.silent = true
-      Thin::Server.start('localhost', port, RackServer)
+  def with_server(addresses: ["#{HOSTNAME}:#{PORT}"], reset_semian_state: true)
+    addresses.each do |address|
+      hostname, port = address.split(":")
+      begin
+        server = nil
+        server_threw_error = false
+        server_thread = Thread.new do
+          Thin::Logging.silent = true
+          server = Thin::Server.new(hostname, port, RackServer)
+          begin
+            server.start
+          rescue StandardError
+            server_threw_error = true
+            raise
+          end
+        end
+
+        begin
+          poll_until_ready(hostname: hostname, port: port)
+        rescue RuntimeError
+          server_thread.kill
+          server_thread.join if server_threw_error
+          raise
+        end
+
+        assert(server.running?)
+        reset_semian_resource(hostname: hostname, port: port) if reset_semian_state
+        @proxy = Toxiproxy[:semian_test_net_http]
+        yield(hostname, port.to_i)
+      ensure
+        server_thread.kill
+        poll_until_gone(hostname: hostname, port: port)
+      end
     end
-    poll_until_ready(port: port)
-    if reset_semian_state
-      Semian["http_localhost_#{port}"].reset if Semian["http_localhost_#{port}"]
-      Semian["http_localhost_#{port + 1}"].reset if Semian["http_localhost_#{port + 1}"]
-      Semian.destroy('http_localhost_#{port}')
-      Semian.destroy('http_localhost_#{port + 1}')
-    end
-    @proxy = Toxiproxy[:semian_test_net_http]
-    yield
-  ensure
-    server_thread.kill
-    poll_until_gone(port: PORT)
   end
 
-  def with_toxic(upstream_port: PORT, toxic_port: upstream_port + 1)
+  def reset_semian_resource(hostname:, port:)
+    Semian["http_#{hostname.tr('.', '_')}_#{port}"].reset if Semian["http_#{hostname.tr('.', '_')}_#{port}"]
+    Semian["http_#{hostname.tr('.', '_')}_#{port.to_i + 1}"].reset if Semian["http_#{hostname.tr('.', '_')}_#{port.to_i + 1}"]
+    Semian.destroy("http_#{hostname.tr('.', '_')}_#{port}")
+    Semian.destroy("http_#{hostname.tr('.', '_')}_#{port.to_i + 1}")
+  end
+
+  def with_toxic(hostname: HOSTNAME, upstream_port: PORT, toxic_port: upstream_port + 1)
     old_proxy = @proxy
-    name = "semian_test_net_http_#{upstream_port}_#{toxic_port}"
+    name = "semian_test_net_http_#{hostname.tr('.', '_')}_#{upstream_port}<-#{toxic_port}"
     Toxiproxy.populate([
       {
         name: name,
-        upstream: "localhost:#{upstream_port}",
-        listen: "localhost:#{toxic_port}",
+        upstream: "#{hostname}:#{upstream_port}",
+        listen: "#{hostname}:#{toxic_port}",
       },
     ])
     @proxy = Toxiproxy[name]
     yield(name)
+  rescue StandardError
   ensure
     @proxy = old_proxy
     begin
       Toxiproxy[name].destroy
-    rescue nil
+    rescue StandardError
     end
   end
 
-  def poll_until_ready(port: PORT, time_to_wait: 2)
+  def poll_until_ready(hostname: HOSTNAME, port: PORT, time_to_wait: 1)
     start_time = Time.now.to_i
     begin
-      TCPSocket.new('127.0.0.1', port).close
+      TCPSocket.new(hostname, port).close
     rescue Errno::ECONNREFUSED, Errno::ECONNRESET
       if Time.now.to_i > start_time + time_to_wait
-        raise "Couldn't reach the service on port #{port} after #{time_to_wait}s"
+        raise "Couldn't reach the service on hostname #{hostname} port #{port} after #{time_to_wait}s"
       else
         retry
       end
     end
   end
 
-  def poll_until_gone(port: PORT, time_to_wait: 2)
+  def poll_until_gone(hostname: HOSTNAME, port: PORT, time_to_wait: 1)
     start_time = Time.now.to_i
     loop do
       if Time.now.to_i > start_time + time_to_wait
-        raise "Could still reach the service on port #{port} after #{time_to_wait}s"
+        raise "Could still reach the service on hostname #{hostname} port #{port} after #{time_to_wait}s"
       end
       begin
-        TCPSocket.new("127.0.0.1", port).close
+        TCPSocket.new(hostname, port).close
       rescue Errno::ECONNREFUSED, Errno::ECONNRESET
         return true
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,8 +23,8 @@ Toxiproxy.populate([
   },
   {
     name: 'semian_test_net_http',
-    upstream: 'localhost:41234',
-    listen: 'localhost:41235',
+    upstream: 'localhost:31050',
+    listen: 'localhost:31051',
   },
 ])
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,6 +21,11 @@ Toxiproxy.populate([
     upstream: 'localhost:6379',
     listen: 'localhost:16379',
   },
+  {
+    name: 'semian_test_net_http',
+    upstream: 'localhost:41234',
+    listen: 'localhost:41235',
+  },
 ])
 
 class MiniTest::Unit::TestCase


### PR DESCRIPTION
^ What the title says. 

If `semian/net_http` is included in a rails server instance, then some sort of initialization like this has to occur:
In `http.yml`:
```yaml
development:
  default:
    tickets: 1
    success_threshold: 1
    error_threshold: 3
    error_timeout: 10
...
```
In an initialization file somewhere:
```ruby

# If we want default semian options:
http_config = YAML.load_file("#{Rails.root}/path_to_file/http.yml")
Semian::NetHTTP.semian_configuration = proc do |host, port|
  semian_identifier = "nethttp_#{host}_#{port}"
  if !http_config[Rails.env].key?(semian_identifier)
    [semian_identifier, http_config[Rails.env]["nethttp_default"]]
  else
    [semian_identifier, http_config[Rails.env][semian_identifier]]
  end
end

# If we don't want default semian options, 
# i.e. adapter is disabled unless parameters are given:
Semian::NetHTTP.semian_configuration = proc do |host, port|
  semian_identifier = "nethttp_#{host}_#{port}"
  [semian_identifier, http_config[Rails.env][semian_identifier]] # nil means disabled
end

# If we want to disable completely
Semian::NetHTTP.raw_semian_options = proc do |semian_identifier|
  nil
end

# If we need extra errors, concat more onto array
# assert_equal(Semian::NetHTTP.exceptions, Semian::NetHTTP::DEFAULT_ERRORS)
Semian::NetHTTP.exceptions.concat([::Resolv::ResolvError, ::OpenURI::HTTPError, ::OpenSSL::SSL::SSLError])
```

Review? @Sirupsen @byroot 