### PR TITLE
allow rollbacks

### DIFF
--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -32,7 +32,11 @@ module Semian
     DEFAULT_HOST = 'localhost'
     DEFAULT_PORT = 3306
 
-    QUERY_WHITELIST = Regexp.union(/\A\s*ROLLBACK/i, /\A\s*RELEASE\s+SAVEPOINT/i)
+    QUERY_WHITELIST = Regexp.union(
+      /\A\s*ROLLBACK/i,
+      /\A\s*COMMIT/i,
+      /\A\s*RELEASE\s+SAVEPOINT/i,
+    )
 
     # The naked methods are exposed as `raw_query` and `raw_connect` for instrumentation purpose
     def self.included(base)

--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -70,6 +70,12 @@ module Semian
 
     def query_whitelisted?(sql, *)
       QUERY_WHITELIST =~ sql
+    rescue ArgumentError
+      # The above regexp match can fail if the input SQL string contains binary
+      # data that is not recognized as a valid encoding, in which case we just
+      # return false.
+      return false unless sql.valid_encoding?
+      raise
     end
 
     def connect(*args)

--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -32,7 +32,7 @@ module Semian
     DEFAULT_HOST = 'localhost'
     DEFAULT_PORT = 3306
 
-    QUERY_WHITELIST = [/\A\s*ROLLBACK/i, /\A\s*RELEASE\s+SAVEPOINT/i].freeze
+    QUERY_WHITELIST = Regexp.union(/\A\s*ROLLBACK/i, /\A\s*RELEASE\s+SAVEPOINT/i)
 
     # The naked methods are exposed as `raw_query` and `raw_connect` for instrumentation purpose
     def self.included(base)
@@ -65,7 +65,7 @@ module Semian
     private
 
     def query_whitelisted?(sql, *)
-      QUERY_WHITELIST.any? { |pattern| sql =~ pattern }
+      QUERY_WHITELIST =~ sql
     end
 
     def connect(*args)

--- a/test/mysql2_test.rb
+++ b/test/mysql2_test.rb
@@ -180,6 +180,15 @@ class TestMysql2 < MiniTest::Unit::TestCase
     end
   end
 
+  def test_query_whitelisted_returns_false_for_binary_sql
+    client = connect_to_mysql!
+
+    q = "INSERT IGNORE INTO `theme_template_bodies` (`cityhash`, `body`, `created_at`) VALUES ('716374049952273167', \
+'\xB1\x01\xD0{\\\"current\\\":{\\\"bg_color\\\":\\\"#ff0000\\\"},\\\"presets\\\":{\\\"sandbox>,\\0\\07\x05\x01\x01, \
+grey_bg\\\":6M\\0\\06\x05\x01\x01!\fblueJ!\\0\x01l\x04ff\x01!\bredJ \\0$ff0000\\\"}}}', '2015-11-06 19:08:03.498432')"
+    refute client.send(:query_whitelisted?, q)
+  end
+
   def test_semian_allows_rollback_to_safepoint
     client = connect_to_mysql!
 

--- a/test/mysql2_test.rb
+++ b/test/mysql2_test.rb
@@ -170,6 +170,16 @@ class TestMysql2 < MiniTest::Unit::TestCase
     end
   end
 
+  def test_semian_allows_commit
+    client = connect_to_mysql!
+
+    client.query('START TRANSACTION;')
+
+    Semian[:mysql_testing].acquire do
+      client.query('COMMIT;')
+    end
+  end
+
   def test_semian_allows_rollback_to_safepoint
     client = connect_to_mysql!
 


### PR DESCRIPTION
Semian should not prevent MySQL rollbacks, otherwise queries that are made within a transaction can't get properly rolled back by things like ActiveRecord, because the rollback query also fails, which might keep transactions open for an unnecessary amount of time, causing database contention.

@tjoyal @camilo @Sirupsen @sroysen @byroot 