### PR TITLE
Extracted CircuitBreaker states into 3 structures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /.bundle/
-/lib/semian/*.so
-/lib/semian/*.bundle
+/lib/**/*.so
+/lib/**/*.bundle
 /tmp/*
 *.gem
 /html/

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -78,7 +78,7 @@ module Semian
   OpenCircuitError = Class.new(BaseError)
 
   def semaphores_enabled?
-    !ENV['SEMIAN_SEMAPHORES_DISABLED']
+    !ENV['SEMIAN_SEMAPHORES_DISABLED'] && Semian.sysv_semaphores_supported?
   end
 
   module AdapterError
@@ -119,10 +119,12 @@ module Semian
   # Returns the registered resource.
   def register(name, tickets:, permissions: 0660, timeout: 0, error_threshold:, error_timeout:, success_threshold:, exceptions: [])
     circuit_breaker = CircuitBreaker.new(
+      name,
       success_threshold: success_threshold,
       error_threshold: error_threshold,
       error_timeout: error_timeout,
       exceptions: Array(exceptions) + [::Semian::BaseError],
+      implementation: ::Semian::Simple,
     )
     resource = Resource.new(name, tickets: tickets, permissions: permissions, timeout: timeout)
     resources[name] = ProtectedResource.new(resource, circuit_breaker)
@@ -154,7 +156,10 @@ require 'semian/circuit_breaker'
 require 'semian/protected_resource'
 require 'semian/unprotected_resource'
 require 'semian/platform'
-if Semian.sysv_semaphores_supported? && Semian.semaphores_enabled?
+require 'semian/simple_sliding_window'
+require 'semian/simple_integer'
+require 'semian/simple_state'
+if Semian.semaphores_enabled?
   require 'semian/semian'
 else
   Semian::MAX_TICKETS = 0
@@ -162,7 +167,7 @@ else
     Semian.logger.info("Semian sysv semaphores are not supported on #{RUBY_PLATFORM} - all operations will no-op")
   end
 
-  unless Semian.semaphores_enabled?
+  if ENV['SEMIAN_SEMAPHORES_DISABLED']
     Semian.logger.info("Semian semaphores are disabled, is this what you really want? - all operations will no-op")
   end
 end

--- a/lib/semian/protected_resource.rb
+++ b/lib/semian/protected_resource.rb
@@ -5,11 +5,16 @@ module Semian
     extend Forwardable
 
     def_delegators :@resource, :destroy, :count, :semid, :tickets, :name
-    def_delegators :@circuit_breaker, :reset, :mark_failed, :request_allowed?
+    def_delegators :@circuit_breaker, :reset, :mark_failed, :mark_success, :request_allowed?
 
     def initialize(resource, circuit_breaker)
       @resource = resource
       @circuit_breaker = circuit_breaker
+    end
+
+    def destroy
+      @resource.destroy
+      @circuit_breaker.destroy
     end
 
     def acquire(timeout: nil, scope: nil, adapter: nil)

--- a/lib/semian/simple_integer.rb
+++ b/lib/semian/simple_integer.rb
@@ -1,0 +1,23 @@
+module Semian
+  module Simple
+    class Integer #:nodoc:
+      attr_accessor :value
+
+      def initialize
+        reset
+      end
+
+      def increment(val = 1)
+        @value += val
+      end
+
+      def reset
+        @value = 0
+      end
+
+      def destroy
+        reset
+      end
+    end
+  end
+end

--- a/lib/semian/simple_sliding_window.rb
+++ b/lib/semian/simple_sliding_window.rb
@@ -1,0 +1,43 @@
+module Semian
+  module Simple
+    class SlidingWindow #:nodoc:
+      extend Forwardable
+
+      def_delegators :@window, :size, :pop, :shift, :first, :last
+      attr_reader :max_size
+
+      # A sliding window is a structure that stores the most @max_size recent timestamps
+      # like this: if @max_size = 4, current time is 10, @window =[5,7,9,10].
+      # Another push of (11) at 11 sec would make @window [7,9,10,11], shifting off 5.
+
+      def initialize(max_size:)
+        @max_size = max_size
+        @window = []
+      end
+
+      def resize_to(size)
+        raise ArgumentError.new('size must be larger than 0') if size < 1
+        @max_size = size
+        @window.shift while @window.size > @max_size
+        self
+      end
+
+      def push(value)
+        @window.shift while @window.size >= @max_size
+        @window << value
+        self
+      end
+
+      alias_method :<<, :push
+
+      def clear
+        @window.clear
+        self
+      end
+
+      def destroy
+        clear
+      end
+    end
+  end
+end

--- a/lib/semian/simple_state.rb
+++ b/lib/semian/simple_state.rb
@@ -1,0 +1,43 @@
+module Semian
+  module Simple
+    class State #:nodoc:
+      def initialize
+        reset
+      end
+
+      attr_reader :value
+
+      def open?
+        value == :open
+      end
+
+      def closed?
+        value == :closed
+      end
+
+      def half_open?
+        value == :half_open
+      end
+
+      def open
+        @value = :open
+      end
+
+      def close
+        @value = :closed
+      end
+
+      def half_open
+        @value = :half_open
+      end
+
+      def reset
+        close
+      end
+
+      def destroy
+        reset
+      end
+    end
+  end
+end

--- a/lib/semian/unprotected_resource.rb
+++ b/lib/semian/unprotected_resource.rb
@@ -36,5 +36,8 @@ module Semian
 
     def mark_failed(_error)
     end
+
+    def mark_success
+    end
   end
 end

--- a/test/simple_integer_test.rb
+++ b/test/simple_integer_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+class TestSimpleInteger < MiniTest::Unit::TestCase
+  CLASS = ::Semian::Simple::Integer
+
+  def setup
+    @integer = CLASS.new
+  end
+
+  def teardown
+    @integer.destroy
+  end
+
+  module IntegerTestCases
+    def test_access_value
+      assert_equal(0, @integer.value)
+      @integer.value = 99
+      assert_equal(99, @integer.value)
+      time_now = (Time.now).to_i
+      @integer.value = time_now
+      assert_equal(time_now, @integer.value)
+      @integer.value = 6
+      assert_equal(6, @integer.value)
+      @integer.value = 6
+      assert_equal(6, @integer.value)
+    end
+
+    def test_increment
+      @integer.increment(4)
+      assert_equal(4, @integer.value)
+      @integer.increment
+      assert_equal(5, @integer.value)
+      @integer.increment(-2)
+      assert_equal(3, @integer.value)
+    end
+
+    def test_reset_on_init
+      assert_equal(0, @integer.value)
+    end
+
+    def test_reset
+      @integer.increment(5)
+      @integer.reset
+      assert_equal(0, @integer.value)
+    end
+  end
+
+  include IntegerTestCases
+end

--- a/test/simple_sliding_window_test.rb
+++ b/test/simple_sliding_window_test.rb
@@ -1,0 +1,65 @@
+require 'test_helper'
+
+class TestSimpleSlidingWindow < MiniTest::Unit::TestCase
+  CLASS = ::Semian::Simple::SlidingWindow
+
+  def setup
+    @sliding_window = CLASS.new(max_size: 6)
+    @sliding_window.clear
+  end
+
+  def teardown
+    @sliding_window.destroy
+  end
+
+  module SlidingWindowTestCases
+    def test_sliding_window_push
+      assert_equal(0, @sliding_window.size)
+      @sliding_window << 1
+      assert_sliding_window(@sliding_window, [1], 6)
+      @sliding_window << 5
+      assert_sliding_window(@sliding_window, [1, 5], 6)
+    end
+
+    def test_sliding_window_resize
+      assert_equal(0, @sliding_window.size)
+      @sliding_window << 1 << 2 << 3 << 4 << 5 << 6
+      assert_sliding_window(@sliding_window, [1, 2, 3, 4, 5, 6], 6)
+      @sliding_window.resize_to 6
+      assert_sliding_window(@sliding_window, [1, 2, 3, 4, 5, 6], 6)
+      @sliding_window.resize_to 5
+      assert_sliding_window(@sliding_window, [2, 3, 4, 5, 6], 5)
+      @sliding_window.resize_to 6
+      assert_sliding_window(@sliding_window, [2, 3, 4, 5, 6], 6)
+    end
+
+    def test_sliding_window_edge_falloff
+      assert_equal(0, @sliding_window.size)
+      @sliding_window << 0 << 1 << 2 << 3 << 4 << 5 << 6 << 7
+      assert_sliding_window(@sliding_window, [2, 3, 4, 5, 6, 7], 6)
+      @sliding_window.shift
+      assert_sliding_window(@sliding_window, [3, 4, 5, 6, 7], 6)
+    end
+
+    def resize_to_less_than_1_raises
+      assert_raises ArgumentError do
+        @sliding_window.resize_to 0
+      end
+    end
+  end
+
+  module SlidingWindowUtilityMethods
+    def assert_sliding_window(sliding_window, array, max_size)
+      # Get private member, the sliding_window doesn't expose the entire array
+      data = sliding_window.instance_variable_get("@window")
+      assert_equal(array, data)
+      assert_equal(max_size, sliding_window.max_size)
+    end
+  end
+
+  include SlidingWindowTestCases
+
+  private
+
+  include SlidingWindowUtilityMethods
+end

--- a/test/simple_state_test.rb
+++ b/test/simple_state_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class TestSimpleEnum < MiniTest::Unit::TestCase
+  CLASS = ::Semian::Simple::State
+
+  def setup
+    @state = CLASS.new
+  end
+
+  def teardown
+    @state.destroy
+  end
+
+  module StateTestCases
+    def test_start_closed?
+      assert @state.closed?
+    end
+
+    def test_open
+      @state.open
+      assert @state.open?
+      assert_equal @state.value, :open
+    end
+
+    def test_close
+      @state.close
+      assert @state.closed?
+      assert_equal @state.value, :closed
+    end
+
+    def test_half_open
+      @state.half_open
+      assert @state.half_open?
+      assert_equal @state.value, :half_open
+    end
+
+    def test_reset
+      @state.reset
+      assert @state.closed?
+      assert_equal @state.value, :closed
+    end
+  end
+
+  include StateTestCases
+end


### PR DESCRIPTION
Older closed PR is this: https://github.com/Shopify/semian/pull/56
Even older massive PR that we're trying to split is this (probably a bit outdated by this point): https://github.com/Shopify/semian/pull/54

Three structures are for holding the `@success`, `@state`, and `@sliding_window` of the `CircuitBreaker` class. 

They are now under `Semian::Simple`, and future SysV implementation will be under `Semian::SysV`. 

Issue that came up and may/may not have been addressed: 

* For methods in the classes that explicitly return `self` as the last line, its so things like `#<<` don't expose the inner array and leak the implementation, and instead return the appropriate wrapper class. Cascading still works: `wrapper_class_instance << 1 << 2`
* The `Atomic` prefix was removed since it is misleading, and we probably won't be providing a `Mutex` or `Monitor`
* it was suggested to rename the enum type from `Semian::Simple::Enum` to `Semian::Simple::State` and be specialized for the three possible items: `:open`, `:closed`, `:half_open`. Similarly, also rename from `Integer` to `SuccessCount`. **I haven't changed it to those names yet**, since it requires removing some code and makes some of the code a bit weird.
 * Pro: specialized, more simple 
 * Con: naming would definitely be weird, even if the in-memory version from `Simple` stores the values directly, the `SysV` enum type delegates the shared-ness to the `SysV` integer type, and would need to keep a `SysV::SuccessCount` type in the `SysV::State` if we use those names. 
* A bit looking into the future, but with the `SysV` versions of the structure needing permissions and a name, `Semian::Simple::SlidingWindow.new(max_size: 4)` and `Semian::SysV::SlidingWindow.new(max_size: 4, permissions: 0660, name: "sample_int")` have different interfaces. Ways to solve
 * do `def initialize(max_size: , **_)`
 * do `def initialize(options = {})` or something of the sort
 * not pass in `permissions` and `name` at all, but they have to come from somewhere else without leaking the implementation, possible from `Semian.register`
* The enum class has an `#increment` because it was suggested that it could be used to iterate through the enums. May/may not be needed.
* Slightly extraneous: it was previously mentioned that test suite naming is a bit off, for example `TestCircuitBreaker` is `circuit_breaker_test.rb`
