### PR TITLE
Encaspsulate Simple::Enum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /.bundle/
-/lib/semian/*.so
-/lib/semian/*.bundle
+/lib/**/*.so
+/lib/**/*.bundle
 /tmp/*
 *.gem
 /html/

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -124,7 +124,7 @@ module Semian
       error_threshold: error_threshold,
       error_timeout: error_timeout,
       exceptions: Array(exceptions) + [::Semian::BaseError],
-      type_namespace: ::Semian::Simple,
+      implementation: ::Semian::Simple,
     )
     resource = Resource.new(name, tickets: tickets, permissions: permissions, timeout: timeout)
     resources[name] = ProtectedResource.new(resource, circuit_breaker)

--- a/lib/semian/circuit_breaker.rb
+++ b/lib/semian/circuit_breaker.rb
@@ -1,13 +1,15 @@
 module Semian
-  class CircuitBreaker
-    attr_reader :state
-
-    def initialize(exceptions:, success_threshold:, error_threshold:, error_timeout:)
+  class CircuitBreaker #:nodoc:
+    def initialize(name, exceptions:, success_threshold:, error_threshold:, error_timeout:, type_namespace:)
+      @name = name.to_s
       @success_count_threshold = success_threshold
       @error_count_threshold = error_threshold
       @error_timeout = error_timeout
       @exceptions = exceptions
-      reset
+
+      @errors = type_namespace::SlidingWindow.new(max_size: @error_count_threshold)
+      @successes = type_namespace::Integer.new
+      @state = type_namespace::Enum.new(symbol_list: [:closed, :half_open, :open])
     end
 
     def acquire
@@ -32,8 +34,7 @@ module Semian
     end
 
     def mark_failed(_error)
-      push_time(@errors, @error_count_threshold, duration: @error_timeout)
-
+      push_time(@errors, duration: @error_timeout)
       if closed?
         open if error_threshold_reached?
       elsif half_open?
@@ -43,70 +44,77 @@ module Semian
 
     def mark_success
       return unless half_open?
-      @successes += 1
+      @successes.increment
       close if success_threshold_reached?
     end
 
     def reset
-      @errors = []
-      @successes = 0
+      @errors.clear
+      @successes.value = 0
       close
+    end
+
+    def destroy
+      @errors.destroy
+      @successes.destroy
+      @state.destroy
     end
 
     private
 
     def closed?
-      state == :closed
+      @state.value == :closed
     end
 
     def close
       log_state_transition(:closed)
-      @state = :closed
-      @errors = []
+      @state.value = :closed
+      @errors.clear
     end
 
     def open?
-      state == :open
+      @state.value == :open
     end
 
     def open
       log_state_transition(:open)
-      @state = :open
+      @state.value = :open
     end
 
     def half_open?
-      state == :half_open
+      @state.value == :half_open
     end
 
     def half_open
       log_state_transition(:half_open)
-      @state = :half_open
-      @successes = 0
+      @state.value = :half_open
+      @successes.value = 0
     end
 
     def success_threshold_reached?
-      @successes >= @success_count_threshold
+      @successes.value >= @success_count_threshold
     end
 
     def error_threshold_reached?
-      @errors.count == @error_count_threshold
+      @errors.size == @error_count_threshold
     end
 
     def error_timeout_expired?
-      @errors.last && (@errors.last + @error_timeout < Time.now)
+      time_ms = @errors.last
+      time_ms && (Time.at(time_ms / 1000) + @error_timeout < Time.now)
     end
 
-    def push_time(window, max_size, duration:, time: Time.now)
-      window.shift while window.first && window.first + duration < time
-      window.shift if window.size == max_size
-      window << time
+    def push_time(window, duration:, time: Time.now)
+      # The sliding window stores the integer amount of milliseconds since epoch as a timestamp
+      window.shift while window.first && Time.at(window.first / 1000) + duration < time
+      window << (time.to_f * 1000).to_i
     end
 
     def log_state_transition(new_state)
-      return if @state.nil? || new_state == @state
+      return if @state.nil? || new_state == @state.value
 
-      str = "[#{self.class.name}] State transition from #{@state} to #{new_state}."
-      str << " success_count=#{@successes} error_count=#{@errors.count}"
+      str = "[#{self.class.name}] State transition from #{@state.value} to #{new_state}."
+      str << " success_count=#{@successes.value} error_count=#{@errors.size}"
       str << " success_count_threshold=#{@success_count_threshold} error_count_threshold=#{@error_count_threshold}"
       str << " error_timeout=#{@error_timeout} error_last_at=\"#{@error_last_at}\""
       Semian.logger.info(str)

--- a/lib/semian/protected_resource.rb
+++ b/lib/semian/protected_resource.rb
@@ -5,11 +5,16 @@ module Semian
     extend Forwardable
 
     def_delegators :@resource, :destroy, :count, :semid, :tickets, :name
-    def_delegators :@circuit_breaker, :reset, :mark_failed, :request_allowed?
+    def_delegators :@circuit_breaker, :reset, :mark_failed, :mark_success, :request_allowed?
 
     def initialize(resource, circuit_breaker)
       @resource = resource
       @circuit_breaker = circuit_breaker
+    end
+
+    def destroy
+      @resource.destroy
+      @circuit_breaker.destroy
     end
 
     def acquire(timeout: nil, scope: nil, adapter: nil)

--- a/lib/semian/simple_enum.rb
+++ b/lib/semian/simple_enum.rb
@@ -1,0 +1,40 @@
+require 'forwardable'
+
+module Semian
+  module Simple
+    class Enum #:nodoc:
+      extend Forwardable
+
+      def_delegators :@integer, :destroy
+
+      def initialize(symbol_list:)
+        @integer = ::Semian::Simple::Integer.new
+        initialize_lookup(symbol_list)
+      end
+
+      def increment(val = 1)
+        @integer.value = (@integer.value + val) % @sym_to_num.size
+        value
+      end
+
+      def value
+        @num_to_sym.fetch(@integer.value)
+      end
+
+      def value=(sym)
+        @integer.value = @sym_to_num.fetch(sym)
+      end
+
+      private
+
+      def initialize_lookup(symbol_list)
+        # Assume symbol_list[0] is mapped to 0
+        # Cannot just use #object_id since #object_id for symbols is different in every run
+        # For now, implement a C-style enum type backed by integers
+
+        @sym_to_num = Hash[symbol_list.each_with_index.to_a]
+        @num_to_sym = @sym_to_num.invert
+      end
+    end
+  end
+end

--- a/lib/semian/simple_enum.rb
+++ b/lib/semian/simple_enum.rb
@@ -1,28 +1,42 @@
 module Semian
   module Simple
     class Enum #:nodoc:
-      def initialize(symbol_list:)
-        @allowed_symbols = symbol_list
+      attr_reader :value
+
+      def initialize
         reset
       end
 
-      attr_reader :value
-
-      def value=(sym)
-        raise ArgumentError unless @allowed_symbols.include?(sym)
-        @value = sym
+      def closed?
+        value == :closed
       end
 
-      def increment(val = 1)
-        @value = @allowed_symbols[(@allowed_symbols.index(@value) + val) % @allowed_symbols.size]
+      def open?
+        value == :open
+      end
+
+      def half_open?
+        value == :half_open
+      end
+
+      def close
+        @value = :closed
+      end
+
+      def open
+        @value = :open
+      end
+
+      def half_open
+        @value = :half_open
       end
 
       def reset
-        @value = @allowed_symbols.first
+        close
       end
 
       def destroy
-        reset
+        close
       end
     end
   end

--- a/lib/semian/simple_enum.rb
+++ b/lib/semian/simple_enum.rb
@@ -1,39 +1,28 @@
-require 'forwardable'
-
 module Semian
   module Simple
     class Enum #:nodoc:
-      extend Forwardable
-
-      def_delegators :@integer, :destroy
-
       def initialize(symbol_list:)
-        @integer = ::Semian::Simple::Integer.new
-        initialize_lookup(symbol_list)
+        @allowed_symbols = symbol_list
+        reset
+      end
+
+      attr_reader :value
+
+      def value=(sym)
+        raise ArgumentError unless @allowed_symbols.include?(sym)
+        @value = sym
       end
 
       def increment(val = 1)
-        @integer.value = (@integer.value + val) % @sym_to_num.size
-        value
+        @value = @allowed_symbols[(@allowed_symbols.index(@value) + val) % @allowed_symbols.size]
       end
 
-      def value
-        @num_to_sym.fetch(@integer.value)
+      def reset
+        @value = @allowed_symbols.first
       end
 
-      def value=(sym)
-        @integer.value = @sym_to_num.fetch(sym)
-      end
-
-      private
-
-      def initialize_lookup(symbol_list)
-        # Assume symbol_list[0] is mapped to 0
-        # Cannot just use #object_id since #object_id for symbols is different in every run
-        # For now, implement a C-style enum type backed by integers
-
-        @sym_to_num = Hash[symbol_list.each_with_index.to_a]
-        @num_to_sym = @sym_to_num.invert
+      def destroy
+        reset
       end
     end
   end

--- a/lib/semian/simple_integer.rb
+++ b/lib/semian/simple_integer.rb
@@ -4,15 +4,19 @@ module Semian
       attr_accessor :value
 
       def initialize
-        @value = 0
+        reset
       end
 
       def increment(val = 1)
         @value += val
       end
 
-      def destroy
+      def reset
         @value = 0
+      end
+
+      def destroy
+        reset
       end
     end
   end

--- a/lib/semian/simple_integer.rb
+++ b/lib/semian/simple_integer.rb
@@ -1,0 +1,19 @@
+module Semian
+  module Simple
+    class Integer #:nodoc:
+      attr_accessor :value
+
+      def initialize
+        @value = 0
+      end
+
+      def increment(val = 1)
+        @value += val
+      end
+
+      def destroy
+        @value = 0
+      end
+    end
+  end
+end

--- a/lib/semian/simple_sliding_window.rb
+++ b/lib/semian/simple_sliding_window.rb
@@ -1,0 +1,45 @@
+module Semian
+  module Simple
+    class SlidingWindow #:nodoc:
+      extend Forwardable
+
+      def_delegators :@window, :size, :pop, :shift, :first, :last
+      attr_reader :max_size
+
+      def initialize(max_size:)
+        @max_size = max_size
+        @window = []
+      end
+
+      # A sliding window is a structure that stores the most @max_size recent timestamps
+      # like this: if @max_size = 4, current time is 10, @window =[5,7,9,10].
+      # Another push of (11) at 11 sec would make @window [7,9,10,11], shifting off 5.
+
+      def resize_to(size)
+        raise ArgumentError.new('size must be larger than 0') if size < 1
+        @max_size = size
+        @window.shift while @window.size > @max_size
+        self
+      end
+
+      def <<(time_ms)
+        push(time_ms)
+      end
+
+      def push(time_ms)
+        @window.shift while @window.size >= @max_size
+        @window << time_ms
+        self
+      end
+
+      def clear
+        @window.clear
+        self
+      end
+
+      def destroy
+        clear
+      end
+    end
+  end
+end

--- a/lib/semian/unprotected_resource.rb
+++ b/lib/semian/unprotected_resource.rb
@@ -36,5 +36,8 @@ module Semian
 
     def mark_failed(_error)
     end
+
+    def mark_success
+    end
   end
 end

--- a/test/simple_enum_test.rb
+++ b/test/simple_enum_test.rb
@@ -37,7 +37,7 @@ class TestSimpleEnum < MiniTest::Unit::TestCase
     end
 
     def test_will_throw_error_when_invalid_symbol_given
-      assert_raises KeyError do
+      assert_raises ArgumentError do
         @enum.value = :four
       end
     end

--- a/test/simple_enum_test.rb
+++ b/test/simple_enum_test.rb
@@ -4,7 +4,7 @@ class TestSimpleEnum < MiniTest::Unit::TestCase
   CLASS = ::Semian::Simple::Enum
 
   def setup
-    @enum = CLASS.new(symbol_list: [:one, :two, :three])
+    @enum = CLASS.new
   end
 
   def teardown
@@ -12,34 +12,25 @@ class TestSimpleEnum < MiniTest::Unit::TestCase
   end
 
   module EnumTestCases
-    def test_assigning
-      old = @enum.value
-      @enum.value = @enum.value
-      assert_equal old, @enum.value
-      @enum.value = :two
-      assert_equal :two, @enum.value
+
+    def test_start_closed
+      assert @enum.closed?
     end
 
-    def test_iterate_enum
-      @enum.value = :one
-      @enum.increment
-      assert_equal :two, @enum.value
-      @enum.increment
-      assert_equal :three, @enum.value
-      @enum.increment
-      assert_equal :one, @enum.value
-      @enum.increment(2)
-      assert_equal :three, @enum.value
-      @enum.increment(4)
-      assert_equal :one, @enum.value
-      @enum.increment(0)
-      assert_equal :one, @enum.value
+    def test_open
+      @enum.open
+      assert @enum.open?
     end
 
-    def test_will_throw_error_when_invalid_symbol_given
-      assert_raises ArgumentError do
-        @enum.value = :four
-      end
+    def test_half_open
+      @enum.half_open
+      assert @enum.half_open?
+    end
+
+    def test_close
+      @enum.half_open
+      @enum.close
+      assert @enum.closed?
     end
   end
 

--- a/test/simple_enum_test.rb
+++ b/test/simple_enum_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+
+class TestSimpleEnum < MiniTest::Unit::TestCase
+  CLASS = ::Semian::Simple::Enum
+
+  def setup
+    @enum = CLASS.new(symbol_list: [:one, :two, :three])
+  end
+
+  def teardown
+    @enum.destroy
+  end
+
+  module EnumTestCases
+    def test_assigning
+      old = @enum.value
+      @enum.value = @enum.value
+      assert_equal old, @enum.value
+      @enum.value = :two
+      assert_equal :two, @enum.value
+    end
+
+    def test_iterate_enum
+      @enum.value = :one
+      @enum.increment
+      assert_equal :two, @enum.value
+      @enum.increment
+      assert_equal :three, @enum.value
+      @enum.increment
+      assert_equal :one, @enum.value
+      @enum.increment(2)
+      assert_equal :three, @enum.value
+      @enum.increment(4)
+      assert_equal :one, @enum.value
+      @enum.increment(0)
+      assert_equal :one, @enum.value
+    end
+
+    def test_will_throw_error_when_invalid_symbol_given
+      assert_raises KeyError do
+        @enum.value = :four
+      end
+    end
+  end
+
+  include EnumTestCases
+end

--- a/test/simple_integer_test.rb
+++ b/test/simple_integer_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class TestSimpleInteger < MiniTest::Unit::TestCase
+  CLASS = ::Semian::Simple::Integer
+
+  def setup
+    @integer = CLASS.new
+    @integer.value = 0
+  end
+
+  def teardown
+    @integer.destroy
+  end
+
+  module IntegerTestCases
+    def test_access_value
+      @integer.value = 0
+      assert_equal(0, @integer.value)
+      @integer.value = 99
+      assert_equal(99, @integer.value)
+      time_now = (Time.now).to_i
+      @integer.value = time_now
+      assert_equal(time_now, @integer.value)
+      @integer.value = 6
+      assert_equal(6, @integer.value)
+      @integer.value = 6
+      assert_equal(6, @integer.value)
+    end
+
+    def test_increment
+      @integer.value = 0
+      @integer.increment(4)
+      assert_equal(4, @integer.value)
+      @integer.increment
+      assert_equal(5, @integer.value)
+      @integer.increment(-2)
+      assert_equal(3, @integer.value)
+    end
+  end
+
+  include IntegerTestCases
+end

--- a/test/simple_integer_test.rb
+++ b/test/simple_integer_test.rb
@@ -36,6 +36,12 @@ class TestSimpleInteger < MiniTest::Unit::TestCase
       @integer.increment(-2)
       assert_equal(3, @integer.value)
     end
+
+    def test_reset
+      @integer.increment(5)
+      @integer.reset
+      assert_equal(0, @integer.value)
+    end
   end
 
   include IntegerTestCases

--- a/test/simple_sliding_window_test.rb
+++ b/test/simple_sliding_window_test.rb
@@ -1,0 +1,67 @@
+require 'test_helper'
+
+class TestSimpleSlidingWindow < MiniTest::Unit::TestCase
+  CLASS = ::Semian::Simple::SlidingWindow
+
+  def setup
+    @sliding_window = CLASS.new(max_size: 6)
+    @sliding_window.clear
+  end
+
+  def teardown
+    @sliding_window.destroy
+  end
+
+  module SlidingWindowTestCases
+    def test_sliding_window_push
+      assert_equal(0, @sliding_window.size)
+      @sliding_window << 1
+      assert_correct_first_and_last_and_size(@sliding_window, 1, 1, 1, 6)
+      @sliding_window << 5
+      assert_correct_first_and_last_and_size(@sliding_window, 1, 5, 2, 6)
+    end
+
+    def test_sliding_window_resize
+      assert_equal(0, @sliding_window.size)
+      @sliding_window << 1 << 2 << 3 << 4 << 5 << 6
+      assert_correct_first_and_last_and_size(@sliding_window, 1, 6, 6, 6)
+      @sliding_window.resize_to 6
+      assert_correct_first_and_last_and_size(@sliding_window, 1, 6, 6, 6)
+      @sliding_window.resize_to 5
+      assert_correct_first_and_last_and_size(@sliding_window, 2, 6, 5, 5)
+      @sliding_window.resize_to 6
+      assert_correct_first_and_last_and_size(@sliding_window, 2, 6, 5, 6)
+    end
+
+    def test_sliding_window_edge_falloff
+      assert_equal(0, @sliding_window.size)
+      @sliding_window << 0 << 1 << 2 << 3 << 4 << 5 << 6 << 7
+      assert_correct_first_and_last_and_size(@sliding_window, 2, 7, 6, 6)
+      @sliding_window.shift
+      assert_correct_first_and_last_and_size(@sliding_window, 3, 7, 5, 6)
+    end
+  end
+
+  module SlidingWindowUtilityMethods
+    def assert_correct_first_and_last_and_size(sliding_window, first, last, size, max_size)
+      assert_equal(first, sliding_window.first)
+      assert_equal(last, sliding_window.last)
+      assert_equal(size, sliding_window.size)
+      assert_equal(max_size, sliding_window.max_size)
+    end
+
+    def assert_sliding_windows_in_sync(sliding_window_1, sliding_window_2)
+      # it only exposes ends, size, and max_size, so can only check those
+      assert_equal(sliding_window_1.first, sliding_window_2.first)
+      assert_equal(sliding_window_1.last, sliding_window_2.last)
+      assert_equal(sliding_window_1.size, sliding_window_2.size)
+      assert_equal(sliding_window_1.max_size, sliding_window_2.max_size)
+    end
+  end
+
+  include SlidingWindowTestCases
+
+  private
+
+  include SlidingWindowUtilityMethods
+end


### PR DESCRIPTION
Here's what I'm trying to express since the beginning. This class should properly encapsulate it's state, and only expose meaningful state transitions.

Your version is way more complicated, just because you can't stop thinking about SysV. 

PS: I don't think Enum is a proper name. `State` or `StateMachine` is probably better. But this is just a sketch anyway.

@kyewei /cc @fw42 @Sirupsen 