### PR TITLE
Proposed SysV structures and Mixin functionality

### DIFF
--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -125,7 +125,7 @@ module Semian
       error_timeout: error_timeout,
       exceptions: Array(exceptions) + [::Semian::BaseError],
       permissions: permissions,
-      implementation: ::Semian::SysV,
+      implementation: Semian.semaphores_enabled? ? ::Semian::SysV : ::Semian::Simple,
     )
     resource = Resource.new(name, tickets: tickets, permissions: permissions, timeout: timeout)
     resources[name] = ProtectedResource.new(resource, circuit_breaker)
@@ -160,11 +160,11 @@ require 'semian/platform'
 require 'semian/simple_sliding_window'
 require 'semian/simple_integer'
 require 'semian/simple_state'
-require 'semian/sysv_shared_memory'
-require 'semian/sysv_sliding_window'
-require 'semian/sysv_integer'
-require 'semian/sysv_state'
 if Semian.semaphores_enabled?
+  require 'semian/sysv_shared_memory'
+  require 'semian/sysv_sliding_window'
+  require 'semian/sysv_integer'
+  require 'semian/sysv_state'
   require 'semian/semian'
 else
   Semian::MAX_TICKETS = 0

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -124,7 +124,8 @@ module Semian
       error_threshold: error_threshold,
       error_timeout: error_timeout,
       exceptions: Array(exceptions) + [::Semian::BaseError],
-      implementation: ::Semian::Simple,
+      permissions: permissions,
+      implementation: ::Semian::SysV,
     )
     resource = Resource.new(name, tickets: tickets, permissions: permissions, timeout: timeout)
     resources[name] = ProtectedResource.new(resource, circuit_breaker)
@@ -159,6 +160,10 @@ require 'semian/platform'
 require 'semian/simple_sliding_window'
 require 'semian/simple_integer'
 require 'semian/simple_state'
+require 'semian/sysv_shared_memory'
+require 'semian/sysv_sliding_window'
+require 'semian/sysv_integer'
+require 'semian/sysv_state'
 if Semian.semaphores_enabled?
   require 'semian/semian'
 else

--- a/lib/semian/circuit_breaker.rb
+++ b/lib/semian/circuit_breaker.rb
@@ -2,16 +2,20 @@ module Semian
   class CircuitBreaker #:nodoc:
     extend Forwardable
 
-    def initialize(name, exceptions:, success_threshold:, error_threshold:, error_timeout:, implementation:)
+    def initialize(name, exceptions:, success_threshold:, error_threshold:, error_timeout:, permissions:, implementation:)
       @name = name.to_sym
       @success_count_threshold = success_threshold
       @error_count_threshold = error_threshold
       @error_timeout = error_timeout
       @exceptions = exceptions
 
-      @errors = implementation::SlidingWindow.new(max_size: @error_count_threshold)
-      @successes = implementation::Integer.new
-      @state = implementation::State.new
+      @errors = implementation::SlidingWindow.new(max_size: @error_count_threshold,
+                                                  name: "#{name}_sysv_sliding_window",
+                                                  permissions: permissions)
+      @successes = implementation::Integer.new(name: "#{name}_sysv_integer",
+                                               permissions: permissions)
+      @state = implementation::State.new(name: "#{name}_sysv_state",
+                                         permissions: permissions)
     end
 
     def acquire

--- a/lib/semian/circuit_breaker.rb
+++ b/lib/semian/circuit_breaker.rb
@@ -10,11 +10,11 @@ module Semian
       @exceptions = exceptions
 
       @errors = implementation::SlidingWindow.new(max_size: @error_count_threshold,
-                                                  name: "#{name}_sysv_sliding_window",
+                                                  name: "#{name}_sliding_window",
                                                   permissions: permissions)
-      @successes = implementation::Integer.new(name: "#{name}_sysv_integer",
+      @successes = implementation::Integer.new(name: "#{name}_integer",
                                                permissions: permissions)
-      @state = implementation::State.new(name: "#{name}_sysv_state",
+      @state = implementation::State.new(name: "#{name}_state",
                                          permissions: permissions)
     end
 

--- a/lib/semian/simple_integer.rb
+++ b/lib/semian/simple_integer.rb
@@ -3,7 +3,7 @@ module Semian
     class Integer #:nodoc:
       attr_accessor :value
 
-      def initialize(**_)
+      def initialize(**)
         reset
       end
 

--- a/lib/semian/simple_integer.rb
+++ b/lib/semian/simple_integer.rb
@@ -3,7 +3,7 @@ module Semian
     class Integer #:nodoc:
       attr_accessor :value
 
-      def initialize
+      def initialize(**_)
         reset
       end
 

--- a/lib/semian/simple_sliding_window.rb
+++ b/lib/semian/simple_sliding_window.rb
@@ -12,7 +12,7 @@ module Semian
       # like this: if @max_size = 4, current time is 10, @window =[5,7,9,10].
       # Another push of (11) at 11 sec would make @window [7,9,10,11], shifting off 5.
 
-      def initialize(max_size:, **_)
+      def initialize(max_size:, **)
         @max_size = max_size
         @window = []
       end

--- a/lib/semian/simple_sliding_window.rb
+++ b/lib/semian/simple_sliding_window.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 module Semian
   module Simple
     class SlidingWindow #:nodoc:
@@ -10,7 +12,7 @@ module Semian
       # like this: if @max_size = 4, current time is 10, @window =[5,7,9,10].
       # Another push of (11) at 11 sec would make @window [7,9,10,11], shifting off 5.
 
-      def initialize(max_size:)
+      def initialize(max_size:, **_)
         @max_size = max_size
         @window = []
       end

--- a/lib/semian/simple_state.rb
+++ b/lib/semian/simple_state.rb
@@ -1,7 +1,7 @@
 module Semian
   module Simple
     class State #:nodoc:
-      def initialize(**_)
+      def initialize(**)
         reset
       end
 

--- a/lib/semian/simple_state.rb
+++ b/lib/semian/simple_state.rb
@@ -5,7 +5,8 @@ module Semian
         reset
       end
 
-      attr_reader :value
+      attr_accessor :value
+      private :value=
 
       def open?
         value == :open
@@ -20,15 +21,15 @@ module Semian
       end
 
       def open
-        @value = :open
+        self.value = :open
       end
 
       def close
-        @value = :closed
+        self.value = :closed
       end
 
       def half_open
-        @value = :half_open
+        self.value = :half_open
       end
 
       def reset

--- a/lib/semian/simple_state.rb
+++ b/lib/semian/simple_state.rb
@@ -1,7 +1,7 @@
 module Semian
   module Simple
     class State #:nodoc:
-      def initialize
+      def initialize(**_)
         reset
       end
 

--- a/lib/semian/sysv_integer.rb
+++ b/lib/semian/sysv_integer.rb
@@ -1,0 +1,12 @@
+module Semian
+  module SysV
+    class Integer < Semian::Simple::Integer #:nodoc:
+      include SysVSharedMemory
+
+      def initialize(name:, permissions:)
+        data_layout = [:int]
+        super() unless acquire_memory_object(name, data_layout, permissions)
+      end
+    end
+  end
+end

--- a/lib/semian/sysv_shared_memory.rb
+++ b/lib/semian/sysv_shared_memory.rb
@@ -1,0 +1,60 @@
+module Semian
+  module SysVSharedMemory #:nodoc:
+    @type_size = {}
+    def self.sizeof(type)
+      size = (@type_size[type.to_sym] ||= (respond_to?(:_sizeof) ? _sizeof(type.to_sym) : 0))
+      raise TypeError.new("#{type} is not a valid C type") if size <= 0
+      size
+    end
+
+    def semid
+      -1
+    end
+
+    def shmid
+      -1
+    end
+
+    def synchronize(&proc)
+      if respond_to?(:_synchronize) && @using_shared_memory
+        return _synchronize(&proc)
+      else
+        yield if block_given?
+      end
+    end
+
+    alias_method :transaction, :synchronize
+
+    def destroy
+      if respond_to?(:_destroy) && @using_shared_memory
+        _destroy
+      else
+        super
+      end
+    end
+
+    private
+
+    def shared?
+      @using_shared_memory
+    end
+
+    def acquire_memory_object(name, data_layout, permissions)
+      return @using_shared_memory = false unless Semian.semaphores_enabled? && respond_to?(:_acquire)
+
+      byte_size = data_layout.inject(0) { |sum, type| sum + ::Semian::SysVSharedMemory.sizeof(type) }
+      raise TypeError.new("Given data layout is 0 bytes: #{data_layout.inspect}") if byte_size <= 0
+      # Calls C layer to acquire/create a memory block, calling #bind_init_fn in the process, see below
+      _acquire(name, byte_size, permissions)
+      @using_shared_memory = true
+    end
+
+    def bind_init_fn
+      # Concrete classes must implement this in a subclass in C to bind a callback function of type
+      # void (*object_init_fn)(size_t byte_size, void *dest, void *prev_data, size_t prev_data_byte_size);
+      # to location ptr->object_init_fn, where ptr is a semian_shm_object*
+      # It is called when memory needs to be initialized or resized, possibly using previous memory
+      raise NotImplementedError
+    end
+  end
+end

--- a/lib/semian/sysv_shared_memory.rb
+++ b/lib/semian/sysv_shared_memory.rb
@@ -59,15 +59,15 @@ module Semian
 
       byte_size = data_layout.inject(0) { |sum, type| sum + ::Semian::SysVSharedMemory.sizeof(type) }
       raise TypeError.new("Given data layout is 0 bytes: #{data_layout.inspect}") if byte_size <= 0
-      # Calls C layer to acquire/create a memory block, calling #bind_init_fn in the process, see below
+      # Calls C layer to acquire/create a memory block, calling #bind_initialize_memory_callback in the process, see below
       _acquire(name, byte_size, permissions)
       @using_shared_memory = true
     end
 
-    def bind_init_fn
+    def bind_initialize_memory_callback
       # Concrete classes must implement this in a subclass in C to bind a callback function of type
-      # void (*object_init_fn)(size_t byte_size, void *dest, void *prev_data, size_t prev_data_byte_size);
-      # to location ptr->object_init_fn, where ptr is a semian_shm_object*
+      # void (*initialize_memory)(size_t byte_size, void *dest, void *prev_data, size_t prev_data_byte_size);
+      # to location ptr->initialize_memory, where ptr is a semian_shm_object*
       # It is called when memory needs to be initialized or resized, possibly using previous memory
       raise NotImplementedError
     end

--- a/lib/semian/sysv_sliding_window.rb
+++ b/lib/semian/sysv_sliding_window.rb
@@ -4,7 +4,7 @@ module Semian
       include SysVSharedMemory
 
       def initialize(max_size:, name:, permissions:)
-        data_layout = [:int, :int].concat(Array.new(max_size, :long))
+        data_layout = [:int, :int] + [:long] * max_size
         super(max_size: max_size) unless acquire_memory_object(name, data_layout, permissions)
       end
     end

--- a/lib/semian/sysv_sliding_window.rb
+++ b/lib/semian/sysv_sliding_window.rb
@@ -1,0 +1,12 @@
+module Semian
+  module SysV
+    class SlidingWindow < Semian::Simple::SlidingWindow #:nodoc:
+      include SysVSharedMemory
+
+      def initialize(max_size:, name:, permissions:)
+        data_layout = [:int, :int].concat(Array.new(max_size, :long))
+        super(max_size: max_size) unless acquire_memory_object(name, data_layout, permissions)
+      end
+    end
+  end
+end

--- a/lib/semian/sysv_state.rb
+++ b/lib/semian/sysv_state.rb
@@ -7,12 +7,12 @@ module Semian
       extend Forwardable
 
       def_delegators :@integer, :semid, :shmid, :synchronize, :transaction,
-                     :shared?, :acquire_memory_object, :bind_init_fn
-      private :shared?, :acquire_memory_object, :bind_init_fn
+                     :shared?, :acquire_memory_object, :bind_initialize_memory_callback
+      private :shared?, :acquire_memory_object, :bind_initialize_memory_callback
 
       def initialize(name:, permissions:)
         @integer = Semian::SysV::Integer.new(name: name, permissions: permissions)
-        initialize_lookup([:closed, :open, :half_open])
+        initialize_lookup
       end
 
       def open
@@ -46,12 +46,12 @@ module Semian
         @integer.value = @sym_to_num.fetch(sym) { raise ArgumentError }
       end
 
-      def initialize_lookup(symbol_list)
+      def initialize_lookup
         # Assume symbol_list[0] is mapped to 0
         # Cannot just use #object_id since #object_id for symbols is different in every run
         # For now, implement a C-style enum type backed by integers
 
-        @sym_to_num = Hash[symbol_list.each_with_index.to_a]
+        @sym_to_num = {closed: 0, open: 1, half_open: 2}
         @num_to_sym = @sym_to_num.invert
       end
     end

--- a/lib/semian/sysv_state.rb
+++ b/lib/semian/sysv_state.rb
@@ -1,0 +1,59 @@
+require 'forwardable'
+
+module Semian
+  module SysV
+    class State < Semian::Simple::State #:nodoc:
+      include SysVSharedMemory
+      extend Forwardable
+
+      def_delegators :@integer, :semid, :shmid, :synchronize, :transaction,
+                     :shared?, :acquire_memory_object, :bind_init_fn
+      private :shared?, :acquire_memory_object, :bind_init_fn
+
+      def initialize(name:, permissions:)
+        @integer = Semian::SysV::Integer.new(name: name, permissions: permissions)
+        initialize_lookup([:closed, :open, :half_open])
+      end
+
+      def open
+        self.value = :open
+      end
+
+      def close
+        self.value = :closed
+      end
+
+      def half_open
+        self.value = :half_open
+      end
+
+      def reset
+        close
+      end
+
+      def destroy
+        reset
+        @integer.destroy
+      end
+
+      def value
+        @num_to_sym.fetch(@integer.value) { raise ArgumentError }
+      end
+
+      private
+
+      def value=(sym)
+        @integer.value = @sym_to_num.fetch(sym) { raise ArgumentError }
+      end
+
+      def initialize_lookup(symbol_list)
+        # Assume symbol_list[0] is mapped to 0
+        # Cannot just use #object_id since #object_id for symbols is different in every run
+        # For now, implement a C-style enum type backed by integers
+
+        @sym_to_num = Hash[symbol_list.each_with_index.to_a]
+        @num_to_sym = @sym_to_num.invert
+      end
+    end
+  end
+end

--- a/lib/semian/sysv_state.rb
+++ b/lib/semian/sysv_state.rb
@@ -15,24 +15,8 @@ module Semian
         initialize_lookup
       end
 
-      def open
-        self.value = :open
-      end
-
-      def close
-        self.value = :closed
-      end
-
-      def half_open
-        self.value = :half_open
-      end
-
-      def reset
-        close
-      end
-
       def destroy
-        reset
+        super
         @integer.destroy
       end
 

--- a/lib/semian/sysv_state.rb
+++ b/lib/semian/sysv_state.rb
@@ -6,37 +6,25 @@ module Semian
       include SysVSharedMemory
       extend Forwardable
 
-      def_delegators :@integer, :semid, :shmid, :synchronize, :transaction,
-                     :shared?, :acquire_memory_object, :bind_initialize_memory_callback
-      private :shared?, :acquire_memory_object, :bind_initialize_memory_callback
+      SYM_TO_NUM = {closed: 0, open: 1, half_open: 2}.freeze
+      NUM_TO_SYM = SYM_TO_NUM.invert.freeze
+
+      def_delegators :@integer, :semid, :shmid, :synchronize, :acquire_memory_object,
+                     :bind_initialize_memory_callback, :destroy
+      private :acquire_memory_object, :bind_initialize_memory_callback
 
       def initialize(name:, permissions:)
         @integer = Semian::SysV::Integer.new(name: name, permissions: permissions)
-        initialize_lookup
-      end
-
-      def destroy
-        super
-        @integer.destroy
       end
 
       def value
-        @num_to_sym.fetch(@integer.value) { raise ArgumentError }
+        NUM_TO_SYM.fetch(@integer.value) { raise ArgumentError }
       end
 
       private
 
       def value=(sym)
-        @integer.value = @sym_to_num.fetch(sym) { raise ArgumentError }
-      end
-
-      def initialize_lookup
-        # Assume symbol_list[0] is mapped to 0
-        # Cannot just use #object_id since #object_id for symbols is different in every run
-        # For now, implement a C-style enum type backed by integers
-
-        @sym_to_num = {closed: 0, open: 1, half_open: 2}
-        @num_to_sym = @sym_to_num.invert
+        @integer.value = SYM_TO_NUM.fetch(sym) { raise ArgumentError }
       end
     end
   end

--- a/test/simple_state_test.rb
+++ b/test/simple_state_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class TestSimpleEnum < MiniTest::Unit::TestCase
+class TestSimpleState < MiniTest::Unit::TestCase
   CLASS = ::Semian::Simple::State
 
   def setup

--- a/test/sysv_integer_test.rb
+++ b/test/sysv_integer_test.rb
@@ -1,10 +1,10 @@
 require 'test_helper'
 
 class TestSysVInteger < MiniTest::Unit::TestCase
-  CLASS = ::Semian::SysV::Integer
+  KLASS = ::Semian::SysV::Integer
 
   def setup
-    @integer = CLASS.new(name: 'TestSysVInteger', permissions: 0660)
+    @integer = KLASS.new(name: 'TestSysVInteger', permissions: 0660)
     @integer.reset
   end
 

--- a/test/sysv_integer_test.rb
+++ b/test/sysv_integer_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class TestSysVInteger < MiniTest::Unit::TestCase
+  CLASS = ::Semian::SysV::Integer
+
+  def setup
+    @integer = CLASS.new(name: 'TestSysVInteger', permissions: 0660)
+    @integer.reset
+  end
+
+  def teardown
+    @integer.destroy
+  end
+
+  include TestSimpleInteger::IntegerTestCases
+end

--- a/test/sysv_sliding_window_test.rb
+++ b/test/sysv_sliding_window_test.rb
@@ -1,10 +1,10 @@
 require 'test_helper'
 
 class TestSysVSlidingWindow < MiniTest::Unit::TestCase
-  CLASS = ::Semian::SysV::SlidingWindow
+  KLASS = ::Semian::SysV::SlidingWindow
 
   def setup
-    @sliding_window = CLASS.new(max_size: 6,
+    @sliding_window = KLASS.new(max_size: 6,
                                 name: 'TestSysVSlidingWindow',
                                 permissions: 0660)
     @sliding_window.clear

--- a/test/sysv_sliding_window_test.rb
+++ b/test/sysv_sliding_window_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class TestSysVSlidingWindow < MiniTest::Unit::TestCase
+  CLASS = ::Semian::SysV::SlidingWindow
+
+  def setup
+    @sliding_window = CLASS.new(max_size: 6,
+                                name: 'TestSysVSlidingWindow',
+                                permissions: 0660)
+    @sliding_window.clear
+  end
+
+  def teardown
+    @sliding_window.destroy
+  end
+
+  include TestSimpleSlidingWindow::SlidingWindowTestCases
+
+  private
+
+  include TestSimpleSlidingWindow::SlidingWindowUtilityMethods
+end

--- a/test/sysv_state_test.rb
+++ b/test/sysv_state_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class TestSysVState < MiniTest::Unit::TestCase
+  CLASS = ::Semian::SysV::State
+
+  def setup
+    @state = CLASS.new(name: 'TestSysVState',
+                       permissions: 0660)
+    @state.reset
+  end
+
+  def teardown
+    @state.destroy
+  end
+
+  include TestSimpleState::StateTestCases
+
+  def test_will_throw_error_when_invalid_symbol_given
+    # May occur if underlying integer gets into bad state
+    integer = @state.instance_eval "@integer"
+    integer.value = 100
+    assert_raises ArgumentError do
+      @state.value
+    end
+    assert_raises ArgumentError do
+      @state.open?
+    end
+    assert_raises ArgumentError do
+      @state.half_open?
+    end
+    assert_raises ArgumentError do
+      @state.closed?
+    end
+  end
+end

--- a/test/sysv_state_test.rb
+++ b/test/sysv_state_test.rb
@@ -1,10 +1,10 @@
 require 'test_helper'
 
 class TestSysVState < MiniTest::Unit::TestCase
-  CLASS = ::Semian::SysV::State
+  KLASS = ::Semian::SysV::State
 
   def setup
-    @state = CLASS.new(name: 'TestSysVState',
+    @state = KLASS.new(name: 'TestSysVState',
                        permissions: 0660)
     @state.reset
   end


### PR DESCRIPTION
Old massive PR: https://github.com/Shopify/semian/pull/54
Small PR 1: https://github.com/Shopify/semian/pull/62

**Possibly outstanding issues**

* With the `SysV` versions of the structure needing permissions and a name, `Semian::Simple::SlidingWindow.new(max_size: 4)` and `Semian::SysV::SlidingWindow.new(max_size: 4, permissions: 0660, name: "sample_int")` have different interfaces. Ways to solve
 * do `def initialize(max_size: , **)` **current choice**
 * do `def initialize(options = {})` or something of the sort
 * not pass in `permissions` and `name` at all, but they have to come from somewhere else without leaking the implementation, possible from `Semian.register`
* Slightly extraneous: it was previously mentioned that test suite naming is a bit off, for example `TestCircuitBreaker` is `circuit_breaker_test.rb`
* Naming issue of `execute_atomically`: you know what, I changed it to `#synchronize`, similar to classes like `Mutex` and `Monitor`. It's still aliased to `#transaction`
* `#shared?` It's private, and just returns `@using_shared_memory`. Hopefully won't ruffle any feathers, or maybe just the `ivar` is enough?
* It was mentioned (not sure if still applies) that giving `name` and `permissions` to the structures was bad. Personally I disagree, but if so, start a discussion below about it.

**Content**
Alright, here's what I propose for adding in the SysV structures. I didn't include the tests yet, they will obviously fail because there's no C code to provide actual shared memory in this commit. 

The three `SysV` classes inherit directly from the `Simple` equivalents. They also mixin the `Semian::SysVSharedMemory` module, which provides the common functionality. 

From the C perspective, to get the memory allocation and things to work, it needs to do a bunch of things. Certain ways of accomplishing them are IMO worse than others, but I'll list the things that the C side needs to do, and the different ways to do them, and why/how I decided on this way.
C needs to accomplish:
* Hooking the allocation of a Ruby object so a backing C struct is made when the class is instantiated, whether or not `acquire_memory_object` is called. The C code needs this when unpacking the Ruby `VALUE self` object into a proper C `semian_shm_object *`
* Hook the implementations of the shared methods like `#acquire_shared_memory` at a shared level
* Override the specific implementations of a class, like `#value=`, `#<<`, etc 

This is about to get heavy. 

There were 3 ways of doing the above, and there is a diamond problem here. I originally had (1), but I changed to (2).

**(1)**: Have a superclass `SharedMemoryObject`, and `Simple` structures inherit from that. The `SysV` further inherit from the `Simple`
* Pros: Only hook access methods, allocation once, can replace functions at any point in time and it will work
* Cons: Weird to have `class Simple::Integer < SharedMemoryObject` even though it doesn't do sharing at all

**(2)**: Mixin a `SysVSharedMemory` module that does shares common functionality into the `SysV` variants only
* Pros: Makes sense from class organization perspective, mixin a module if you want shared-ness
* Cons: Although you can hook methods like `acquire_memory_object` in one spot, you have to replace the three different allocation methods separately. There is also a timing issue involved. You can't simply do this: 

  ```ruby
module SysVSharedMemory
  ...
  def self.included(base)
    # this doesn't work! The classes that mixin this module 
    # are defined before semian.so are loaded
    # meaning this isn't defined when self.included is called
    call_c_function_to_override_alloc()  
  end
end
  ```
Instead, as I found out, you had to do something like this in the C extension:

  ```C
void Init_semian_shm_object() {
  ...
  call_c_function_to_override_alloc_for(klass)
  ...
}
  ```

**(3)**: Make the `SysV` classes inherit from `SharedMemoryObject`. But what do we do about the common functionality between `Simple` and `SysV` versions? Put that in a module, and include it into things that need the functionality, like this:
* 

  ```ruby
class Simple::Enum
  module EnumImplementation
    ...
  end
  include EnumImplementation
end
class SysV::Enum < SharedMemoryObject
  include Simple::Enum::EnumImplementation
end
  ```
* Pros: Share things. Single point of replacing methods.
* Again, this is ugly.


If you made it this far, :+1:, it was really long.
I chose (2) because it's the most structurally clean, and I have a working solution to the timing problem, and there are no random abuses of Ruby features like Mixins beyond what is necessary.

I've isolated the locking/unlocking, and by doing that, eliminated the lock() and unlock() functions for a synchronize(), and using some delegating I wrap the methods with lock() and `ensure` unlock().

Here's the typical structure of an `acquire` that encompasses the C features as well just so we're on the same page:
```ruby
:acquire_memory_object
  # calculate byte_size, verify semaphores enabled and _acquire exists, else exit
  :_acquire (in C as semian_shm_object_acquire())
    # receive name, permissions, byte_size, check validity
    # hash the name, 
    :bind_initialize_memory_callback
      # It binds a void* function pointer to the C struct. 
         the function is a callback that initializes memory of a given size.
         this is specialized per SysV structure.
    semian_shm_object_acquire_semaphore()
      # call semget, set permissions
    semian_shm_object_synchronize()
      semian_shm_object_lock_without_gvl()
      semian_shm_object_synchronize_with_block() (in begin block)
        semian_shm_object_check_and_resize_if_needed()
          # check requested byte_size against a possible existing memory block, 
             resizing if necesssary by calling shmctl to check sizes
          semian_shm_object_acquire_memory()
            # call callback bound by :bind_initialize_memory_callback to initialize the acquired memory
            # call shmat to attach
      semian_shm_object_synchronize_restore_lock_status() (in ensure block)
  # set @using_shared_memory to true
```

Here's the structure of a synchronized access. Any method defined using `define_method_with_synchronize` is synchronized.
```ruby
:value
  :synchronize
    semian_shm_object_lock_without_gvl()
    semian_shm_object_synchronize_with_block() (in begin block)
      semian_shm_object_check_and_resize_if_needed()
      :value_inner (all the _inner methods are private)
        # access value from C struct
    semian_shm_object_synchronize_restore_lock_status() (in ensure block)
```
`define_method_with_synchronize` basically defines the original method, and then calls `do_with_sync :method_name`

**Discussion, opinions, etc would be great. I also want suggestions as to how to go forward with this.**

A version with everything working is on the branch with the large PR, https://github.com/Shopify/semian/pull/54
@Sirupsen @byroot 