### PR TITLE
Fix semian resource memoization

### DIFF
--- a/lib/semian/adapter.rb
+++ b/lib/semian/adapter.rb
@@ -5,7 +5,7 @@ module Semian
     end
 
     def semian_resource
-      @semian_options ||= case semian_options
+      @semian_resource ||= case semian_options
       when false
         UnprotectedResource.new(semian_identifier)
       when nil


### PR DESCRIPTION
If any options were specified and accessed earlier then upon subsequently attempting to create a resource it would find the already accessed options and skip creating the resource, instead returning the options hash which was then asked to `#acquire` and yielded something like:

     NoMethodError: undefined method `acquire' for #<Hash:0x007fb7cae23090>
     .../vendor/cache/ruby/2.1.0/gems/semian-0.3.0/lib/semian/adapter.rb:27:in `acquire_semian_resource'
     .../vendor/cache/ruby/2.1.0/gems/semian-0.3.0/lib/semian/redis.rb:60:in `connect'
     .../vendor/cache/ruby/2.1.0/gems/redis-3.0.7/lib/redis/client.rb:304:in `ensure_connected'
     .../vendor/cache/ruby/2.1.0/gems/redis-3.0.7/lib/redis/client.rb:191:in `block in process'
     ...