### PR TITLE
Fix flakey test by ignoring toxiproxy when activating Net::HTTP

### DIFF
--- a/test/net_http_test.rb
+++ b/test/net_http_test.rb
@@ -21,6 +21,7 @@ class TestNetHTTP < MiniTest::Unit::TestCase
     error_timeout: 10,
   }.freeze
   DEFAULT_SEMIAN_CONFIGURATION = proc do |host, port|
+    next nil if host == "127.0.0.1" && port == 8474 # disable if toxiproxy
     DEFAULT_SEMIAN_OPTIONS.merge(name: "#{host}_#{port}")
   end
 
@@ -230,7 +231,8 @@ class TestNetHTTP < MiniTest::Unit::TestCase
     semian_config["development"]["nethttp_default"] = DEFAULT_SEMIAN_OPTIONS
     sample_env = "development"
 
-    semian_configuration_proc = proc do
+    semian_configuration_proc = proc do |host, port|
+      next nil if host == "127.0.0.1" && port == 8474 # # disable if toxiproxy
       semian_identifier = "nethttp_default"
       semian_config[sample_env][semian_identifier].merge(name: "default")
     end


### PR DESCRIPTION
^ what it says.

The Toxiproxy ruby interface communicates over http to the daemon. When you combine `semian_identifier`'s in `test_use_custom_configuration_to_combine_endpoints_into_one_resource`, 3 errors are probably reached through the 'GET's, but since Toxiproxy shares the same circuit breaker state, `semian_identifier`: `nethttp_default`, it tries to communicate and triggers `Net::CircuitOpenError: [nethttp_default] Semian::OpenCircuitError`.

Small fix disables the adapter (returns `nil`) for connections to the Toxiproxy daemon.

This also explains why it triggers more failed tests after: since it was a `:down` call on the proxy, the call to bring it back up doesn't go through and further tests that reuse the same proxy fail.

Look it over and I suppose merge it into 0.4?

@Sirupsen @methodmissing 