### PR TITLE
Rescue DNS errors

### DIFF
--- a/semian.gemspec
+++ b/semian.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'mysql2'
   s.add_development_dependency 'redis'
+  s.add_development_dependency 'hiredis'
   s.add_development_dependency 'thin'
   s.add_development_dependency 'toxiproxy'
 end


### PR DESCRIPTION
We had problems in the past where due to a network outage in our datacenter, Redis clients would randomly show DNS resolution errors for their hostnames. Semian doesn't rescue those. The problem gets even more shitty since Redis and HiRedis handle those cases differently (see https://github.com/redis/hiredis-rb/issues/40).

This is a super quick-and-dirty fix. I'm sure there is a better way, but I want to get the discussion going.

Is this useful?

@byroot @csfrancis @Sirupsen 