### PR TITLE
NetHTTP response code handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /html/
 Gemfile.lock
 vendor/
+
+test/test_config.yml

--- a/test/mysql2_test.rb
+++ b/test/mysql2_test.rb
@@ -25,7 +25,7 @@ class TestMysql2 < MiniTest::Unit::TestCase
   end
 
   def test_semian_can_be_disabled
-    resource = Mysql2::Client.new(semian: false).semian_resource
+    resource = Mysql2::Client.new(mysql_config.merge(semian: false)).semian_resource
     assert_instance_of Semian::UnprotectedResource, resource
   end
 
@@ -254,7 +254,7 @@ grey_bg\\\":6M\\0\\06\x05\x01\x01!\fblueJ!\\0\x01l\x04ff\x01!\bredJ \\0$ff0000\\
   end
 
   def test_unconfigured
-    client = Mysql2::Client.new(host: '127.0.0.1', port: '13306')
+    client = Mysql2::Client.new(mysql_config)
     assert_equal 2, client.query('SELECT 1 + 1 as sum;').to_a.first['sum']
   end
 
@@ -262,10 +262,10 @@ grey_bg\\\":6M\\0\\06\x05\x01\x01!\fblueJ!\\0\x01l\x04ff\x01!\bredJ \\0$ff0000\\
 
   def connect_to_mysql!(semian_options = {})
     Mysql2::Client.new(
-      connect_timeout: 1,
-      host: '127.0.0.1',
-      port: '13306',
-      semian: SEMIAN_OPTIONS.merge(semian_options),
+      mysql_config.merge(
+        connect_timeout: 1,
+        semian: SEMIAN_OPTIONS.merge(semian_options),
+      ),
     )
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ require 'toxiproxy'
 require 'timecop'
 require 'tempfile'
 require 'fileutils'
+require 'yaml'
 
 require 'helpers/background_helper'
 
@@ -27,6 +28,20 @@ Toxiproxy.populate([
     listen: 'localhost:31051',
   },
 ])
+
+def mysql_config
+  defaults = {
+    username: ENV['USER'],
+    host: '127.0.0.1',
+    port: '13306',
+  }
+  defaults.merge(user_config['mysql2'])
+end
+
+def user_config
+  Hash.new({})
+    .merge(File.exist?(Dir.pwd + '/test/test_config.yml') ? YAML.load_file(Dir.pwd + '/test/test_config.yml') : {})
+end
 
 class MiniTest::Unit::TestCase
   include BackgroundHelper


### PR DESCRIPTION
Getting an unwanted response code, say, a `500`, doesn't actually raise anything in Net::HTTP, and therefore doesn't trigger anything for Semian to detect.

This provides that via an optional `raise_on` config key :)

@Sirupsen @byroot - can you guys take a peek please?
cc @Mavvie - relevant to your interests