### PR TITLE
Automatically convert T_FLOAT ticket count

### DIFF
--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -283,6 +283,10 @@ semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE permission
   if (TYPE(id) != T_SYMBOL && TYPE(id) != T_STRING) {
     rb_raise(rb_eTypeError, "id must be a symbol or string");
   }
+  if (TYPE(tickets) == T_FLOAT) {
+    rb_warn("semian ticket value %f is a float, converting to fixnum", RFLOAT_VALUE(tickets));
+    tickets = INT2FIX((int) RFLOAT_VALUE(tickets));
+  }
   Check_Type(tickets, T_FIXNUM);
   Check_Type(permissions, T_FIXNUM);
   if (TYPE(default_timeout) != T_FIXNUM && TYPE(default_timeout) != T_FLOAT) {

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -26,6 +26,12 @@ class TestResource < MiniTest::Unit::TestCase
     end
   end
 
+  def test_initialize_with_float
+    resource = create_resource :testing, tickets: 1.0
+    assert resource
+    assert_equal 1, resource.tickets
+  end
+
   def test_max_tickets
     assert Semian::MAX_TICKETS > 0
   end


### PR DESCRIPTION
@Sirupsen, @byroot 

This will automatically convert floating point ticket counts to integer values instead of raising `TypeError`.
