### PR TITLE
Don't use rake 11

### DIFF
--- a/semian.gemspec
+++ b/semian.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split("\n")
   s.extensions = ['ext/semian/extconf.rb']
   s.add_development_dependency 'rake-compiler', '~> 0.9'
+  s.add_development_dependency 'rake', '< 11.0'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'mysql2'
   s.add_development_dependency 'redis'


### PR DESCRIPTION
@byroot 

Apparently rake 11 removes the `last_comment` method, which breaks Travis (via Rubocop) with:

```
rake aborted!
NoMethodError: undefined method `last_comment' for #<Rake::Application:0x00000000fc6520>
/home/travis/.rvm/gems/ruby-2.1.1/gems/rubocop-0.34.2/lib/rubocop/rake_task.rb:23:in `initialize'
/home/travis/build/Shopify/semian/Rakefile:4:in `new'
/home/travis/build/Shopify/semian/Rakefile:4:in `<top (required)>'
/home/travis/.rvm/gems/ruby-2.1.1/bin/ruby_executable_hooks:15:in `eval'
/home/travis/.rvm/gems/ruby-2.1.1/bin/ruby_executable_hooks:15:in `<main>'
(See full trace by running task with --trace)
```

This just forces us to use rake 10.

http://stackoverflow.com/questions/35893584/nomethoderror-undefined-method-last-comment-after-upgrading-to-rake-11