### PR TITLE
Remove deprecated TimeoutError const

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
 
 rvm:
   - 2.1.1
+  - 2.3.0
 
 services:
   - redis-server

--- a/lib/semian/net_http.rb
+++ b/lib/semian/net_http.rb
@@ -34,7 +34,6 @@ module Semian
 
     DEFAULT_ERRORS = [
       ::Timeout::Error, # includes ::Net::ReadTimeout and ::Net::OpenTimeout
-      ::TimeoutError, # alias for above
       ::SocketError,
       ::Net::HTTPBadResponse,
       ::Net::HTTPHeaderSyntaxError,

--- a/semian.gemspec
+++ b/semian.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake-compiler', '~> 0.9'
   s.add_development_dependency 'rake', '< 11.0'
   s.add_development_dependency 'timecop'
+  s.add_development_dependency 'minitest'
   s.add_development_dependency 'mysql2'
   s.add_development_dependency 'redis'
   s.add_development_dependency 'thin'


### PR DESCRIPTION
Ruby 2.3.0 has deprecated the `TimeoutError` const causing Ruby to issue some warnings.

```
lib/semian/net_http.rb:37: warning: constant ::TimeoutError is deprecated
```

Since this was listed as an alias for `Timeout::Error` seems safe(?) to propose it's removal.

Added Ruby 2.3.0 to the Travis builds to confirm.