### PR TITLE
Fix lazy aliasing of Redis#semian_resource

### DIFF
--- a/lib/semian/redis.rb
+++ b/lib/semian/redis.rb
@@ -16,11 +16,17 @@ class Redis
   ResourceBusyError = Class.new(SemianError)
   CircuitOpenError = Class.new(SemianError)
 
-  # This memoized alias is necessary because during a `pipelined` block
-  # the client is replaced by an instance of `Redis::Pipeline` and there is
-  # no way to access the original client.
-  def semian_resource
-    @semian_resource ||= @client.semian_resource
+  attr_reader :semian_resource
+
+  alias_method :_original_initialize, :initialize
+
+  def initialize(*args, &block)
+    _original_initialize(*args, &block)
+
+    # This alias is necessary because during a `pipelined` block
+    # the client is replaced by an instance of `Redis::Pipeline` and there is
+    # no way to access the original client.
+    @semian_resource = client.semian_resource
   end
 
   def semian_identifier


### PR DESCRIPTION
### Context

The redis client is a bit special because:
  - `Redis.new` returns some kind of wrapper.
  - The "real" client is in `Redis.new.client`
  - So we have an delegator on `Redis#semian_resource` to `Redis::Client#semian_resource` to respect's semian contract.

The problem is that the redis "wrapper", during `pipelined` and similar block calls, replaces the `Redis::Client` instance by a `Redis::Pipeline` instance, and there is no way to access the real client anymore because it's just in a local variable. See: https://github.com/redis/redis-rb/blob/fd77358708920b3b7b76955eda22e8c89647aae5/lib/redis.rb#L2248-L2258

### Problem

We knew about this error, I even put a descriptive comment about why we were memoizing the resource.

Where I dropped the ball is that if the first call ever to `semian_resource` is from inside a `pipelined` block, then you end up with

```ruby
NoMethodError·undefined method `semian_resource' for #<Redis::Pipeline:0x005631a026c398>
```

Any of @fw42 @pushrax @Sirupsen @csfrancis for review please.