### PR TITLE
Use published version of the toxiproxy gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,5 @@ group :debug do
 end
 
 group :development, :test do
-  gem 'toxiproxy', github: 'Shopify/toxiproxy-ruby', ref: 'f0c5d0bebca01180e2cfd5234e3d18affefbc670', require: 'toxiproxy'
   gem 'rubocop', '~> 0.34.2'
 end

--- a/scripts/install_toxiproxy.sh
+++ b/scripts/install_toxiproxy.sh
@@ -7,7 +7,7 @@ fi
 
 if which apt-get > /dev/null; then
   echo "Installing toxiproxy"
-  wget -O /tmp/toxiproxy.deb https://github.com/Shopify/toxiproxy/releases/download/v2.0.0rc1/toxiproxy_2.0.0rc1_amd64.deb
+  wget -O /tmp/toxiproxy.deb https://github.com/Shopify/toxiproxy/releases/download/v2.0.0/toxiproxy_2.0.0_amd64.deb
   sudo dpkg -i /tmp/toxiproxy.deb
   sudo service toxiproxy start
   exit 0

--- a/semian.gemspec
+++ b/semian.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mysql2'
   s.add_development_dependency 'redis'
   s.add_development_dependency 'thin'
-  s.add_development_dependency 'toxiproxy'
+  s.add_development_dependency 'toxiproxy', '~> 1.0.0'
 end


### PR DESCRIPTION
It's been a while that toxiproxy  server 2.0 and client 1.0 have been released.

FYI @Sirupsen 