### PR TITLE
Make request_allowed? thread safe

### DIFF
--- a/lib/semian/protected_resource.rb
+++ b/lib/semian/protected_resource.rb
@@ -3,7 +3,8 @@ module Semian
     extend Forwardable
 
     def_delegators :@resource, :destroy, :count, :semid, :tickets, :name
-    def_delegators :@circuit_breaker, :reset, :mark_failed, :mark_success, :request_allowed?
+    def_delegators :@circuit_breaker, :reset, :mark_failed, :mark_success, :request_allowed?,
+                   :open?, :closed?, :half_open?
 
     def initialize(resource, circuit_breaker)
       @resource = resource

--- a/lib/semian/unprotected_resource.rb
+++ b/lib/semian/unprotected_resource.rb
@@ -30,6 +30,18 @@ module Semian
     def reset
     end
 
+    def open?
+      false
+    end
+
+    def closed?
+      true
+    end
+
+    def half_open?
+      false
+    end
+
     def request_allowed?
       true
     end

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -86,6 +86,18 @@ class TestCircuitBreaker < Minitest::Test
     Semian.destroy(:three)
   end
 
+  def test_request_allowed_query_doesnt_trigger_transitions
+    Timecop.travel(Time.now - 6) do
+      open_circuit!
+
+      refute_predicate @resource, :request_allowed?
+      assert_predicate @resource, :open?
+    end
+
+    assert_predicate @resource, :request_allowed?
+    assert_predicate @resource, :open?
+  end
+
   private
 
   def open_circuit!(resource = @resource)


### PR DESCRIPTION
First draft for https://github.com/Shopify/semian/issues/86

The idea here is to remove any side effect `request_allowed?` might have, so that it's safe to call it from a threaded environment.

NB: The other circuit breaker methods stays unsafe and it's the adapter's responsibility to call them safely.

