### PR TITLE
mysql: circuit break pings

### DIFF
--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -27,6 +27,7 @@ module Semian
 
     ResourceBusyError = ::Mysql2::ResourceBusyError
     CircuitOpenError = ::Mysql2::CircuitOpenError
+    PingFailure = Class.new(::Mysql2::Error)
 
     DEFAULT_HOST = 'localhost'
     DEFAULT_PORT = 3306
@@ -44,6 +45,9 @@ module Semian
 
       base.send(:alias_method, :raw_connect, :connect)
       base.send(:remove_method, :connect)
+
+      base.send(:alias_method, :raw_ping, :ping)
+      base.send(:remove_method, :ping)
     end
 
     def semian_identifier
@@ -55,6 +59,17 @@ module Semian
         end
         :"mysql_#{name}"
       end
+    end
+
+    def ping
+      result = nil
+      acquire_semian_resource(adapter: :mysql, scope: :ping) do
+        result = raw_ping
+        raise PingFailure.new(result.to_s) unless result
+      end
+      result
+    rescue ResourceBusyError, CircuitOpenError, PingFailure
+      false
     end
 
     def query(*args)
@@ -84,7 +99,7 @@ module Semian
     def acquire_semian_resource(*)
       super
     rescue ::Mysql2::Error => error
-      if error.message =~ CONNECTION_ERROR
+      if error.message =~ CONNECTION_ERROR || error.is_a?(PingFailure)
         semian_resource.mark_failed(error)
         error.semian_identifier = semian_identifier
       end

--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -21,7 +21,7 @@ module Semian
 
     CONNECTION_ERROR = Regexp.union(
       /Can't connect to MySQL server on/i,
-      /Lost connection to MySQL server during query/i,
+      /Lost connection to MySQL server/i,
       /MySQL server has gone away/i,
     )
 


### PR DESCRIPTION
Currently pings are not behind circuit breakers. They respect the default `read_timeout`, **which means that in stock Rails each request will take at least `read_timeout`, even if the data store is behind a circuit breaker**. This is because a connection is always pinged when it's checked out of the pool, see [`ActiveRecord::ConnectionPool#checkout_and_verify`](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L776) and [`ActiveRecord::AbstractAdapter#verify!`](https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L339).

Tagging Shopify people who've dabbled in AR:

@dylanahsmith @csfrancis @rafaelfranca @casperisfine 