### PR TITLE
Also let "Too many connections" be a first class conn error

### DIFF
--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -23,6 +23,7 @@ module Semian
       /Can't connect to MySQL server on/i,
       /Lost connection to MySQL server/i,
       /MySQL server has gone away/i,
+      /Too many connections/i,
     )
 
     ResourceBusyError = ::Mysql2::ResourceBusyError

--- a/lib/semian/version.rb
+++ b/lib/semian/version.rb
@@ -1,3 +1,3 @@
 module Semian
-  VERSION = '0.5.3'
+  VERSION = '0.5.4'
 end


### PR DESCRIPTION
Observed that this isn't handled by the adapter when lowering MySQL `max_connections` counts during testing.

@Sirupsen @camilo @csfrancis @byroot 