### PR TITLE
Implement AR::AbstractAdapter#semian_resource

### DIFF
--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -173,3 +173,9 @@ if Semian.semaphores_enabled?
 else
   Semian::MAX_TICKETS = 0
 end
+
+if defined? ActiveSupport
+  ActiveSupport.on_load :active_record do
+    require 'semian/rails'
+  end
+end

--- a/lib/semian/rails.rb
+++ b/lib/semian/rails.rb
@@ -1,0 +1,7 @@
+require 'active_record/connection_adapters/abstract_adapter'
+
+class ActiveRecord::ConnectionAdapters::AbstractAdapter
+  def semian_resource
+    @connection.semian_resource
+  end
+end


### PR DESCRIPTION
Allows for things like:

```ruby
if ActiveRecord::Base.connection.semian_resource.request_allowed?
  # ...
end
```

It's easily done with most semian adapters, but if you use Rails, the actual MySQL2 client is hard to get access to.

@fw42 @Sirupsen 