### PR TITLE
Let Net::OpenTimeout be a default error for the Net::HTTP adapter as well

### DIFF
--- a/lib/semian/net_http.rb
+++ b/lib/semian/net_http.rb
@@ -33,11 +33,12 @@ module Semian
     end
 
     DEFAULT_ERRORS = [
-      ::Timeout::Error, # includes ::Net::ReadTimeout and ::Net::OpenTimeout
+      ::Timeout::Error, # includes ::Net::ReadTimeout
       ::SocketError,
       ::Net::HTTPBadResponse,
       ::Net::HTTPHeaderSyntaxError,
       ::Net::ProtocolError,
+      ::Net::OpenTimeout, # https://github.com/ruby/ruby/blob/trunk/lib/net/http.rb#L902
       ::EOFError,
       ::IOError,
       ::SystemCallError, # includes ::Errno::EINVAL, ::Errno::ECONNRESET, ::Errno::ECONNREFUSED, ::Errno::ETIMEDOUT, and more


### PR DESCRIPTION
We've been noticing a few `Net::OpenTimeout: execution expired` under flakey network conditions for resources wrapped with the Net::HTTP adapter. We expected this to be intercepted by Semian, however further investigation revealed that it's in fact not coerced to `Timeout::Error`, but bubbles up as an explicit `Net::TimeoutError` from within stdlib `Net::HTTP`:

* https://github.com/ruby/ruby/blob/trunk/lib/net/http.rb#L902
* https://github.com/ruby/ruby/blob/trunk/lib/timeout.rb#L61

```
/usr/lib/ruby/2.3.1/lib/ruby/2.3.0/net/http.rb:880
/usr/lib/ruby/2.3.1/lib/ruby/2.3.0/net/http.rb:880
/usr/lib/ruby/2.3.1/lib/ruby/2.3.0/net/http.rb:880
/usr/lib/ruby/2.3.1/lib/ruby/2.3.0/timeout.rb:101
/usr/lib/ruby/2.3.1/lib/ruby/2.3.0/net/http.rb:878
[GEM_ROOT]/gems/semian-0.5.4/lib/semian/net_http.rb:92
[GEM_ROOT]/gems/semian-0.5.4/lib/semian/adapter.rb:62
[GEM_ROOT]/gems/semian-0.5.4/lib/semian/adapter.rb:30
[GEM_ROOT]/gems/semian-0.5.4/lib/semian/protected_resource.rb:24
[GEM_ROOT]/gems/semian-0.5.4/lib/semian/protected_resource.rb:22
[GEM_ROOT]/gems/semian-0.5.4/lib/semian/protected_resource.rb:22
[GEM_ROOT]/gems/semian-0.5.4/lib/semian/circuit_breaker.rb:26
[GEM_ROOT]/gems/semian-0.5.4/lib/semian/protected_resource.rb:20
[GEM_ROOT]/gems/semian-0.5.4/lib/semian/adapter.rb:29
[GEM_ROOT]/gems/semian-0.5.4/lib/semian/net_http.rb:92
```

@csfrancis @fw42 @Sirupsen @tjoyal @Shopify/byroot 