### PR TITLE
Refactor semian.c includes and types into header files

### DIFF
--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -1,25 +1,4 @@
-#include <sys/types.h>
-#include <sys/ipc.h>
-#include <sys/sem.h>
-#include <sys/time.h>
-#include <errno.h>
-#include <string.h>
-
-#include <ruby.h>
-#include <ruby/util.h>
-#include <ruby/io.h>
-
-#include <openssl/sha.h>
-
-#include <stdio.h>
-
-union semun {
-  int              val;    /* Value for SETVAL */
-  struct semid_ds *buf;    /* Buffer for IPC_STAT, IPC_SET */
-  unsigned short  *array;  /* Array for GETALL, SETALL */
-  struct seminfo  *__buf;  /* Buffer for IPC_INFO
-                             (Linux-specific) */
-};
+#include <semian.h>
 
 #if defined(HAVE_RB_THREAD_CALL_WITHOUT_GVL) && defined(HAVE_RUBY_THREAD_H)
 // 2.0
@@ -34,21 +13,6 @@ typedef VALUE (*my_blocking_fn_t)(void*);
 static ID id_timeout;
 static VALUE eSyscall, eTimeout, eInternal;
 static int system_max_semaphore_count;
-
-typedef enum
-{
-  SI_SEM_TICKETS,            // semaphore for the tickets currently issued
-  SI_SEM_CONFIGURED_TICKETS, // semaphore to track the desired number of tickets available for issue
-  SI_SEM_LOCK,               // metadata lock to act as a mutex, ensuring thread-safety for updating other semaphores
-  SI_NUM_SEMAPHORES          // always leave this as last entry for count to be accurate
-} semaphore_indices;
-
-typedef struct {
-  int sem_id;
-  struct timespec timeout;
-  int error;
-  char *name;
-} semian_resource_t;
 
 static key_t
 generate_key(const char *name)
@@ -159,11 +123,6 @@ perform_semop(int sem_id, short index, short op, short flags, struct timespec *t
     return semop(sem_id, &buf, 1);
   }
 }
-
-typedef struct {
-  int sem_id;
-  int tickets;
-} update_ticket_count_t;
 
 static VALUE
 update_ticket_count(update_ticket_count_t *tc)

--- a/ext/semian/semian.h
+++ b/ext/semian/semian.h
@@ -1,0 +1,30 @@
+/*
+System, 3rd party, and project includes
+
+Implements Init_semian, which is used as C/Ruby entrypoint.
+*/
+
+#ifndef SEMIAN_H
+#define SEMIAN_H
+
+// System includes
+#include <sys/types.h>
+#include <sys/ipc.h>
+#include <sys/sem.h>
+#include <sys/time.h>
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+
+// 3rd party includes
+#include <openssl/sha.h>
+#include <ruby.h>
+#include <ruby/util.h>
+#include <ruby/io.h>
+
+//semian includes
+#include <semian_types.h>
+
+void Init_semian();
+
+#endif //SEMIAN_H

--- a/ext/semian/semian.h
+++ b/ext/semian/semian.h
@@ -8,10 +8,6 @@ Implements Init_semian, which is used as C/Ruby entrypoint.
 #define SEMIAN_H
 
 // System includes
-#include <sys/types.h>
-#include <sys/ipc.h>
-#include <sys/sem.h>
-#include <sys/time.h>
 #include <errno.h>
 #include <string.h>
 #include <stdio.h>

--- a/ext/semian/semian_types.h
+++ b/ext/semian/semian_types.h
@@ -4,6 +4,11 @@ For custom type definitions specific to semian
 #ifndef SEMIAN_TYPES_H
 #define SEMIAN_TYPES_H
 
+#include <sys/types.h>
+#include <sys/ipc.h>
+#include <sys/sem.h>
+#include <sys/time.h>
+
 // For sysV semop syscals
 // see man semop
 union semun {

--- a/ext/semian/semian_types.h
+++ b/ext/semian/semian_types.h
@@ -1,0 +1,41 @@
+/*
+For custom type definitions specific to semian
+*/
+#ifndef SEMIAN_TYPES_H
+#define SEMIAN_TYPES_H
+
+// For sysV semop syscals
+// see man semop
+union semun {
+  int              val;    /* Value for SETVAL */
+  struct semid_ds *buf;    /* Buffer for IPC_STAT, IPC_SET */
+  unsigned short  *array;  /* Array for GETALL, SETALL */
+  struct seminfo  *__buf;  /* Buffer for IPC_INFO
+                             (Linux-specific) */
+};
+
+// To update the ticket count
+typedef struct {
+  int sem_id;
+  int tickets;
+} update_ticket_count_t;
+
+// Internal semaphore structure
+typedef struct {
+  int sem_id;
+  struct timespec timeout;
+  int error;
+  char *name;
+} semian_resource_t;
+
+
+// FIXME: REMOVE ME once semset.h is merged
+typedef enum
+{
+  SI_SEM_TICKETS,            // semaphore for the tickets currently issued
+  SI_SEM_CONFIGURED_TICKETS, // semaphore to track the desired number of tickets available for issue
+  SI_SEM_LOCK,               // metadata lock to act as a mutex, ensuring thread-safety for updating other semaphores
+  SI_NUM_SEMAPHORES          // always leave this as last entry for count to be accurate
+} semaphore_indices;
+
+#endif // SEMIAN_TYPES_H


### PR DESCRIPTION
# What

Part of https://github.com/Shopify/semian/pull/101
- Refactor semian includes into semian.h
- Refactor semian types into semian_types.h

# Why

Splitting larger omnibus refactor into more reviewable PRs