### PR TITLE
Use glob instead of git for gemspec file list

### DIFF
--- a/semian.gemspec
+++ b/semian.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.email = 'scott.francis@shopify.com'
   s.license = 'MIT'
 
-  s.files = `git ls-files`.split("\n")
+  s.files = Dir['{lib,ext}/**/**/*.{rb,h,c}']
   s.extensions = ['ext/semian/extconf.rb']
   s.add_development_dependency 'rake-compiler', '~> 0.9'
   s.add_development_dependency 'rake', '< 11.0'


### PR DESCRIPTION
# What

This moves the gemspec to use files on disk instead of files from git.

Only files in ext and lib folders are included, and only ruby, C source, and C headers are permitted.

# Why

Right now if you are refactoring, rake will base its file list off of the gemfile, which has it's list from git. This is quite annoying if you've added or removed files such that your file list is out of sync from git.

This change should cause it to always use the files on disk, which is a bit more intuitive.