### PR TITLE
Don't require sudo for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 
-sudo: true
-
 before_install:
   - gem update --system
   - gem install bundler

--- a/scripts/install_toxiproxy.sh
+++ b/scripts/install_toxiproxy.sh
@@ -5,7 +5,12 @@ if which toxiproxy > /dev/null; then
   exit 0
 fi
 
-if which apt-get > /dev/null; then
+if [ -n "${CI}" ]; then
+  wget https://github.com/Shopify/toxiproxy/releases/download/v2.1.0/toxiproxy-server-linux-amd64 -O toxiproxy
+  chmod +x toxiproxy
+  nohup ./toxiproxy &
+  exit 0
+elif which apt-get > /dev/null; then
   echo "Installing toxiproxy"
   wget -O /tmp/toxiproxy.deb https://github.com/Shopify/toxiproxy/releases/download/v2.0.0/toxiproxy_2.0.0_amd64.deb
   sudo dpkg -i /tmp/toxiproxy.deb

--- a/scripts/install_toxiproxy.sh
+++ b/scripts/install_toxiproxy.sh
@@ -6,13 +6,13 @@ if which toxiproxy > /dev/null; then
 fi
 
 if [ -n "${CI}" ]; then
-  wget https://github.com/Shopify/toxiproxy/releases/download/v2.1.0/toxiproxy-server-linux-amd64 -O toxiproxy
-  chmod +x toxiproxy
-  nohup ./toxiproxy &
+  wget -O /tmp/toxiproxy https://github.com/Shopify/toxiproxy/releases/download/v2.1.0/toxiproxy-server-linux-amd64
+  chmod +x /tmp/toxiproxy
+  nohup /tmp/toxiproxy &
   exit 0
 elif which apt-get > /dev/null; then
   echo "Installing toxiproxy"
-  wget -O /tmp/toxiproxy.deb https://github.com/Shopify/toxiproxy/releases/download/v2.0.0/toxiproxy_2.0.0_amd64.deb
+  wget -O /tmp/toxiproxy.deb https://github.com/Shopify/toxiproxy/releases/download/v2.1.0/toxiproxy_2.1.0_amd64.deb
   sudo dpkg -i /tmp/toxiproxy.deb
   sudo service toxiproxy start
   exit 0


### PR DESCRIPTION
# What 

Fixes https://github.com/Shopify/semian/issues/68

Allows us to run CI builds faster by not using the legacy infrastructure. In order to do this, we have to stop using sudo.

*Note:* The builds take around the same amount of time, but are able to be scheduled right away.

# How

The only reason we "need" sudo right now is to install a deb, and the only thing that deb is doing is running a single binary as a service.

Rather than grab the deb and start the service, let's just grab the binary and run it in the background with nohup.