### PR TITLE
Check arguments for initialize_resource

### DIFF
--- a/ext/semian/resource.c
+++ b/ext/semian/resource.c
@@ -155,13 +155,15 @@ cleanup_semian_resource_acquire(VALUE self)
   return Qnil;
 }
 
-static long check_permissions_arg(VALUE permissions)
+static long
+check_permissions_arg(VALUE permissions)
 {
   Check_Type(permissions, T_FIXNUM);
   return FIX2LONG(permissions);
 }
 
-static int check_tickets_arg(VALUE tickets)
+static int
+check_tickets_arg(VALUE tickets)
 {
   int c_tickets;
 
@@ -183,7 +185,8 @@ static int check_tickets_arg(VALUE tickets)
   return c_tickets;
 }
 
-static const char* check_id_arg(VALUE id)
+static const char*
+check_id_arg(VALUE id)
 {
   const char *c_id_str = NULL;
 
@@ -199,7 +202,8 @@ static const char* check_id_arg(VALUE id)
   return c_id_str;
 }
 
-static double check_default_timeout_arg(VALUE default_timeout)
+static double
+check_default_timeout_arg(VALUE default_timeout)
 {
   if (TYPE(default_timeout) != T_FIXNUM && TYPE(default_timeout) != T_FLOAT) {
     rb_raise(rb_eTypeError, "expected numeric type for default_timeout");

--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -22,14 +22,14 @@ raise_semian_syscall_error(const char *syscall, int error_num)
 }
 
 void
-set_semaphore_permissions(int sem_id, int permissions)
+set_semaphore_permissions(int sem_id, long permissions)
 {
   union semun sem_opts;
   struct semid_ds stat_buf;
 
   sem_opts.buf = &stat_buf;
   semctl(sem_id, 0, IPC_STAT, sem_opts);
-  if ((stat_buf.sem_perm.mode & 0xfff) != FIX2LONG(permissions)) {
+  if ((stat_buf.sem_perm.mode & 0xfff) != permissions) {
     stat_buf.sem_perm.mode &= ~0xfff;
     stat_buf.sem_perm.mode |= permissions;
     semctl(sem_id, 0, IPC_SET, sem_opts);
@@ -143,13 +143,13 @@ configure_tickets(int sem_id, int tickets, int should_initialize)
 }
 
 int
-create_semaphore(int key, int permissions, int *created)
+create_semaphore(int key, long permissions, int *created)
 {
   int semid = 0;
   int flags = 0;
 
   *created = 0;
-  flags = IPC_EXCL | IPC_CREAT | FIX2LONG(permissions);
+  flags = IPC_EXCL | IPC_CREAT | permissions;
 
   semid = semget(key, SI_NUM_SEMAPHORES, flags);
   if (semid >= 0) {

--- a/ext/semian/semian.h
+++ b/ext/semian/semian.h
@@ -47,10 +47,10 @@ key_t
 generate_key(const char *name);
 
 void
-set_semaphore_permissions(int sem_id, int permissions);
+set_semaphore_permissions(int sem_id, long permissions);
 
 int
-create_semaphore(int key, int permissions, int *created);
+create_semaphore(int key, long permissions, int *created);
 
 int
 get_semaphore(int key);


### PR DESCRIPTION
# What

Here we refactor argument checks for resource initialization out into static methods.
The static methods also perform type casting to the desired type.

A potential bug was discovered, where permissions were being downcasted from long to int.
This has been repaired, and signatures have been adjusted to use long instead of int where required.
The type conversion is now happening in exactly one place.

# Why

It's easier to read the initialize_resource function with this checking out of the way.

This also asserts a contract that each argument should have a function that checks it for validity, and then casts it to the correct C type.