### PR TITLE
Refactor semaphore operations

### DIFF
--- a/ext/semian/resource.h
+++ b/ext/semian/resource.h
@@ -3,12 +3,12 @@ For core semian resource functions exposed directly to ruby.
 
 Functions here are associated with rubyland operations.
 */
-
 #ifndef SEMIAN_RESOURCE_H
 #define SEMIAN_RESOURCE_H
 
-#include "semian.h" // FIXME remove this once temporary declarations are removed
+#include "semian.h" // FIXME remove this once configure_tickets has been refactored
 #include "types.h"
+#include "sysv_semaphores.h"
 
 // Ruby variables
 ID id_timeout;

--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -5,7 +5,7 @@ update_ticket_count(update_ticket_count_t *tc)
 {
   short delta;
   struct timespec ts = { 0 };
-  ts.tv_sec = kInternalTimeout;
+  ts.tv_sec = INTERNAL_TIMEOUT;
 
   if (get_max_tickets(tc->sem_id) != tc->tickets) {
     delta = tc->tickets - get_max_tickets(tc->sem_id);
@@ -45,7 +45,7 @@ configure_tickets(int sem_id, int tickets, int should_initialize)
       while (get_max_tickets(sem_id) == 0) {
         usleep(10000); /* 10ms */
         gettimeofday(&cur_time, NULL);
-        if ((cur_time.tv_sec - start_time.tv_sec) > kInternalTimeout) {
+        if ((cur_time.tv_sec - start_time.tv_sec) > INTERNAL_TIMEOUT) {
           rb_raise(eInternal, "timeout waiting for semaphore initialization");
         }
       }
@@ -57,7 +57,7 @@ configure_tickets(int sem_id, int tickets, int should_initialize)
        (tickets - current_max_tickets) to the semaphore value.
     */
     if (get_max_tickets(sem_id) != tickets) {
-      ts.tv_sec = kInternalTimeout;
+      ts.tv_sec = INTERNAL_TIMEOUT;
 
       if (perform_semop(sem_id, SI_SEM_LOCK, -1, SEM_UNDO, &ts) == -1) {
         raise_semian_syscall_error("error acquiring internal semaphore lock, semtimedop()", errno);

--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -1,87 +1,11 @@
 #include "semian.h"
 
-// Time to wait for timed ops to complete
-#define INTERNAL_TIMEOUT 5 // seconds
-
-key_t
-generate_key(const char *name)
-{
-  char semset_size_key[20];
-  char *uniq_id_str;
-
-  // It is necessary for the cardinatily of the semaphore set to be part of the key
-  // or else sem_get will complain that we have requested an incorrect number of sems
-  // for the desired key, and have changed the number of semaphores for a given key
-  sprintf(semset_size_key, "_NUM_SEMS_%d", SI_NUM_SEMAPHORES);
-  uniq_id_str = malloc(strlen(name)+strlen(semset_size_key)+1);
-  strcpy(uniq_id_str, name);
-  strcat(uniq_id_str, semset_size_key);
-
-  union {
-    unsigned char str[SHA_DIGEST_LENGTH];
-    key_t key;
-  } digest;
-  SHA1((const unsigned char *) uniq_id_str, strlen(uniq_id_str), digest.str);
-  free(uniq_id_str);
-  /* TODO: compile-time assertion that sizeof(key_t) > SHA_DIGEST_LENGTH */
-  return digest.key;
-}
-
-void
-raise_semian_syscall_error(const char *syscall, int error_num)
-{
-  rb_raise(eSyscall, "%s failed, errno: %d (%s)", syscall, error_num, strerror(error_num));
-}
-
-void
-set_semaphore_permissions(int sem_id, long permissions)
-{
-  union semun sem_opts;
-  struct semid_ds stat_buf;
-
-  sem_opts.buf = &stat_buf;
-  semctl(sem_id, 0, IPC_STAT, sem_opts);
-  if ((stat_buf.sem_perm.mode & 0xfff) != permissions) {
-    stat_buf.sem_perm.mode &= ~0xfff;
-    stat_buf.sem_perm.mode |= permissions;
-    semctl(sem_id, 0, IPC_SET, sem_opts);
-  }
-}
-
-static const int kInternalTimeout = 5; /* seconds */
-
-static int
-get_max_tickets(int sem_id)
-{
-  int ret = semctl(sem_id, SI_SEM_CONFIGURED_TICKETS, GETVAL);
-  if (ret == -1) {
-    rb_raise(eInternal, "error getting max ticket count, errno: %d (%s)", errno, strerror(errno));
-  }
-  return ret;
-}
-
-int
-perform_semop(int sem_id, short index, short op, short flags, struct timespec *ts)
-{
-  struct sembuf buf = { 0 };
-
-  buf.sem_num = index;
-  buf.sem_op  = op;
-  buf.sem_flg = flags;
-
-  if (ts) {
-    return semtimedop(sem_id, &buf, 1, ts);
-  } else {
-    return semop(sem_id, &buf, 1);
-  }
-}
-
 static VALUE
 update_ticket_count(update_ticket_count_t *tc)
 {
   short delta;
   struct timespec ts = { 0 };
-  ts.tv_sec = kInternalTimeout;
+  ts.tv_sec = INTERNAL_TIMEOUT;
 
   if (get_max_tickets(tc->sem_id) != tc->tickets) {
     delta = tc->tickets - get_max_tickets(tc->sem_id);
@@ -91,7 +15,7 @@ update_ticket_count(update_ticket_count_t *tc)
     }
 
     if (semctl(tc->sem_id, SI_SEM_CONFIGURED_TICKETS, SETVAL, tc->tickets) == -1) {
-      rb_raise(eInternal, "error updating max ticket count, errno: %d (%s)", errno, strerror(errno));
+      rb_raise(eInternal, "error updating configured ticket count, errno: %d (%s)", errno, strerror(errno));
     }
   }
 
@@ -121,19 +45,19 @@ configure_tickets(int sem_id, int tickets, int should_initialize)
       while (get_max_tickets(sem_id) == 0) {
         usleep(10000); /* 10ms */
         gettimeofday(&cur_time, NULL);
-        if ((cur_time.tv_sec - start_time.tv_sec) > kInternalTimeout) {
+        if ((cur_time.tv_sec - start_time.tv_sec) > INTERNAL_TIMEOUT) {
           rb_raise(eInternal, "timeout waiting for semaphore initialization");
         }
       }
     }
 
     /*
-       If the current max ticket count is not the same as the requested ticket
+       If the current configured ticket count is not the same as the requested ticket
        count, we need to resize the count. We do this by adding the delta of
-       (tickets - current_max_tickets) to the semaphore value.
+       (tickets - current_configured_tickets) to the semaphore value.
     */
     if (get_max_tickets(sem_id) != tickets) {
-      ts.tv_sec = kInternalTimeout;
+      ts.tv_sec = INTERNAL_TIMEOUT;
 
       if (perform_semop(sem_id, SI_SEM_LOCK, -1, SEM_UNDO, &ts) == -1) {
         raise_semian_syscall_error("error acquiring internal semaphore lock, semtimedop()", errno);
@@ -152,42 +76,6 @@ configure_tickets(int sem_id, int tickets, int should_initialize)
       }
     }
   }
-}
-
-int
-create_semaphore(int key, long permissions, int *created)
-{
-  int semid = 0;
-  int flags = 0;
-
-  *created = 0;
-  flags = IPC_EXCL | IPC_CREAT | permissions;
-
-  semid = semget(key, SI_NUM_SEMAPHORES, flags);
-  if (semid >= 0) {
-    *created = 1;
-  } else if (semid == -1 && errno == EEXIST) {
-    flags &= ~IPC_EXCL;
-    semid = semget(key, SI_NUM_SEMAPHORES, flags);
-  }
-  return semid;
-}
-
-void *
-acquire_semaphore_without_gvl(void *p)
-{
-  semian_resource_t *res = (semian_resource_t *) p;
-  res->error = 0;
-  if (perform_semop(res->sem_id, SI_SEM_TICKETS, -1, SEM_UNDO, &res->timeout) == -1) {
-    res->error = errno;
-  }
-  return NULL;
-}
-
-int
-get_semaphore(int key)
-{
-  return semget(key, SI_NUM_SEMAPHORES, 0);
 }
 
 void Init_semian()

--- a/ext/semian/semian.h
+++ b/ext/semian/semian.h
@@ -21,6 +21,7 @@ Implements Init_semian, which is used as C/Ruby entrypoint.
 //semian includes
 #include "types.h"
 #include "resource.h"
+#include "sysv_semaphores.h"
 
 // FIXME: This is needed here temporarily
 // Defines for ruby threading primitives
@@ -34,34 +35,11 @@ typedef VALUE (*my_blocking_fn_t)(void*);
 #define WITHOUT_GVL(fn,a,ubf,b) rb_thread_blocking_region((my_blocking_fn_t)(fn),(a),(ubf),(b))
 #endif
 
-VALUE eSyscall, eTimeout, eInternal;
-
 void Init_semian();
 
 // FIXME: These are needed here temporarily while we move functions around
 // Will be removed once there are new header files that the should belong to.
 void
 configure_tickets(int sem_id, int tickets, int should_initialize);
-
-key_t
-generate_key(const char *name);
-
-void
-set_semaphore_permissions(int sem_id, long permissions);
-
-int
-create_semaphore(int key, long permissions, int *created);
-
-int
-get_semaphore(int key);
-
-void
-raise_semian_syscall_error(const char *syscall, int error_num);
-
-int
-perform_semop(int sem_id, short index, short op, short flags, struct timespec *ts);
-
-void *
-acquire_semaphore_without_gvl(void *p);
 
 #endif //SEMIAN_H

--- a/ext/semian/semian.h
+++ b/ext/semian/semian.h
@@ -7,33 +7,9 @@ Implements Init_semian, which is used as C/Ruby entrypoint.
 #ifndef SEMIAN_H
 #define SEMIAN_H
 
-// System includes
-#include <errno.h>
-#include <string.h>
-#include <stdio.h>
-
-// 3rd party includes
-#include <openssl/sha.h>
-#include <ruby.h>
-#include <ruby/util.h>
-#include <ruby/io.h>
-
-//semian includes
+// semian includes
 #include "types.h"
 #include "resource.h"
-#include "sysv_semaphores.h"
-
-// FIXME: This is needed here temporarily
-// Defines for ruby threading primitives
-#if defined(HAVE_RB_THREAD_CALL_WITHOUT_GVL) && defined(HAVE_RUBY_THREAD_H)
-// 2.0
-#include <ruby/thread.h>
-#define WITHOUT_GVL(fn,a,ubf,b) rb_thread_call_without_gvl((fn),(a),(ubf),(b))
-#elif defined(HAVE_RB_THREAD_BLOCKING_REGION)
- // 1.9
-typedef VALUE (*my_blocking_fn_t)(void*);
-#define WITHOUT_GVL(fn,a,ubf,b) rb_thread_blocking_region((my_blocking_fn_t)(fn),(a),(ubf),(b))
-#endif
 
 void Init_semian();
 

--- a/ext/semian/sysv_semaphores.c
+++ b/ext/semian/sysv_semaphores.c
@@ -1,0 +1,128 @@
+#include <sysv_semaphores.h>
+
+void
+raise_semian_syscall_error(const char *syscall, int error_num)
+{
+  rb_raise(eSyscall, "%s failed, errno: %d (%s)", syscall, error_num, strerror(error_num));
+}
+
+key_t
+generate_key(const char *name)
+{
+  char semset_size_key[20];
+  char *uniq_id_str;
+
+  // It is necessary for the cardinatily of the semaphore set to be part of the key
+  // or else sem_get will complain that we have requested an incorrect number of sems
+  // for the desired key, and have changed the number of semaphores for a given key
+  sprintf(semset_size_key, "_NUM_SEMS_%d", SI_NUM_SEMAPHORES);
+  uniq_id_str = malloc(strlen(name)+strlen(semset_size_key)+1);
+  strcpy(uniq_id_str, name);
+  strcat(uniq_id_str, semset_size_key);
+
+  union {
+    unsigned char str[SHA_DIGEST_LENGTH];
+    key_t key;
+  } digest;
+  SHA1((const unsigned char *) uniq_id_str, strlen(uniq_id_str), digest.str);
+  free(uniq_id_str);
+  /* TODO: compile-time assertion that sizeof(key_t) > SHA_DIGEST_LENGTH */
+  return digest.key;
+}
+
+void
+set_semaphore_permissions(int sem_id, long permissions)
+{
+  union semun sem_opts;
+  struct semid_ds stat_buf;
+
+  sem_opts.buf = &stat_buf;
+  semctl(sem_id, 0, IPC_STAT, sem_opts);
+  if ((stat_buf.sem_perm.mode & 0xfff) != permissions) {
+    stat_buf.sem_perm.mode &= ~0xfff;
+    stat_buf.sem_perm.mode |= permissions;
+    semctl(sem_id, 0, IPC_SET, sem_opts);
+  }
+}
+
+int
+create_semaphore(int key, long permissions, int *created)
+{
+  int semid = 0;
+  int flags = 0;
+
+  *created = 0;
+  flags = IPC_EXCL | IPC_CREAT | permissions;
+
+  semid = semget(key, SI_NUM_SEMAPHORES, flags);
+  if (semid >= 0) {
+    *created = 1;
+  } else if (semid == -1 && errno == EEXIST) {
+    flags &= ~IPC_EXCL;
+    semid = semget(key, SI_NUM_SEMAPHORES, flags);
+  }
+  return semid;
+}
+
+
+int
+perform_semop(int sem_id, short index, short op, short flags, struct timespec *ts)
+{
+  struct sembuf buf = { 0 };
+
+  buf.sem_num = index;
+  buf.sem_op  = op;
+  buf.sem_flg = flags;
+
+  if (ts) {
+    return semtimedop(sem_id, &buf, 1, ts);
+  } else {
+    return semop(sem_id, &buf, 1);
+  }
+}
+
+int
+get_max_tickets(int sem_id)
+{
+  int ret = semctl(sem_id, SI_SEM_CONFIGURED_TICKETS, GETVAL);
+  if (ret == -1) {
+    rb_raise(eInternal, "error getting max ticket count, errno: %d (%s)", errno, strerror(errno));
+  }
+  return ret;
+}
+
+void
+sem_meta_lock(int sem_id)
+{
+  struct timespec ts = { 0 };
+  ts.tv_sec = INTERNAL_TIMEOUT;
+
+  if (perform_semop(sem_id, SI_SEM_LOCK, -1, SEM_UNDO, &ts) == -1) {
+    raise_semian_syscall_error("error acquiring internal semaphore lock, semtimedop()", errno);
+  }
+}
+
+void
+sem_meta_unlock(int sem_id)
+{
+  if (perform_semop(sem_id, SI_SEM_LOCK, 1, SEM_UNDO, NULL) == -1) {
+    raise_semian_syscall_error("error releasing internal semaphore lock, semop()", errno);
+  }
+}
+
+int
+get_semaphore(int key)
+{
+  return semget(key, SI_NUM_SEMAPHORES, 0);
+}
+
+void *
+acquire_semaphore_without_gvl(void *p)
+{
+  semian_resource_t *res = (semian_resource_t *) p;
+  res->error = 0;
+  if (perform_semop(res->sem_id, SI_SEM_TICKETS, -1, SEM_UNDO, &res->timeout) == -1) {
+    res->error = errno;
+  }
+  return NULL;
+}

--- a/ext/semian/sysv_semaphores.c
+++ b/ext/semian/sysv_semaphores.c
@@ -91,25 +91,6 @@ get_max_tickets(int sem_id)
   return ret;
 }
 
-void
-sem_meta_lock(int sem_id)
-{
-  struct timespec ts = { 0 };
-  ts.tv_sec = INTERNAL_TIMEOUT;
-
-  if (perform_semop(sem_id, SI_SEM_LOCK, -1, SEM_UNDO, &ts) == -1) {
-    raise_semian_syscall_error("error acquiring internal semaphore lock, semtimedop()", errno);
-  }
-}
-
-void
-sem_meta_unlock(int sem_id)
-{
-  if (perform_semop(sem_id, SI_SEM_LOCK, 1, SEM_UNDO, NULL) == -1) {
-    raise_semian_syscall_error("error releasing internal semaphore lock, semop()", errno);
-  }
-}
-
 int
 get_semaphore(int key)
 {

--- a/ext/semian/sysv_semaphores.h
+++ b/ext/semian/sysv_semaphores.h
@@ -1,0 +1,58 @@
+/*
+For manipulating the semian's semaphore set
+
+Semian semaphore operations and initialization,
+and functions associated directly weth semops.
+*/
+#ifndef SEMIAN_SEMSET_H
+#define SEMIAN_SEMSET_H
+
+// Time to wait for timed ops to complete
+#define INTERNAL_TIMEOUT 5 // seconds
+
+#include <semian.h>
+
+VALUE eSyscall, eTimeout, eInternal;
+
+// Helper for syscall verbose debugging
+void
+raise_semian_syscall_error(const char *syscall, int error_num);
+
+// Genurates a unique key for the semaphore from the resource id
+key_t
+generate_key(const char *name);
+
+// Set semaphore UNIX octal permissions
+void
+set_semaphore_permissions(int sem_id, long permissions);
+
+// Create a new sysV IPC semaphore set
+int
+create_semaphore(int key, long permissions, int *created);
+
+// Wrapper to performs a semop call
+// The call may be timed or untimed
+int
+perform_semop(int sem_id, short index, short op, short flags, struct timespec *ts);
+
+// Retrieve the current number of tickets in a semaphore by its semaphore index
+int
+get_max_tickets(int sem_id);
+
+// Obtain an exclusive lock on the semaphore set critical section
+void
+sem_meta_lock(int sem_id);
+
+// Release an exclusive lock on the semaphore set critical section
+void
+sem_meta_unlock(int sem_id);
+
+// Retrieve a semaphore's ID from its key
+int
+get_semaphore(int key);
+
+// Decrements the ticket semaphore within the semaphore set
+void *
+acquire_semaphore_without_gvl(void *p);
+
+#endif // SEMIAN_SEMSET_H

--- a/ext/semian/sysv_semaphores.h
+++ b/ext/semian/sysv_semaphores.h
@@ -30,7 +30,7 @@ typedef VALUE (*my_blocking_fn_t)(void*);
 #endif
 
 // Time to wait for timed ops to complete
-const int kInternalTimeout = 5; /* seconds */
+#define INTERNAL_TIMEOUT 5 /* seconds */
 
 VALUE eSyscall, eTimeout, eInternal;
 

--- a/ext/semian/sysv_semaphores.h
+++ b/ext/semian/sysv_semaphores.h
@@ -7,10 +7,31 @@ and functions associated directly weth semops.
 #ifndef SEMIAN_SEMSET_H
 #define SEMIAN_SEMSET_H
 
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <openssl/sha.h>
+#include <ruby.h>
+#include <ruby/util.h>
+#include <ruby/io.h>
+
+#include <types.h>
+
+// Defines for ruby threading primitives
+#if defined(HAVE_RB_THREAD_CALL_WITHOUT_GVL) && defined(HAVE_RUBY_THREAD_H)
+// 2.0
+#include <ruby/thread.h>
+#define WITHOUT_GVL(fn,a,ubf,b) rb_thread_call_without_gvl((fn),(a),(ubf),(b))
+#elif defined(HAVE_RB_THREAD_BLOCKING_REGION)
+ // 1.9
+typedef VALUE (*my_blocking_fn_t)(void*);
+#define WITHOUT_GVL(fn,a,ubf,b) rb_thread_blocking_region((my_blocking_fn_t)(fn),(a),(ubf),(b))
+#endif
+
 // Time to wait for timed ops to complete
 #define INTERNAL_TIMEOUT 5 // seconds
 
-#include <semian.h>
 
 VALUE eSyscall, eTimeout, eInternal;
 

--- a/ext/semian/sysv_semaphores.h
+++ b/ext/semian/sysv_semaphores.h
@@ -39,14 +39,6 @@ perform_semop(int sem_id, short index, short op, short flags, struct timespec *t
 int
 get_max_tickets(int sem_id);
 
-// Obtain an exclusive lock on the semaphore set critical section
-void
-sem_meta_lock(int sem_id);
-
-// Release an exclusive lock on the semaphore set critical section
-void
-sem_meta_unlock(int sem_id);
-
 // Retrieve a semaphore's ID from its key
 int
 get_semaphore(int key);

--- a/ext/semian/sysv_semaphores.h
+++ b/ext/semian/sysv_semaphores.h
@@ -30,8 +30,7 @@ typedef VALUE (*my_blocking_fn_t)(void*);
 #endif
 
 // Time to wait for timed ops to complete
-#define INTERNAL_TIMEOUT 5 // seconds
-
+const int kInternalTimeout = 5; /* seconds */
 
 VALUE eSyscall, eTimeout, eInternal;
 


### PR DESCRIPTION
# What

This moves sysv_semaphore related operations into their own files.

# How

The implementations from semian.c are moved to sysv_semaphores.c almost without changes.

Likewise, much of the prototypes from semian.h have been moved to sysv_semaphores.h. This also includes some macros and includes that are specific to sysv_semaphores.

The only thing I added was documentation above the function prototypes in sysv_semaphores.h

**note:* kInternalTimeout was replaced by #define INTERNAL_TIMEOUT because this was simpler than dealing with making this variable an extern.