### PR TITLE
Create sem_meta_lock and sem_meta_unlock

### DIFF
--- a/ext/semian/sysv_semaphores.c
+++ b/ext/semian/sysv_semaphores.c
@@ -91,6 +91,25 @@ get_max_tickets(int sem_id)
   return ret;
 }
 
+void
+sem_meta_lock(int sem_id)
+{
+  struct timespec ts = { 0 };
+  ts.tv_sec = INTERNAL_TIMEOUT;
+
+  if (perform_semop(sem_id, SI_SEM_LOCK, -1, SEM_UNDO, &ts) == -1) {
+    raise_semian_syscall_error("error acquiring internal semaphore lock, semtimedop()", errno);
+  }
+}
+
+void
+sem_meta_unlock(int sem_id)
+{
+  if (perform_semop(sem_id, SI_SEM_LOCK, 1, SEM_UNDO, NULL) == -1) {
+    raise_semian_syscall_error("error releasing internal semaphore lock, semop()", errno);
+  }
+}
+
 int
 get_semaphore(int key)
 {

--- a/ext/semian/sysv_semaphores.h
+++ b/ext/semian/sysv_semaphores.h
@@ -59,6 +59,14 @@ perform_semop(int sem_id, short index, short op, short flags, struct timespec *t
 int
 get_max_tickets(int sem_id);
 
+// Obtain an exclusive lock on the semaphore set critical section
+void
+sem_meta_lock(int sem_id);
+
+// Release an exclusive lock on the semaphore set critical section
+void
+sem_meta_unlock(int sem_id);
+
 // Retrieve a semaphore's ID from its key
 int
 get_semaphore(int key);


### PR DESCRIPTION
# What

Helpers to protect critical sections when operating on the semaphores directly (manipulating ticket counts)

# Why

Currently only one use, but will be needed for additional ticket management strategies (particularly, the upcoming quota strategy).

In another upcoming PR, i'll be cleaning up the ticket management and having this PR in place helps tidy that up.