### PR TITLE
Refactor get_max_tickets to be a more generic get_sem_val

### DIFF
--- a/ext/semian/sysv_semaphores.c
+++ b/ext/semian/sysv_semaphores.c
@@ -1,6 +1,7 @@
 #include <sysv_semaphores.h>
 
-const char *SEMINDEX_STRING[] = {
+// Generate string rep for sem indices for debugging puproses
+static const char *SEMINDEX_STRING[] = {
     FOREACH_SEMINDEX(GENERATE_STRING)
 };
 

--- a/ext/semian/sysv_semaphores.c
+++ b/ext/semian/sysv_semaphores.c
@@ -1,5 +1,9 @@
 #include <sysv_semaphores.h>
 
+const char *SEMINDEX_STRING[] = {
+    FOREACH_SEMINDEX(GENERATE_STRING)
+};
+
 void
 raise_semian_syscall_error(const char *syscall, int error_num)
 {
@@ -82,11 +86,11 @@ perform_semop(int sem_id, short index, short op, short flags, struct timespec *t
 }
 
 int
-get_max_tickets(int sem_id)
+get_sem_val(int sem_id, int sem_index)
 {
-  int ret = semctl(sem_id, SI_SEM_CONFIGURED_TICKETS, GETVAL);
+  int ret = semctl(sem_id, sem_index, GETVAL);
   if (ret == -1) {
-    rb_raise(eInternal, "error getting max ticket count, errno: %d (%s)", errno, strerror(errno));
+    rb_raise(eInternal, "error getting value of %s, errno: %d (%s)", SEMINDEX_STRING[sem_index], errno, strerror(errno));
   }
   return ret;
 }

--- a/ext/semian/sysv_semaphores.h
+++ b/ext/semian/sysv_semaphores.h
@@ -54,10 +54,6 @@ enum SEMINDEX_ENUM {
     FOREACH_SEMINDEX(GENERATE_ENUM)
 };
 
-// Generate string rep for sem indices for debugging puproses
-extern const char *SEMINDEX_STRING[];
-
-
 VALUE eSyscall, eTimeout, eInternal;
 
 // Helper for syscall verbose debugging

--- a/ext/semian/sysv_semaphores.h
+++ b/ext/semian/sysv_semaphores.h
@@ -32,6 +32,32 @@ typedef VALUE (*my_blocking_fn_t)(void*);
 // Time to wait for timed ops to complete
 #define INTERNAL_TIMEOUT 5 /* seconds */
 
+// Here we define an enum value and string representation of each semaphore
+// This allows us to key the sem value and string rep in sync easily
+// utilizing pre-processor macros.
+// If you're unfamiliar with this pattern, this is using "x macros"
+//   SI_SEM_TICKETS             semaphore for the tickets currently issued
+//   SI_SEM_CONFIGURED_TICKETS  semaphore to track the desired number of tickets available for issue
+//   SI_SEM_LOCK                metadata lock to act as a mutex, ensuring thread-safety for updating other semaphores
+//   SI_NUM_SEMAPHORES          always leave this as last entry for count to be accurate
+#define FOREACH_SEMINDEX(SEMINDEX) \
+        SEMINDEX(SI_SEM_TICKETS)   \
+        SEMINDEX(SI_SEM_CONFIGURED_TICKETS)  \
+        SEMINDEX(SI_SEM_LOCK)   \
+        SEMINDEX(SI_NUM_SEMAPHORES)  \
+
+#define GENERATE_ENUM(ENUM) ENUM,
+#define GENERATE_STRING(STRING) #STRING,
+
+// Generate enum for sem indices
+enum SEMINDEX_ENUM {
+    FOREACH_SEMINDEX(GENERATE_ENUM)
+};
+
+// Generate string rep for sem indices for debugging puproses
+extern const char *SEMINDEX_STRING[];
+
+
 VALUE eSyscall, eTimeout, eInternal;
 
 // Helper for syscall verbose debugging
@@ -57,7 +83,7 @@ perform_semop(int sem_id, short index, short op, short flags, struct timespec *t
 
 // Retrieve the current number of tickets in a semaphore by its semaphore index
 int
-get_max_tickets(int sem_id);
+get_sem_val(int sem_id, int sem_index);
 
 // Obtain an exclusive lock on the semaphore set critical section
 void

--- a/ext/semian/types.h
+++ b/ext/semian/types.h
@@ -33,13 +33,4 @@ typedef struct {
   char *name;
 } semian_resource_t;
 
-// FIXME: move this to more appropriate location once the file exists
-typedef enum
-{
-  SI_SEM_TICKETS,            // semaphore for the tickets currently issued
-  SI_SEM_CONFIGURED_TICKETS, // semaphore to track the desired number of tickets available for issue
-  SI_SEM_LOCK,               // metadata lock to act as a mutex, ensuring thread-safety for updating other semaphores
-  SI_NUM_SEMAPHORES          // always leave this as last entry for count to be accurate
-} semaphore_indices;
-
 #endif // SEMIAN_TYPES_H


### PR DESCRIPTION
# What

replace get_max_tickets with a more generic get_sem_val, to be used to retrieve the value of an arbitrary semaphore in the set.

# How

The function has been refactored to accept a second parameter - the index to use.

I also moved the semian indices to be generated via a C pre-processor technique called "x macros".

**Before you run away screaming**, keep in mind that the x macro is a fairly elegant solution to keeping to data structures in sync in C, and is a standard pattern for **exactly** this type of application. 

The x macro is utilized to keep the enum symbols and strings in sync. This allows for us to easily print which semaphore is being operated on for debugging purposes, or any time we would like to "pretty print" a semaphore by ID.