### PR TITLE
Support quota based allocation strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 /html/
 Gemfile.lock
 vendor/
+*.swp
+*.swo
+nohup.out

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,7 +35,7 @@ Style/DoubleNegation:
   Enabled: false
 
 Metrics/LineLength:
-  Max: 135
+  Max: 150
 
 Metrics/MethodLength:
   Max: 40

--- a/ext/semian/extconf.rb
+++ b/ext/semian/extconf.rb
@@ -25,7 +25,7 @@ have_func 'rb_thread_call_without_gvl'
 
 $CFLAGS = "-D_GNU_SOURCE -Werror -Wall "
 if ENV.key?('DEBUG')
-  $CFLAGS << "-O0 -g"
+  $CFLAGS << "-O0 -g -DDEBUG"
 else
   $CFLAGS << "-O3"
 end

--- a/ext/semian/resource.c
+++ b/ext/semian/resource.c
@@ -3,6 +3,12 @@
 static VALUE
 cleanup_semian_resource_acquire(VALUE self);
 
+static void
+check_tickets_xor_quota_arg(VALUE tickets, VALUE quota);
+
+static double
+check_quota_arg(VALUE quota);
+
 static int
 check_tickets_arg(VALUE tickets);
 
@@ -63,9 +69,20 @@ semian_resource_acquire(int argc, VALUE *argv, VALUE self)
 VALUE
 semian_resource_destroy(VALUE self)
 {
+  struct timespec ts = { 0 };
+  ts.tv_sec = INTERNAL_TIMEOUT;
+
   semian_resource_t *res = NULL;
 
   TypedData_Get_Struct(self, semian_resource_t, &semian_resource_type, res);
+
+  // Prevent a race to deletion
+  if (perform_semop(res->sem_id, SI_SEM_LOCK, -1, 0, &ts) == -1) {
+    if (errno == EINVAL || errno == EIDRM) {
+      return Qtrue;
+    }
+  }
+
   if (semctl(res->sem_id, SI_NUM_SEMAPHORES, IPC_RMID) == -1) {
     raise_semian_syscall_error("semctl()", errno);
   }
@@ -89,6 +106,21 @@ semian_resource_count(VALUE self)
 }
 
 VALUE
+semian_resource_tickets(VALUE self)
+{
+  int ret;
+  semian_resource_t *res = NULL;
+
+  TypedData_Get_Struct(self, semian_resource_t, &semian_resource_type, res);
+  ret = semctl(res->sem_id, SI_SEM_CONFIGURED_TICKETS, GETVAL);
+  if (ret == -1) {
+    raise_semian_syscall_error("semctl()", errno);
+  }
+
+  return LONG2FIX(ret);
+}
+
+VALUE
 semian_resource_id(VALUE self)
 {
   semian_resource_t *res = NULL;
@@ -97,17 +129,18 @@ semian_resource_id(VALUE self)
 }
 
 VALUE
-semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE permissions, VALUE default_timeout)
+semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VALUE permissions, VALUE default_timeout)
 {
-  key_t key;
-  int c_permissions;
+  long c_permissions;
   double c_timeout;
+  double c_quota;
   int c_tickets;
-  int created = 0;
   semian_resource_t *res = NULL;
   const char *c_id_str = NULL;
 
   // Check and cast arguments
+  check_tickets_xor_quota_arg(tickets, quota);
+  c_quota = check_quota_arg(quota);
   c_tickets = check_tickets_arg(tickets);
   c_permissions = check_permissions_arg(permissions);
   c_id_str = check_id_arg(id);
@@ -119,19 +152,8 @@ semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE permission
   // Populate struct fields
   ms_to_timespec(c_timeout * 1000, &res->timeout);
   res->name = strdup(c_id_str);
-
-  // Get or create semaphore set
-  //  note that tickets = 0 will be used to acquire a semaphore set after it's been created elswhere
-  key = generate_key(c_id_str);
-  res->sem_id = c_tickets == 0 ? get_semaphore(key) : create_semaphore(key, c_permissions, &created);
-  if (res->sem_id == -1) {
-    raise_semian_syscall_error("semget()", errno);
-  }
-
-  set_semaphore_permissions(res->sem_id, c_permissions);
-
-  // Configure semaphore ticket counts
-  configure_tickets(res->sem_id, c_tickets, created);
+  res->quota = c_quota;
+  res->sem_id = initialize_semaphore_set(c_id_str, c_permissions, c_tickets, c_quota);
 
   return self;
 }
@@ -160,6 +182,33 @@ check_permissions_arg(VALUE permissions)
 {
   Check_Type(permissions, T_FIXNUM);
   return FIX2LONG(permissions);
+}
+
+static void
+check_tickets_xor_quota_arg(VALUE tickets, VALUE quota)
+{
+  if ((TYPE(tickets) == T_NIL && TYPE(quota) == T_NIL) ||(TYPE(tickets) != T_NIL && TYPE(quota) != T_NIL)){
+    rb_raise(rb_eArgError, "Must pass exactly one of ticket or quota");
+  }
+}
+
+static double
+check_quota_arg(VALUE quota)
+{
+  double c_quota;
+
+  if (TYPE(quota) != T_NIL) {
+    if (TYPE(quota) != T_FIXNUM && TYPE(quota) != T_FLOAT) {
+      rb_raise(rb_eTypeError, "expected decimal type for quota");
+    }
+    if (NUM2DBL(quota) <= 0 || NUM2DBL(quota) > 1) {
+      rb_raise(rb_eArgError, "quota must be a decimal between 0 and 1");
+    }
+    c_quota = NUM2DBL(quota);
+  } else {
+    c_quota = -1.0f;
+  }
+  return c_quota;
 }
 
 static int

--- a/ext/semian/resource.h
+++ b/ext/semian/resource.h
@@ -7,7 +7,6 @@ Functions here are associated with rubyland operations.
 #define SEMIAN_RESOURCE_H
 
 #include "types.h"
-#include "tickets.h"
 #include "sysv_semaphores.h"
 
 // Ruby variables
@@ -16,12 +15,12 @@ int system_max_semaphore_count;
 
 /*
  * call-seq:
- *    Semian::Resource.new(id, tickets, permissions, default_timeout) -> resource
+ *    Semian::Resource.new(id, tickets, quota, permissions, default_timeout) -> resource
  *
  * Creates a new Resource. Do not create resources directly. Use Semian.register.
  */
 VALUE
-semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE permissions, VALUE default_timeout);
+semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VALUE permissions, VALUE default_timeout);
 
 /*
  * call-seq:
@@ -58,6 +57,15 @@ semian_resource_destroy(VALUE self);
  */
 VALUE
 semian_resource_count(VALUE self);
+
+/*
+ * call-seq:
+ *    resource.tickets -> count
+ *
+ * Returns the configured number of tickets for a resource.
+ */
+VALUE
+semian_resource_tickets(VALUE self);
 
 /*
  * call-seq:

--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -42,10 +42,11 @@ void Init_semian()
   eInternal = rb_const_get(cSemian, rb_intern("InternalError"));
 
   rb_define_alloc_func(cResource, semian_resource_alloc);
-  rb_define_method(cResource, "initialize_semaphore", semian_resource_initialize, 4);
+  rb_define_method(cResource, "initialize_semaphore", semian_resource_initialize, 5);
   rb_define_method(cResource, "acquire", semian_resource_acquire, -1);
   rb_define_method(cResource, "count", semian_resource_count, 0);
   rb_define_method(cResource, "semid", semian_resource_id, 0);
+  rb_define_method(cResource, "tickets", semian_resource_tickets, 0);
   rb_define_method(cResource, "destroy", semian_resource_destroy, 0);
 
   id_timeout = rb_intern("timeout");

--- a/ext/semian/sysv_semaphores.h
+++ b/ext/semian/sysv_semaphores.h
@@ -17,6 +17,7 @@ and functions associated directly weth semops.
 #include <ruby/io.h>
 
 #include "types.h"
+#include "tickets.h"
 
 // Defines for ruby threading primitives
 #if defined(HAVE_RB_THREAD_CALL_WITHOUT_GVL) && defined(HAVE_RUBY_THREAD_H)
@@ -32,18 +33,26 @@ typedef VALUE (*my_blocking_fn_t)(void*);
 // Time to wait for timed ops to complete
 #define INTERNAL_TIMEOUT 5 /* seconds */
 
+// Time to wait while checking if semaphore has been initialized
+#define INIT_WAIT 10 /* microseconds */
+
+// Helper definition to prevent magic number for conversion of microseconds to seconds
+#define MICROSECONDS_IN_SECOND 1000000
+
 // Here we define an enum value and string representation of each semaphore
 // This allows us to key the sem value and string rep in sync easily
 // utilizing pre-processor macros.
 // If you're unfamiliar with this pattern, this is using "x macros"
+//   SI_SEM_LOCK                metadata lock to act as a mutex, ensuring thread-safety for updating other semaphores
 //   SI_SEM_TICKETS             semaphore for the tickets currently issued
 //   SI_SEM_CONFIGURED_TICKETS  semaphore to track the desired number of tickets available for issue
-//   SI_SEM_LOCK                metadata lock to act as a mutex, ensuring thread-safety for updating other semaphores
+//   SI_SEM_REGISTERED_WORKERS  semaphore for the number of workers currently registered
 //   SI_NUM_SEMAPHORES          always leave this as last entry for count to be accurate
 #define FOREACH_SEMINDEX(SEMINDEX) \
+        SEMINDEX(SI_SEM_LOCK)   \
         SEMINDEX(SI_SEM_TICKETS)   \
         SEMINDEX(SI_SEM_CONFIGURED_TICKETS)  \
-        SEMINDEX(SI_SEM_LOCK)   \
+        SEMINDEX(SI_SEM_REGISTERED_WORKERS)  \
         SEMINDEX(SI_NUM_SEMAPHORES)  \
 
 #define GENERATE_ENUM(ENUM) ENUM,
@@ -60,9 +69,9 @@ VALUE eSyscall, eTimeout, eInternal;
 void
 raise_semian_syscall_error(const char *syscall, int error_num);
 
-// Genurates a unique key for the semaphore from the resource id
-key_t
-generate_key(const char *name);
+// Initialize the sysv semaphore structure
+int
+initialize_semaphore_set(const char* id_str, long permissions, int tickets, double quota);
 
 // Set semaphore UNIX octal permissions
 void
@@ -96,5 +105,18 @@ get_semaphore(int key);
 // Decrements the ticket semaphore within the semaphore set
 void *
 acquire_semaphore_without_gvl(void *p);
+
+#ifdef DEBUG
+static inline void
+print_sem_vals(int sem_id)
+{
+  printf("lock %d, tickets: %d configured: %d, registered workers %d\n",
+   get_sem_val(sem_id, SI_SEM_LOCK),
+   get_sem_val(sem_id, SI_SEM_TICKETS),
+   get_sem_val(sem_id, SI_SEM_CONFIGURED_TICKETS),
+   get_sem_val(sem_id, SI_SEM_REGISTERED_WORKERS)
+  );
+}
+#endif
 
 #endif // SEMIAN_SEMSET_H

--- a/ext/semian/tickets.h
+++ b/ext/semian/tickets.h
@@ -6,12 +6,8 @@ For logic specific to manipulating semian ticket counts
 
 #include "sysv_semaphores.h"
 
-// Update the ticket count for static ticket tracking
-VALUE
-update_ticket_count(update_ticket_count_t *tc);
-
 // Set initial ticket values upon resource creation
 void
-configure_tickets(int sem_id, int tickets, int should_initialize);
+configure_tickets(int sem_id, int tickets, double quota);
 
 #endif // SEMIAN_TICKETS_H

--- a/ext/semian/types.h
+++ b/ext/semian/types.h
@@ -29,6 +29,7 @@ typedef struct {
 typedef struct {
   int sem_id;
   struct timespec timeout;
+  double quota;
   int error;
   char *name;
 } semian_resource_t;

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -120,6 +120,12 @@ module Semian
   #
   # +tickets+: Number of tickets. If this value is 0, the ticket count will not be set,
   # but the resource must have been previously registered otherwise an error will be raised.
+  # Mutually exclusive with the 'quota' argument.
+  #
+  # +quota+: Calculate tickets as a ratio of the number of registered workers.
+  # Must be greater than 0, less than or equal to 1. There will always be at least 1 ticket, as it
+  # is calculated as (workers * quota).ceil
+  # Mutually exclusive with the 'ticket' argument.
   #
   # +permissions+: Octal permissions of the resource.
   #
@@ -134,7 +140,7 @@ module Semian
   # +exceptions+: An array of exception classes that should be accounted as resource errors.
   #
   # Returns the registered resource.
-  def register(name, tickets:, permissions: 0660, timeout: 0, error_threshold:, error_timeout:, success_threshold:, exceptions: [])
+  def register(name, tickets: nil, quota: nil, permissions: 0660, timeout: 0, error_threshold:, error_timeout:, success_threshold:, exceptions: [])
     circuit_breaker = CircuitBreaker.new(
       name,
       success_threshold: success_threshold,
@@ -143,7 +149,7 @@ module Semian
       exceptions: Array(exceptions) + [::Semian::BaseError],
       implementation: ::Semian::Simple,
     )
-    resource = Resource.new(name, tickets: tickets, permissions: permissions, timeout: timeout)
+    resource = Resource.instance(name, tickets: tickets, quota: quota, permissions: permissions, timeout: timeout)
     resources[name] = ProtectedResource.new(resource, circuit_breaker)
   end
 

--- a/lib/semian/resource.rb
+++ b/lib/semian/resource.rb
@@ -2,14 +2,20 @@ module Semian
   class Resource #:nodoc:
     attr_reader :tickets, :name
 
-    def initialize(name, tickets:, permissions: 0660, timeout: 0)
+    class << Semian::Resource
+      # Ensure that there can only be one resource of a given type
+      def instance(*args)
+        Semian.resources[args.first] ||= new(*args)
+      end
+    end
+
+    def initialize(name, tickets: nil, quota: nil, permissions: 0660, timeout: 0)
       if Semian.semaphores_enabled?
-        initialize_semaphore(name, tickets, permissions, timeout) if respond_to?(:initialize_semaphore)
+        initialize_semaphore(name, tickets, quota, permissions, timeout) if respond_to?(:initialize_semaphore)
       else
         Semian.issue_disabled_semaphores_warning
       end
       @name = name
-      @tickets = tickets
     end
 
     def destroy
@@ -20,6 +26,10 @@ module Semian
     end
 
     def count
+      0
+    end
+
+    def tickets
       0
     end
 

--- a/semian.gemspec
+++ b/semian.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
     across process boundaries with SysV semaphores.
   DOC
   s.homepage = 'https://github.com/shopify/semian'
-  s.authors = ['Scott Francis', 'Simon Eskildsen']
+  s.authors = ['Scott Francis', 'Simon Eskildsen', 'Dale Hamel']
   s.email = 'scott.francis@shopify.com'
   s.license = 'MIT'
 

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -9,6 +9,8 @@ class TestResource < Minitest::Test
 
   def teardown
     destroy_resources
+    signal_workers('KILL')
+    Process.waitall
   end
 
   def test_initialize_invalid_args
@@ -40,9 +42,50 @@ class TestResource < Minitest::Test
     create_resource :testing, tickets: 2
   end
 
+  def test_register_with_quota
+    create_resource :testing, quota: 0.5
+  end
+
+  def test_exactly_one_register_with_quota
+    r = Semian::Resource.instance(:testing, quota: 0.5)
+
+    10.times do
+      Semian::Resource.instance(:testing, quota: 0.5)
+    end
+
+    assert_equal 1, r.tickets
+    r.destroy
+  end
+
+  def test_register_with_invalid_quota
+    assert_raises ArgumentError do
+      create_resource :testing, quota: 2.0
+    end
+
+    assert_raises ArgumentError do
+      create_resource :testing, quota: 0
+    end
+
+    assert_raises ArgumentError do
+      create_resource :testing, quota: -1.0
+    end
+  end
+
+  def test_register_with_quota_and_tickets_raises
+    assert_raises ArgumentError do
+      create_resource :testing, tickets: 2, quota: 0.5
+    end
+  end
+
+  def test_register_with_neither_quota_nor_tickets_raises
+    assert_raises ArgumentError do
+      create_resource :testing
+    end
+  end
+
   def test_register_with_no_tickets_raises
     assert_raises Semian::SyscallError do
-      create_resource :testing, tickets: 0
+      create_resource :test_raises, tickets: 0
     end
   end
 
@@ -60,57 +103,23 @@ class TestResource < Minitest::Test
   end
 
   def test_acquire_timeout
-    resource = create_resource :testing, tickets: 1, timeout: 0.05
-
-    acquired = false
-    m = Monitor.new
-    cond = m.new_cond
-
-    t = Thread.start do
-      m.synchronize do
-        cond.wait_until { acquired }
-        assert_raises Semian::TimeoutError do
-          resource.acquire { refute true }
-        end
-      end
-    end
-
-    resource.acquire do
-      acquired = true
-      m.synchronize { cond.signal }
-      sleep 0.2
-    end
-
-    t.join
-
-    assert acquired
+    fork_workers(count: 2, tickets: 1, timeout: 1, wait_for_timeout: true)
+    signal_workers('TERM')
+    timeouts = count_worker_timeouts
+    assert 1, timeouts
   end
 
   def test_acquire_timeout_override
-    resource = create_resource :testing, tickets: 1, timeout: 0.01
-
-    acquired = false
-    thread_acquired = false
-    m = Monitor.new
-    cond = m.new_cond
-
-    t = Thread.start do
-      m.synchronize do
-        cond.wait_until { acquired }
-        resource.acquire(timeout: 1) { thread_acquired = true }
-      end
+    fork_workers(count: 1, tickets: 1, timeout: 0.5, wait_for_timeout: true) do
+      sleep 0.6
     end
 
-    resource.acquire do
-      acquired = true
-      m.synchronize { cond.signal }
-      sleep 0.2
-    end
+    fork_workers(count: 1, tickets: 1, timeout: 1, wait_for_timeout: true)
 
-    t.join
+    signal_workers('TERM')
 
-    assert acquired
-    assert thread_acquired
+    timeouts = count_worker_timeouts
+    assert 0, timeouts
   end
 
   def test_acquire_with_fork
@@ -127,10 +136,117 @@ class TestResource < Minitest::Test
           exit! 0
         end
       end
+      timeouts = count_worker_timeouts
 
-      timeouts = Process.waitall.count { |s| s.last.exitstatus == 100 }
       assert_equal(1, timeouts)
     end
+  end
+
+  def test_quota_acquire
+    quota = 0.5
+    workers = 9
+
+    resource = create_resource :testing, quota: quota, timeout: 0.1
+    fork_workers(count: workers, quota: quota, wait_for_timeout: true)
+
+    # Ensure that the number of tickets is correct and none are remaining
+    assert_equal quota * (workers + 1), resource.tickets
+    assert_equal 0, resource.count
+
+    # Ensure that no more tickets may be allocated
+    assert_raises Semian::TimeoutError do
+      resource.acquire {}
+    end
+
+    signal_workers('TERM')
+
+    # Ensure the correct number of processes timed out
+    timeouts = count_worker_timeouts
+    assert_equal workers - ((1 - quota) * workers).ceil, timeouts
+
+    # Ensure that the tickets were released
+    assert_equal resource.tickets, resource.count
+  end
+
+  def test_quota_increase
+    quota = 0.5
+    new_quota = 0.7
+    workers = 20
+
+    # Spawn some workers with an initial quota
+    fork_workers(count: workers - 1, quota: quota, timeout: 0.5, wait_for_timeout: true)
+    resource = create_resource :testing, quota: new_quota, timeout: 0.1
+
+    assert_equal((workers * new_quota).ceil, resource.tickets)
+  end
+
+  def test_quota_decrease
+    quota = 0.5
+    new_quota = 0.3
+    workers = 20
+
+    # Spawn some workers with an initial quota
+    fork_workers(count: workers - 1, quota: quota, timeout: 0.5, wait_for_timeout: true) do
+      sleep 1
+    end
+
+    # We need to signal here to be able to enter the critical section
+    signal_workers('TERM')
+    resource = create_resource :testing, quota: new_quota, timeout: 0.1
+
+    assert_equal((workers * new_quota).ceil, resource.tickets)
+  end
+
+  def test_quota_sets_tickets_from_workers
+    quota = 0.5
+    workers = 50
+
+    resource = create_resource :testing, quota: quota, timeout: 0.1
+    fork_workers(count: workers - 1, quota: quota, wait_for_timeout: true)
+
+    assert_equal((workers * quota).ceil, resource.tickets)
+  end
+
+  def test_quota_adjust_tickets_on_new_workers
+    quota = 0.5
+    workers = 50
+
+    resource = create_resource :testing, quota: quota, timeout: 0.1
+
+    # Spawn some workers to get a basis for the quota
+    fork_workers(count: workers - 1, quota: quota, wait_for_timeout: true)
+    assert_equal((workers * quota).ceil, resource.tickets)
+
+    # Add more workers to ensure the number of tickets increases
+    fork_workers(count: workers - 1, quota: quota, wait_for_timeout: true)
+    assert_equal((2 * workers * quota).ceil, resource.tickets)
+  end
+
+  def test_quota_adjust_tickets_on_kill
+    quota = 0.5
+    workers = 50
+
+    resource = create_resource :testing, quota: quota, timeout: 0.1
+
+    # Spawn some workers to get a basis for the quota
+    fork_workers(count: workers - 1, quota: quota, wait_for_timeout: true)
+    assert_equal((workers * quota).ceil, resource.tickets)
+
+    # Signal and wait for the workers to quit
+    signal_workers('KILL')
+    Process.waitall
+
+    # Number of tickets should be unchanged until resource is created
+    assert_equal((workers * quota).ceil, resource.tickets)
+
+    resource = create_resource :testing, quota: quota, timeout: 0.1
+    assert_equal 1, resource.tickets
+  end
+
+  def test_quota_minimum_one_ticket
+    resource = create_resource :testing, quota: 0.1, timeout: 0.1
+
+    assert_equal 1, resource.tickets
   end
 
   def test_acquire_releases_on_kill
@@ -198,18 +314,25 @@ class TestResource < Minitest::Test
     end
   end
 
+  def test_destroy_already_destroyed
+    resource = create_resource :testing, tickets: 1
+    100.times do
+      resource.destroy
+    end
+  end
+
   def test_permissions
-    resource = create_resource :testing, permissions: 0600, tickets: 1
+    resource = create_resource :testing, permissions: 0o600, tickets: 1
     semid = resource.semid
-    `ipcs -s `.lines.each do |line|
+    `ipcs -s`.lines.each do |line|
       if /\s#{semid}\s/.match(line)
         assert_equal '600', line.split[3]
       end
     end
 
-    resource = create_resource :testing, permissions: 0660, tickets: 1
+    resource = create_resource :testing, permissions: 0o660, tickets: 1
     semid = resource.semid
-    `ipcs -s `.lines.each do |line|
+    `ipcs -s`.lines.each do |line|
       if /\s#{semid}\s/.match(line)
         assert_equal '660', line.split[3]
       end
@@ -219,90 +342,76 @@ class TestResource < Minitest::Test
   def test_resize_tickets_increase
     resource = create_resource :testing, tickets: 1
 
-    acquired = false
-    m = Monitor.new
-    cond = m.new_cond
-
-    t = Thread.start do
-      m.synchronize do
-        cond.wait_until { acquired }
-
-        resource = create_resource :testing, tickets: 5
-        assert_equal 4, resource.count
-      end
-    end
-
+    assert_equal resource.tickets, resource.count
     assert_equal 1, resource.count
 
-    resource.acquire do
-      acquired = true
-      m.synchronize { cond.signal }
-      sleep 0.2
-    end
+    fork_workers(count: 1, tickets: 5, timeout: 1, wait_for_timeout: true)
 
-    t.join
+    signal_workers('TERM')
+    Process.waitall
 
+    assert_equal resource.tickets, resource.count
     assert_equal 5, resource.count
   end
 
   def test_resize_tickets_decrease
     resource = create_resource :testing, tickets: 5
 
-    acquired = false
-    m = Monitor.new
-    cond = m.new_cond
-
-    t = Thread.start do
-      m.synchronize do
-        cond.wait_until { acquired }
-
-        resource = create_resource :testing, tickets: 1
-        assert_equal 0, resource.count
-      end
-    end
-
+    assert_equal resource.tickets, resource.count
     assert_equal 5, resource.count
 
-    resource.acquire do
-      acquired = true
-      m.synchronize { cond.signal }
-      sleep 0.2
-    end
+    fork_workers(count: 1, tickets: 1, timeout: 1, wait_for_timeout: true)
+    signal_workers('TERM')
+    Process.waitall
 
-    t.join
-
+    assert_equal resource.tickets, resource.count
     assert_equal 1, resource.count
   end
 
-  def test_multiple_register_with_fork
-    f = Tempfile.new('semian_test')
+  def test_resize_tickets_decrease_with_fork
+    tickets = 10
+    workers = 50
 
-    begin
-      f.flock(File::LOCK_EX)
+    resource = create_resource :testing, tickets: tickets
 
-      children = []
-      5.times do
-        children << fork do
-          acquired = false
-
-          f.flock(File::LOCK_SH)
-          create_resource(:testing, tickets: 5).acquire do |resource|
-            assert resource.count < 5
-            acquired = true
-          end
-          assert acquired
-        end
-      end
-      children.compact!
-
-      f.flock(File::LOCK_UN)
-
-      children.delete(Process.wait) while children.any?
-
-      assert_equal 5, create_resource(:testing, tickets: 0).count
-    ensure
-      f.close!
+    # Need to have the processes sleep for a bit after they are signalled to die
+    fork_workers(count: workers, tickets: 0, wait_for_timeout: true) do
+      sleep 2
     end
+
+    assert_equal(tickets, resource.tickets)
+    assert_equal(0, resource.count)
+
+    # Signal the workers to quit
+    signal_workers('TERM')
+
+    # Request the ticket count be adjusted immediately
+    # This should only return once the ticket count has been adjusted
+    # This is sort of racey, because it's waiting on enough workers to quit
+    # So that it has room to adjust the ticket count to the desired value.
+    # This must happen in less than 5 seconds, or an internal timeout occurs.
+    resource = create_resource :testing, tickets: (tickets / 2).floor
+
+    # Immediately on the above call returning, the tickets should be correct
+    assert_equal((tickets / 2).floor, resource.tickets)
+
+    # Wait for all other processes to quit
+    Process.waitall
+  end
+
+  def test_multiple_register_with_fork
+    count = 5
+    tickets = 5
+
+    fork_workers(resource: :testing, count: count, tickets: tickets, wait_for_timeout: true)
+    assert_equal 5, create_resource(:testing, tickets: 0).tickets
+    assert_equal 0, create_resource(:testing, tickets: 0).count
+
+    signal_workers('TERM')
+    timeouts = count_worker_timeouts
+
+    assert_equal 5, create_resource(:testing, tickets: 0).count
+    assert_equal 0, timeouts
   end
 
   def create_resource(*args)
@@ -322,5 +431,60 @@ class TestResource < Minitest::Test
       end
     end
     @resources = []
+  end
+
+  # Utility function to test with multiple processes
+  # In particular, this is necessary to ensure handling of unique PIDs is correct,
+  # which is key to functionality that is utilized like SEM_UNDO
+  # Active workers are accumulated in the instance variable @workers,
+  # and workers must be cleaned up between tests by the teardown script
+  # An exit value of 100 is to keep track of timeouts, 0 for success.
+  def fork_workers(count:, resource: :testing, quota: nil, tickets: nil, timeout: 0.1, wait_for_timeout: false)
+    fail 'Must provide at least one of tickets or quota' unless tickets || quota
+
+    @workers ||= []
+    count.times do
+      @workers << fork do
+        begin
+          resource = Semian::Resource.new(resource.to_sym, quota: quota, tickets: tickets, timeout: timeout)
+          resource.acquire do
+            # Hold the resource until signalled
+            # This helps to avoid race conditions in testing.
+            Signal.trap('TERM') do
+              yield if block_given?
+              exit! 0
+            end
+            sleep
+          end
+        rescue Semian::TimeoutError
+          Signal.trap('TERM') do
+            exit! 100
+          end
+          sleep
+        rescue => e
+          puts "Unhandled exception occurred in worker"
+          puts e
+          exit! 2
+        end
+      end
+    end
+    sleep((count / 2.0).ceil * timeout) if wait_for_timeout # give time for threads to timeout
+  end
+
+  def count_worker_timeouts
+    Process.waitall.count { |s| s.last.exitstatus == 100 }
+  end
+
+  # Signals all workers
+  def signal_workers(signal, delete: true)
+    return unless @workers
+    @workers.each do |worker|
+      begin
+        Process.kill(signal, worker)
+      rescue
+        nil
+      end
+    end
+    @workers = [] if delete
   end
 end


### PR DESCRIPTION
**Note:** This is still a work in progress - particularly I'm missing test coverage, but I'd like a preliminary review (low time investment) on the approach here. I want to make sure that it passes a basic "kick-the-tires" test before devoting more time to something I may potentially have to drastically change.

Specifically, I'm looking for:

* Things I've blatantly overlooked or misunderstood
* Design issues or shortcomings
* Edge cases that I've missed during testing
* Tests cases that I should add but haven't

This still contains some debug prints / reminders to myself, please ignore those.

For deploying this, I'd like to:

* Do a first round of review on the approach / tests as described above
* Ship existing semian changes as 0.6.3
* Finalize the review / acceptance of these changes
* Release this as 0.7.0 due to the new functionality it adds

# What

This implements a new strategy for ticket allocation that is based on the number of workers per the function:

```
ceil(workers * quota)
```

Such that the number of configured tickets shall always be proportional to the number of registered workers.

# How

* If a quota > 0 is specified, we toggle to using the 'quota' strategy instead of the 'static ticket count' strategy.
* Ticket counts provided by resource.ticket come directly from the number of configured tickets instead of a ruby instance variable, since this can now be variable
* Whenever a worker registers using the quota strategy, it increments SI_SEM_REGISTERED_WORKER
* Whenever the quota is updated based on SI_SEM_REGISTERED_WORKER, we set SI_SEM_CONFIGURED_WORKER to match SI_SEM_REGISTERED_WORKER, and configure SI_SEM_CONFIGURED_TICKETS according to the configured quota
* We updated the quotas on each call to acquire, in case there is a mismatch between the configured and registered workers

# Testing

The most difficult part of this PR so far has been developing a testing strategy.

I lost a fair bit of time trying to use the existing create_resource helper along with a forking strategy. This is doomed to failure, and will cause resources under tests to be spontaneously deleted, which is quite aggravating.

I tried a few other strategies, including spawning new ruby VMs to run a fixture script that would simply acquire a lock.

I ended up going back to a forking strategy, but manually keeping track of the forked PIDs.

The key here is the TRAP and SIGNAL approach I am using. Any forked child that manages to acquire the ticket will be sleep forever until it is signaled. This allow us to avoid guesswork and race conditions while reasoning about workers and ticket counts.

# Outstanding issues

* [ ] How should small ticket counts be address during, for instance, rolling deploys? Should a minimum ticket count be specified?
* [ ] How should 1 registration per worker be enforced?
* [ ] What should the bounds of a quota value be? Should a quota of 1 be allowed?

Fixes https://github.com/Shopify/semian/issues/98 (when done)