### PR TITLE
Refactor acquire_semaphore_without_gvl to always be WITHOUT_GVL

### DIFF
--- a/ext/semian/resource.c
+++ b/ext/semian/resource.c
@@ -48,7 +48,7 @@ semian_resource_acquire(int argc, VALUE *argv, VALUE self)
   }
 
   /* release the GVL to acquire the semaphore */
-  WITHOUT_GVL(acquire_semaphore_without_gvl, &res, RUBY_UBF_IO, NULL); // FIXME - replace with wrapped version
+  acquire_semaphore_without_gvl(&res);
   if (res.error != 0) {
     if (res.error == EAGAIN) {
       rb_raise(eTimeout, "timed out waiting for resource '%s'", res.name);

--- a/ext/semian/sysv_semaphores.c
+++ b/ext/semian/sysv_semaphores.c
@@ -1,5 +1,8 @@
 #include "sysv_semaphores.h"
 
+static void *
+acquire_semaphore(void *p);
+
 // Generate string rep for sem indices for debugging puproses
 static const char *SEMINDEX_STRING[] = {
     FOREACH_SEMINDEX(GENERATE_STRING)
@@ -123,6 +126,13 @@ get_semaphore(int key)
 
 void *
 acquire_semaphore_without_gvl(void *p)
+{
+  WITHOUT_GVL(acquire_semaphore, p, RUBY_UBF_IO, NULL);
+  return NULL;
+}
+
+static void *
+acquire_semaphore(void *p)
 {
   semian_resource_t *res = (semian_resource_t *) p;
   res->error = 0;


### PR DESCRIPTION
# What

Refactor acquire_semaphore_without_gvl so that it is **always** using WITHOUT_GVL

# How

```acquire_semaphore_without_gvl``` is refactored to be ```acquire_semaphore``` (which is what it actually does).

A new ```acquire_semaphore_without_gvl``` is defined that simply wraps  ```acquire_semaphore```, but always using ```WITHOUT_GVL```.

This way, the caller need not know about ```WITHOUT_GVL```, which it is already demanding when it issues ```acquire_semaphore_without_gvl```, as it's right in the name.