### PR TITLE
Fix the 'acquire_with_fork' test

### DIFF
--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -119,13 +119,17 @@ class TestResource < Minitest::Test
     resource.acquire do
       fork do
         resource.acquire do
-          assert_raises Semian::TimeoutError do
+          begin
             resource.acquire {}
+          rescue Semian::TimeoutError
+            exit! 100
           end
+          exit! 0
         end
       end
 
-      Process.wait
+      timeouts = Process.waitall.count { |s| s.last.exitstatus == 100 }
+      assert_equal(1, timeouts)
     end
   end
 


### PR DESCRIPTION
# What

I found a bug in this test. Because the assertion doesn't happen in the main process, the results are always ignored.

I fixed this test so that it can actually fail.

# How

Under the existing implementation, a forked process attempts to make an assertion.

The results of this minitest assertion will always be ignored by the parent process,
because the master process doesn't care about the exit status of the forked process.

To work around this, the exit status of the child process is used to determine if a
timeout has occured, and the assertion is run in the parent process, running the rest
of the test suite.