### PR TITLE
Break the coupling between the protected resource and circuit breaker

### DIFF
--- a/lib/semian/protected_resource.rb
+++ b/lib/semian/protected_resource.rb
@@ -2,34 +2,56 @@ module Semian
   class ProtectedResource
     extend Forwardable
 
-    def_delegators :@resource, :destroy, :count, :semid, :tickets, :name
+    def_delegators :@bulkhead, :destroy, :count, :semid, :tickets, :name
     def_delegators :@circuit_breaker, :reset, :mark_failed, :mark_success, :request_allowed?,
                    :open?, :closed?, :half_open?
 
-    def initialize(resource, circuit_breaker)
-      @resource = resource
+    attr_reader :bulkhead, :circuit_breaker
+
+    def initialize(bulkhead, circuit_breaker)
+      @bulkhead = bulkhead
       @circuit_breaker = circuit_breaker
     end
 
     def destroy
-      @resource.destroy
-      @circuit_breaker.destroy
+      @bulkhead.destroy unless @bulkhead.nil?
+      @circuit_breaker.destroy unless @circuit_breaker.nil?
     end
 
     def acquire(timeout: nil, scope: nil, adapter: nil)
-      @circuit_breaker.acquire do
-        begin
-          @resource.acquire(timeout: timeout) do
-            Semian.notify(:success, self, scope, adapter)
-            yield self
-          end
-        rescue ::Semian::TimeoutError
-          Semian.notify(:busy, self, scope, adapter)
-          raise
+      acquire_circuit_breaker(scope, adapter) do
+        acquire_bulkhead(timeout, scope, adapter) do
+          yield self
+        end
+      end
+    end
+
+    private
+
+    def acquire_circuit_breaker(scope, adapter)
+      if @circuit_breaker.nil?
+        yield self
+      else
+        @circuit_breaker.acquire do
+          yield self
         end
       end
     rescue ::Semian::OpenCircuitError
       Semian.notify(:circuit_open, self, scope, adapter)
+      raise
+    end
+
+    def acquire_bulkhead(timeout, scope, adapter)
+      if @bulkhead.nil?
+        yield self
+      else
+        @bulkhead.acquire(timeout: timeout) do
+          Semian.notify(:success, self, scope, adapter)
+          yield self
+        end
+      end
+    rescue ::Semian::TimeoutError
+      Semian.notify(:busy, self, scope, adapter)
       raise
     end
   end

--- a/lib/semian/unprotected_resource.rb
+++ b/lib/semian/unprotected_resource.rb
@@ -51,5 +51,13 @@ module Semian
 
     def mark_success
     end
+
+    def bulkhead
+      nil
+    end
+
+    def circuit_breaker
+      nil
+    end
   end
 end

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class TestCircuitBreaker < Minitest::Test
-  SomeError = Class.new(StandardError)
+  include CircuitBreakerHelper
 
   def setup
     begin
@@ -96,38 +96,5 @@ class TestCircuitBreaker < Minitest::Test
 
     assert_predicate @resource, :request_allowed?
     assert_predicate @resource, :open?
-  end
-
-  private
-
-  def open_circuit!(resource = @resource)
-    2.times { trigger_error!(resource) }
-  end
-
-  def half_open_cicuit!(resource = @resource)
-    Timecop.travel(Time.now - 10) do
-      open_circuit!(resource)
-    end
-  end
-
-  def trigger_error!(resource = @resource)
-    resource.acquire { raise SomeError }
-  rescue SomeError
-  end
-
-  def assert_circuit_closed(resource = @resource)
-    block_called = false
-    resource.acquire { block_called = true }
-    assert block_called, 'Expected the circuit to be closed, but it was open'
-  end
-
-  def assert_circuit_opened(resource = @resource)
-    open = false
-    begin
-      resource.acquire {}
-    rescue Semian::OpenCircuitError
-      open = true
-    end
-    assert open, 'Expected the circuit to be open, but it was closed'
   end
 end

--- a/test/helpers/circuit_breaker_helper.rb
+++ b/test/helpers/circuit_breaker_helper.rb
@@ -1,0 +1,36 @@
+module CircuitBreakerHelper
+  SomeError = Class.new(StandardError)
+
+  private
+
+  def open_circuit!(resource = @resource, error_count = 2)
+    error_count.times { trigger_error!(resource) }
+  end
+
+  def half_open_cicuit!(resource = @resource, backwards_time_travel = 10)
+    Timecop.travel(Time.now - backwards_time_travel) do
+      open_circuit!(resource)
+    end
+  end
+
+  def trigger_error!(resource = @resource)
+    resource.acquire { raise SomeError }
+  rescue SomeError
+  end
+
+  def assert_circuit_closed(resource = @resource)
+    block_called = false
+    resource.acquire { block_called = true }
+    assert block_called, 'Expected the circuit to be closed, but it was open'
+  end
+
+  def assert_circuit_opened(resource = @resource)
+    open = false
+    begin
+      resource.acquire {}
+    rescue Semian::OpenCircuitError
+      open = true
+    end
+    assert open, 'Expected the circuit to be open, but it was closed'
+  end
+end

--- a/test/helpers/resource_helper.rb
+++ b/test/helpers/resource_helper.rb
@@ -1,0 +1,22 @@
+module ResourceHelper
+  private
+
+  def create_resource(*args)
+    @resources ||= []
+    resource = Semian::Resource.new(*args)
+    @resources << resource
+    resource
+  end
+
+  def destroy_resources
+    return unless @resources
+    @resources.each do |resource|
+      begin
+        resource.destroy
+      rescue
+        nil
+      end
+    end
+    @resources = []
+  end
+end

--- a/test/protected_resource_test.rb
+++ b/test/protected_resource_test.rb
@@ -1,0 +1,85 @@
+require 'test_helper'
+
+class TestProtectedResource < Minitest::Test
+  include CircuitBreakerHelper
+  include ResourceHelper
+  include BackgroundHelper
+
+  def setup
+    Semian.destroy(:testing)
+  rescue
+    nil
+  end
+
+  def teardown
+    destroy_resources
+    super
+  end
+
+  def test_acquire_without_bulkhead
+    Semian.register(
+      :testing,
+      exceptions: [SomeError],
+      error_threshold: 2,
+      error_timeout: 5,
+      success_threshold: 1,
+      bulkhead: false,
+    )
+
+    10.times do
+      background do
+        block_called = false
+        @resource = Semian[:testing]
+        @resource.acquire { block_called = true }
+        assert_equal true, block_called
+        assert_instance_of Semian::CircuitBreaker, @resource.circuit_breaker
+        assert_nil @resource.bulkhead
+      end
+    end
+
+    yield_to_background
+  end
+
+  def test_acquire_bulkhead_without_circuit_breaker
+    Semian.register(
+      :testing,
+      tickets: 2,
+      circuit_breaker: false,
+    )
+    acquired = false
+
+    @resource = Semian[:testing]
+    @resource.acquire do
+      acquired = true
+      assert_equal 1, @resource.count
+      assert_equal 2, @resource.tickets
+    end
+
+    assert acquired
+    assert_nil @resource.circuit_breaker
+  end
+
+  def test_acquire_bulkhead_with_circuit_breaker
+    Semian.register(
+      :testing,
+      tickets: 2,
+      exceptions: [SomeError],
+      error_threshold: 2,
+      error_timeout: 5,
+      success_threshold: 1,
+    )
+
+    acquired = false
+
+    @resource = Semian[:testing]
+    @resource.acquire do
+      acquired = true
+      assert_equal 1, @resource.count
+      assert_equal 2, @resource.tickets
+      half_open_cicuit!(@resource)
+      assert_circuit_closed(@resource)
+    end
+
+    assert acquired
+  end
+end

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 
 class TestResource < Minitest::Test
+  include ResourceHelper
   def setup
     Semian.destroy(:testing)
   rescue

--- a/test/semian_test.rb
+++ b/test/semian_test.rb
@@ -14,6 +14,26 @@ class TestSemian < Minitest::Test
     assert acquired
   end
 
+  def test_register_with_circuit_breaker_missing_options
+    assert_raises ArgumentError do
+      Semian.register(
+        :testing,
+        error_threshold: 2,
+        error_timeout: 5,
+        bulkhead: false,
+      )
+    end
+  end
+
+  def test_register_with_bulkhead_missing_options
+    assert_raises ArgumentError do
+      Semian.register(
+        :testing,
+        circuit_breaker: false,
+      )
+    end
+  end
+
   def test_unsuported_constants
     assert defined?(Semian::BaseError)
     assert defined?(Semian::SyscallError)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,8 @@ require 'tempfile'
 require 'fileutils'
 
 require 'helpers/background_helper'
+require 'helpers/circuit_breaker_helper'
+require 'helpers/resource_helper'
 
 Semian.logger = Logger.new(nil)
 Toxiproxy.populate([

--- a/test/unprotected_resource_test.rb
+++ b/test/unprotected_resource_test.rb
@@ -57,4 +57,12 @@ class UnprotectedResourceTest < Minitest::Test
   def test_mark_failed
     @resource.mark_failed(:error)
   end
+
+  def test_bulkhead
+    assert_nil @resource.bulkhead
+  end
+
+  def test_circuit_breaker
+    assert_nil @resource.circuit_breaker
+  end
 end


### PR DESCRIPTION
# What
Breaking the coupling of ProtectedResource from circuit breaker and bulkhead. To allow the ability to request a circuit_breaker or bulkhead independent of each other without breaking the path of processing. 

Fixes #95 

# How

The protected resource will be registered but will only contain the resources that have been requested. Given you do not want a resource the code path will not execute and will allow the ability to interact based on the properties given in `acquire` or `register`.