### PR TITLE
Add support for a minimum number of tickets when using the quota strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ In this case, we'd allow 50% of the workers on a particular host to connect to t
 - Tickets available will be the ceiling of the quota ratio to the number of workers
  - So, with one worker, there will always be a minimum of 1 ticket
 - Workers in different processes will automatically unregister when the process exits.
+- You will likely also want to specify a `min_tickets` argument, to prevent spurious timeouts during the initial rollout, or deploys.
 
 #### Net::HTTP
 For the `Net::HTTP` specific Semian adapter, since many external libraries may create

--- a/ext/semian/resource.h
+++ b/ext/semian/resource.h
@@ -20,7 +20,7 @@ int system_max_semaphore_count;
  * Creates a new Resource. Do not create resources directly. Use Semian.register.
  */
 VALUE
-semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VALUE permissions, VALUE default_timeout);
+semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VALUE min_tickets, VALUE permissions, VALUE default_timeout);
 
 /*
  * call-seq:

--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -42,7 +42,7 @@ void Init_semian()
   eInternal = rb_const_get(cSemian, rb_intern("InternalError"));
 
   rb_define_alloc_func(cResource, semian_resource_alloc);
-  rb_define_method(cResource, "initialize_semaphore", semian_resource_initialize, 5);
+  rb_define_method(cResource, "initialize_semaphore", semian_resource_initialize, 6);
   rb_define_method(cResource, "acquire", semian_resource_acquire, -1);
   rb_define_method(cResource, "count", semian_resource_count, 0);
   rb_define_method(cResource, "semid", semian_resource_id, 0);

--- a/ext/semian/sysv_semaphores.c
+++ b/ext/semian/sysv_semaphores.c
@@ -24,7 +24,7 @@ raise_semian_syscall_error(const char *syscall, int error_num)
 }
 
 int
-initialize_semaphore_set(const char* id_str, long permissions, int tickets, double quota)
+initialize_semaphore_set(const char* id_str, long permissions, int tickets, double quota, int min_tickets)
 {
   int sem_id;
   key_t key;
@@ -52,7 +52,7 @@ initialize_semaphore_set(const char* id_str, long permissions, int tickets, doub
   set_semaphore_permissions(sem_id, permissions);
 
   sem_meta_lock(sem_id); // Sets otime for the first time by acquiring the sem lock
-  configure_tickets(sem_id, tickets,  quota);
+  configure_tickets(sem_id, tickets, quota, min_tickets);
   sem_meta_unlock(sem_id);
 
   return sem_id;

--- a/ext/semian/sysv_semaphores.h
+++ b/ext/semian/sysv_semaphores.h
@@ -71,7 +71,7 @@ raise_semian_syscall_error(const char *syscall, int error_num);
 
 // Initialize the sysv semaphore structure
 int
-initialize_semaphore_set(const char* id_str, long permissions, int tickets, double quota);
+initialize_semaphore_set(const char* id_str, long permissions, int tickets, double quota, int min_tickets);
 
 // Set semaphore UNIX octal permissions
 void

--- a/ext/semian/tickets.h
+++ b/ext/semian/tickets.h
@@ -6,8 +6,13 @@ For logic specific to manipulating semian ticket counts
 
 #include "sysv_semaphores.h"
 
+#ifndef max
+// max is not defined in any standard, portable C header...
+#define max(a,b) (((a)>(b))?(a):(b))
+#endif
+
 // Set initial ticket values upon resource creation
 void
-configure_tickets(int sem_id, int tickets, double quota);
+configure_tickets(int sem_id, int tickets, double quota, int min_tickets);
 
 #endif // SEMIAN_TICKETS_H

--- a/ext/semian/types.h
+++ b/ext/semian/types.h
@@ -29,7 +29,6 @@ typedef struct {
 typedef struct {
   int sem_id;
   struct timespec timeout;
-  double quota;
   int error;
   char *name;
 } semian_resource_t;

--- a/lib/semian/resource.rb
+++ b/lib/semian/resource.rb
@@ -9,9 +9,9 @@ module Semian
       end
     end
 
-    def initialize(name, tickets: nil, quota: nil, permissions: 0660, timeout: 0)
+    def initialize(name, tickets: nil, quota: nil, min_tickets: 0, permissions: 0660, timeout: 0)
       if Semian.semaphores_enabled?
-        initialize_semaphore(name, tickets, quota, permissions, timeout) if respond_to?(:initialize_semaphore)
+        initialize_semaphore(name, tickets, quota, min_tickets, permissions, timeout) if respond_to?(:initialize_semaphore)
       else
         Semian.issue_disabled_semaphores_warning
       end


### PR DESCRIPTION
# What

Allow for a minimum number of tickets to still be allocated while using quotas to provide tickets.

# Why

Since the quota strategy makes the number of tickets available proportional to the number of workers,
it's possible that the number of tickets may be very constrained during some normal operations,
such as rolling restarts during, for instance, a deploy.

To prevent these situations from resulting in a large number of tripped circuit breakers,
a minimum number of tickets can be specified.

The actual ticket count used will be the max of the tickets calculated by the quota, and the
minimum value.

# How

We simply pass along a min_ticket value, and when we calculate the quota tickets if the quota value would be less than min_tickets, we use that instead.