### PR TITLE
Allow a boot grace period using quota strategy

### DIFF
--- a/ext/semian/resource.c
+++ b/ext/semian/resource.c
@@ -1,4 +1,5 @@
 #include "resource.h"
+#include <time.h>
 
 static VALUE
 cleanup_semian_resource_acquire(VALUE self);
@@ -21,6 +22,9 @@ char *check_id_arg(VALUE id);
 static double
 check_default_timeout_arg(VALUE default_timeout);
 
+static double
+check_quota_grace_timeout_arg(VALUE quota_grace_timeout);
+
 static void
 ms_to_timespec(long ms, struct timespec *ts);
 
@@ -32,6 +36,7 @@ semian_resource_acquire(int argc, VALUE *argv, VALUE self)
 {
   semian_resource_t *self_res = NULL;
   semian_resource_t res = { 0 };
+  struct semid_ds sem_ds;
 
   if (!rb_block_given_p()) {
     rb_raise(rb_eArgError, "acquire requires a block");
@@ -51,6 +56,17 @@ semian_resource_acquire(int argc, VALUE *argv, VALUE self)
     }
   } else if (argc > 0) {
     rb_raise(rb_eArgError, "invalid arguments");
+  }
+
+  // If we recently booted, and are using the quota strategy
+  // we need to give the workers some time to register or else
+  // we may have spurious timeouts due to a small number of registered workers.
+  if(res.quota > 0) {
+    semaphore_stat(res.sem_id, &sem_ds);
+    if (difftime(time(0), sem_ds.sem_ctime) < QUOTA_BOOT_GRACE_PERIOD) {
+      res.timeout.tv_sec = res.quota_grace_timeout;
+      res.timeout.tv_nsec = 0;
+    }
   }
 
   /* release the GVL to acquire the semaphore */
@@ -129,10 +145,11 @@ semian_resource_id(VALUE self)
 }
 
 VALUE
-semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VALUE permissions, VALUE default_timeout)
+semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VALUE permissions, VALUE default_timeout, VALUE quota_grace_timeout)
 {
   long c_permissions;
   double c_timeout;
+  double c_quota_grace_timeout;
   double c_quota;
   int c_tickets;
   semian_resource_t *res = NULL;
@@ -145,6 +162,7 @@ semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VAL
   c_permissions = check_permissions_arg(permissions);
   c_id_str = check_id_arg(id);
   c_timeout = check_default_timeout_arg(default_timeout);
+  c_quota_grace_timeout = check_quota_grace_timeout_arg(quota_grace_timeout);
 
   // Build semian resource structure
   TypedData_Get_Struct(self, semian_resource_t, &semian_resource_type, res);
@@ -153,6 +171,7 @@ semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VAL
   ms_to_timespec(c_timeout * 1000, &res->timeout);
   res->name = strdup(c_id_str);
   res->quota = c_quota;
+  res->quota_grace_timeout = c_quota_grace_timeout;
   res->sem_id = initialize_semaphore_set(c_id_str, c_permissions, c_tickets, c_quota);
 
   return self;
@@ -262,6 +281,19 @@ check_default_timeout_arg(VALUE default_timeout)
     rb_raise(rb_eArgError, "default timeout must be non-negative value");
   }
   return NUM2DBL(default_timeout);
+}
+
+static double
+check_quota_grace_timeout_arg(VALUE quota_grace_timeout)
+{
+  if (TYPE(quota_grace_timeout) != T_FIXNUM && TYPE(quota_grace_timeout) != T_FLOAT) {
+    rb_raise(rb_eTypeError, "expected numeric type for quota_grace_timeout");
+  }
+
+  if (NUM2DBL(quota_grace_timeout) < 0) {
+    rb_raise(rb_eArgError, "default timeout must be non-negative value");
+  }
+  return NUM2DBL(quota_grace_timeout);
 }
 
 static void

--- a/ext/semian/resource.h
+++ b/ext/semian/resource.h
@@ -9,9 +9,6 @@ Functions here are associated with rubyland operations.
 #include "types.h"
 #include "sysv_semaphores.h"
 
-// Time to wait for workers to boot using the quota strategy
-#define QUOTA_BOOT_GRACE_PERIOD 60 // seconds
-
 // Ruby variables
 ID id_timeout;
 int system_max_semaphore_count;
@@ -23,7 +20,7 @@ int system_max_semaphore_count;
  * Creates a new Resource. Do not create resources directly. Use Semian.register.
  */
 VALUE
-semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VALUE permissions, VALUE default_timeout, VALUE quota_grace_timeout);
+semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VALUE permissions, VALUE default_timeout, VALUE quota_grace_timeout, VALUE quota_grace_period);
 
 /*
  * call-seq:

--- a/ext/semian/resource.h
+++ b/ext/semian/resource.h
@@ -9,6 +9,9 @@ Functions here are associated with rubyland operations.
 #include "types.h"
 #include "sysv_semaphores.h"
 
+// Time to wait for workers to boot using the quota strategy
+#define QUOTA_BOOT_GRACE_PERIOD 60 // seconds
+
 // Ruby variables
 ID id_timeout;
 int system_max_semaphore_count;
@@ -20,7 +23,7 @@ int system_max_semaphore_count;
  * Creates a new Resource. Do not create resources directly. Use Semian.register.
  */
 VALUE
-semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VALUE permissions, VALUE default_timeout);
+semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VALUE permissions, VALUE default_timeout, VALUE quota_grace_timeout);
 
 /*
  * call-seq:

--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -42,7 +42,7 @@ void Init_semian()
   eInternal = rb_const_get(cSemian, rb_intern("InternalError"));
 
   rb_define_alloc_func(cResource, semian_resource_alloc);
-  rb_define_method(cResource, "initialize_semaphore", semian_resource_initialize, 6);
+  rb_define_method(cResource, "initialize_semaphore", semian_resource_initialize, 7);
   rb_define_method(cResource, "acquire", semian_resource_acquire, -1);
   rb_define_method(cResource, "count", semian_resource_count, 0);
   rb_define_method(cResource, "semid", semian_resource_id, 0);

--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -42,7 +42,7 @@ void Init_semian()
   eInternal = rb_const_get(cSemian, rb_intern("InternalError"));
 
   rb_define_alloc_func(cResource, semian_resource_alloc);
-  rb_define_method(cResource, "initialize_semaphore", semian_resource_initialize, 5);
+  rb_define_method(cResource, "initialize_semaphore", semian_resource_initialize, 6);
   rb_define_method(cResource, "acquire", semian_resource_acquire, -1);
   rb_define_method(cResource, "count", semian_resource_count, 0);
   rb_define_method(cResource, "semid", semian_resource_id, 0);

--- a/ext/semian/sysv_semaphores.c
+++ b/ext/semian/sysv_semaphores.c
@@ -187,15 +187,25 @@ initialize_new_semaphore_values(int sem_id, long permissions)
 #endif
 }
 
+void
+semaphore_stat(int sem_id, struct semid_ds *sem_ds)
+{
+  union semun sem_opts;
+
+  sem_opts.buf = sem_ds;
+
+  if (semctl(sem_id, 0, IPC_STAT, sem_opts) == -1) {
+    raise_semian_syscall_error("semget()", errno);
+  }
+}
+
 static int
 wait_for_new_semaphore_set(key_t key, long permissions)
 {
   int i;
   int sem_id = -1;
-  union semun sem_opts;
   struct semid_ds sem_ds;
 
-  sem_opts.buf = &sem_ds;
   sem_id = semget(key, 1, permissions);
 
   if (sem_id == -1){
@@ -204,9 +214,7 @@ wait_for_new_semaphore_set(key_t key, long permissions)
 
   for (i = 0; i < ((INTERNAL_TIMEOUT * MICROSECONDS_IN_SECOND) / INIT_WAIT); i++) {
 
-    if (semctl(sem_id, 0, IPC_STAT, sem_opts) == -1) {
-      raise_semian_syscall_error("semget()", errno);
-    }
+    semaphore_stat(sem_id, &sem_ds);
 
     // If a semop has been performed by someone else, the values must be initialized
     if (sem_ds.sem_otime != 0) {

--- a/ext/semian/sysv_semaphores.h
+++ b/ext/semian/sysv_semaphores.h
@@ -106,6 +106,10 @@ get_semaphore(int key);
 void *
 acquire_semaphore_without_gvl(void *p);
 
+// Get stats about the semaphore via IPC_STAT
+void
+semaphore_stat(int sem_id, struct semid_ds *sem_ds);
+
 #ifdef DEBUG
 static inline void
 print_sem_vals(int sem_id)

--- a/ext/semian/tickets.c
+++ b/ext/semian/tickets.c
@@ -66,6 +66,7 @@ update_ticket_count(update_ticket_count_t *tc)
     }
   }
 
+  // This will update the ctime
   if (semctl(tc->sem_id, SI_SEM_CONFIGURED_TICKETS, SETVAL, tc->tickets) == -1) {
     rb_raise(eInternal, "error configuring ticket count, errno: %d (%s)", errno, strerror(errno));
   }

--- a/ext/semian/types.h
+++ b/ext/semian/types.h
@@ -30,6 +30,7 @@ typedef struct {
   int sem_id;
   struct timespec timeout;
   double quota;
+  int quota_grace_timeout;
   int error;
   char *name;
 } semian_resource_t;

--- a/ext/semian/types.h
+++ b/ext/semian/types.h
@@ -30,7 +30,8 @@ typedef struct {
   int sem_id;
   struct timespec timeout;
   double quota;
-  int quota_grace_timeout;
+  double quota_grace_period; // Time to wait for workers to boot using the quota strategy
+  double quota_grace_timeout; // Semop timeout to use during grace period
   int error;
   char *name;
 } semian_resource_t;

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -140,8 +140,17 @@ module Semian
   # +exceptions+: An array of exception classes that should be accounted as resource errors.
   #
   # Returns the registered resource.
-  def register(name, tickets: nil, quota: nil, permissions: 0660, timeout: 0,
-    quota_grace_timeout: 10, error_threshold:, error_timeout:, success_threshold:, exceptions: [])
+  def register(name,
+    tickets: nil,
+    quota: nil,
+    permissions: 0660,
+    timeout: 0,
+    quota_grace_period: 120,
+    quota_grace_timeout: 10,
+    error_threshold:,
+    error_timeout:,
+    success_threshold:,
+    exceptions: [])
 
     circuit_breaker = CircuitBreaker.new(
       name,
@@ -151,8 +160,13 @@ module Semian
       exceptions: Array(exceptions) + [::Semian::BaseError],
       implementation: ::Semian::Simple,
     )
-    resource = Resource.instance(name, tickets: tickets, quota: quota, permissions: permissions,
-                                       timeout: timeout, quota_grace_timeout: quota_grace_timeout)
+    resource = Resource.instance(name,
+                                 tickets: tickets,
+                                 quota: quota,
+                                 permissions: permissions,
+                                 timeout: timeout,
+                                 quota_grace_timeout: quota_grace_timeout,
+                                 quota_grace_period: quota_grace_period)
     resources[name] = ProtectedResource.new(resource, circuit_breaker)
   end
 

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -131,6 +131,12 @@ module Semian
   #
   # +timeout+: Default timeout in seconds.
   #
+  # +quota_grace_timeout+: Time in seconds to wait for acquire if during the quota_grace_period
+  #
+  # +quota_grace_period+: Time in seconds to consider the 'grace period', to give quota workers time to boot.
+  # If less than quota_grace_period has elapsed, all acquires will use quota_grace_timeout. This is to help
+  # prevent spurious fails during deploys and initialization.
+  #
   # +error_threshold+: The number of errors that will trigger the circuit opening.
   #
   # +error_timeout+: The duration in seconds since the last error after which the error count is reset to 0.
@@ -145,8 +151,8 @@ module Semian
     quota: nil,
     permissions: 0660,
     timeout: 0,
-    quota_grace_period: 120,
     quota_grace_timeout: 10,
+    quota_grace_period: 120,
     error_threshold:,
     error_timeout:,
     success_threshold:,

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -140,7 +140,9 @@ module Semian
   # +exceptions+: An array of exception classes that should be accounted as resource errors.
   #
   # Returns the registered resource.
-  def register(name, tickets: nil, quota: nil, permissions: 0660, timeout: 0, error_threshold:, error_timeout:, success_threshold:, exceptions: [])
+  def register(name, tickets: nil, quota: nil, permissions: 0660, timeout: 0,
+    quota_grace_timeout: 10, error_threshold:, error_timeout:, success_threshold:, exceptions: [])
+
     circuit_breaker = CircuitBreaker.new(
       name,
       success_threshold: success_threshold,
@@ -149,7 +151,8 @@ module Semian
       exceptions: Array(exceptions) + [::Semian::BaseError],
       implementation: ::Semian::Simple,
     )
-    resource = Resource.instance(name, tickets: tickets, quota: quota, permissions: permissions, timeout: timeout)
+    resource = Resource.instance(name, tickets: tickets, quota: quota, permissions: permissions,
+                                       timeout: timeout, quota_grace_timeout: quota_grace_timeout)
     resources[name] = ProtectedResource.new(resource, circuit_breaker)
   end
 

--- a/lib/semian/resource.rb
+++ b/lib/semian/resource.rb
@@ -9,9 +9,21 @@ module Semian
       end
     end
 
-    def initialize(name, tickets: nil, quota: nil, permissions: 0660, timeout: 0, quota_grace_timeout: 0)
+    def initialize(name,
+                   tickets: nil,
+                   quota: nil,
+                   permissions: 0660,
+                   timeout: 0,
+                   quota_grace_timeout: 0,
+                   quota_grace_period: 0)
       if Semian.semaphores_enabled?
-        initialize_semaphore(name, tickets, quota, permissions, timeout, quota_grace_timeout) if respond_to?(:initialize_semaphore)
+        initialize_semaphore(name,
+                             tickets,
+                             quota,
+                             permissions,
+                             timeout,
+                             quota_grace_timeout,
+                             quota_grace_period) if respond_to?(:initialize_semaphore)
       else
         Semian.issue_disabled_semaphores_warning
       end

--- a/lib/semian/resource.rb
+++ b/lib/semian/resource.rb
@@ -9,9 +9,9 @@ module Semian
       end
     end
 
-    def initialize(name, tickets: nil, quota: nil, permissions: 0660, timeout: 0)
+    def initialize(name, tickets: nil, quota: nil, permissions: 0660, timeout: 0, quota_grace_timeout: 0)
       if Semian.semaphores_enabled?
-        initialize_semaphore(name, tickets, quota, permissions, timeout) if respond_to?(:initialize_semaphore)
+        initialize_semaphore(name, tickets, quota, permissions, timeout, quota_grace_timeout) if respond_to?(:initialize_semaphore)
       else
         Semian.issue_disabled_semaphores_warning
       end

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -142,6 +142,26 @@ class TestResource < Minitest::Test
     end
   end
 
+  def test_quota_grace_period
+    quota = 0.5
+    workers = 20
+    acquired = false
+
+    # We want these to block for longer than the default timeout, but less than our grace period
+    fork_workers(count: workers, quota: quota, timeout: 0.5, wait_for_timeout: true) do
+      sleep 7
+    end
+
+    # Once signalled, all tickets should still be held for the above sleep period
+    signal_workers('TERM')
+
+    # our resource should still be able to acquire, since it's grace timeout is longer than above
+    resource = create_resource :testing, quota: quota, timeout: 0.1, quota_grace_timeout: 8
+    resource.acquire { acquired = true }
+
+    assert_equal(true, acquired)
+  end
+
   def test_quota_acquire
     quota = 0.5
     workers = 9
@@ -439,14 +459,17 @@ class TestResource < Minitest::Test
   # Active workers are accumulated in the instance variable @workers,
   # and workers must be cleaned up between tests by the teardown script
   # An exit value of 100 is to keep track of timeouts, 0 for success.
-  def fork_workers(count:, resource: :testing, quota: nil, tickets: nil, timeout: 0.1, wait_for_timeout: false)
+  def fork_workers(count:, resource: :testing, quota: nil, tickets: nil,
+                   timeout: 0.1, wait_for_timeout: false, quota_grace_timeout: 0)
+
     fail 'Must provide at least one of tickets or quota' unless tickets || quota
 
     @workers ||= []
     count.times do
       @workers << fork do
         begin
-          resource = Semian::Resource.new(resource.to_sym, quota: quota, tickets: tickets, timeout: timeout)
+          resource = Semian::Resource.new(resource.to_sym, quota: quota, tickets: tickets,
+                                                           timeout: timeout, quota_grace_timeout: quota_grace_timeout)
           resource.acquire do
             # Hold the resource until signalled
             # This helps to avoid race conditions in testing.

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -148,7 +148,7 @@ class TestResource < Minitest::Test
     acquired = false
 
     # We want these to block for longer than the default timeout, but less than our grace period
-    fork_workers(count: workers, quota: quota, timeout: 0.5, wait_for_timeout: true) do
+    fork_workers(count: workers - 1, quota: quota, timeout: 0.5, wait_for_timeout: true) do
       sleep 7
     end
 
@@ -156,10 +156,30 @@ class TestResource < Minitest::Test
     signal_workers('TERM')
 
     # our resource should still be able to acquire, since it's grace timeout is longer than above
-    resource = create_resource :testing, quota: quota, timeout: 0.1, quota_grace_timeout: 8
+    resource = create_resource :testing, quota: quota, timeout: 0.1, quota_grace_timeout: 8, quota_grace_period: 120
     resource.acquire { acquired = true }
 
     assert_equal(true, acquired)
+  end
+
+  def test_quota_grace_period_timeout
+    quota = 0.5
+    workers = 20
+
+    # We want these to block for longer than the default timeout, but less than our grace period
+    fork_workers(count: workers - 1, quota: quota, timeout: 0.5, wait_for_timeout: true) do
+      sleep 7
+    end
+
+    # Once signalled, all tickets should still be held for the above sleep period
+    signal_workers('TERM')
+
+    # our resource fail to acquire, since the grace period isn't long enough
+    resource = create_resource :testing, quota: quota, timeout: 0.1, quota_grace_timeout: 1, quota_grace_period: 120
+
+    assert_raises Semian::TimeoutError do
+      resource.acquire {}
+    end
   end
 
   def test_quota_acquire
@@ -459,8 +479,14 @@ class TestResource < Minitest::Test
   # Active workers are accumulated in the instance variable @workers,
   # and workers must be cleaned up between tests by the teardown script
   # An exit value of 100 is to keep track of timeouts, 0 for success.
-  def fork_workers(count:, resource: :testing, quota: nil, tickets: nil,
-                   timeout: 0.1, wait_for_timeout: false, quota_grace_timeout: 0)
+  def fork_workers(count:,
+                   resource: :testing,
+                   quota: nil,
+                   tickets: nil,
+                   timeout: 0.1,
+                   wait_for_timeout: false,
+                   quota_grace_timeout: 0,
+                   quota_grace_period: 0)
 
     fail 'Must provide at least one of tickets or quota' unless tickets || quota
 
@@ -468,8 +494,12 @@ class TestResource < Minitest::Test
     count.times do
       @workers << fork do
         begin
-          resource = Semian::Resource.new(resource.to_sym, quota: quota, tickets: tickets,
-                                                           timeout: timeout, quota_grace_timeout: quota_grace_timeout)
+          resource = Semian::Resource.new(resource.to_sym,
+                                          quota: quota,
+                                          tickets: tickets,
+                                          timeout: timeout,
+                                          quota_grace_timeout: quota_grace_timeout,
+                                          quota_grace_period: quota_grace_period)
           resource.acquire do
             # Hold the resource until signalled
             # This helps to avoid race conditions in testing.


### PR DESCRIPTION
# What

Allow for quota workers to pad the acquire timeout while workers are booting.

# Why

There is the possibility of timeouts when using the quota strategy while
workers are booting, since there are a small number of workers.

We can prevent spurious timeouts caused by a small number of tickets
during this period, by allowing for the acquire timeout to be padded.

# How

We store the desired padding value as part of the resource structure.

Whenever the ticket count is updated (workers are registered), a SETVAL occurs that will write the ctime of the semaphore.

We can compare this value with the current time to see if we are within the QUOTA_BOOT_GRACE_PERIOD. If we are, we know to replace any configured timeout value with our padded value.