### PR TITLE
Revert "Allow a boot grace period using quota strategy (#125)"

### DIFF
--- a/ext/semian/resource.c
+++ b/ext/semian/resource.c
@@ -1,5 +1,4 @@
 #include "resource.h"
-#include <time.h>
 
 static VALUE
 cleanup_semian_resource_acquire(VALUE self);
@@ -22,12 +21,6 @@ char *check_id_arg(VALUE id);
 static double
 check_default_timeout_arg(VALUE default_timeout);
 
-static double
-check_quota_grace_timeout_arg(VALUE quota_grace_timeout);
-
-static double
-check_quota_grace_period_arg(VALUE quota_grace_timeout);
-
 static void
 ms_to_timespec(long ms, struct timespec *ts);
 
@@ -39,9 +32,6 @@ semian_resource_acquire(int argc, VALUE *argv, VALUE self)
 {
   semian_resource_t *self_res = NULL;
   semian_resource_t res = { 0 };
-  time_t tv_sec;
-  long tv_nsec;
-  struct semid_ds sem_ds;
 
   if (!rb_block_given_p()) {
     rb_raise(rb_eArgError, "acquire requires a block");
@@ -63,20 +53,6 @@ semian_resource_acquire(int argc, VALUE *argv, VALUE self)
     rb_raise(rb_eArgError, "invalid arguments");
   }
 
-  // Backup the timeout values in case we need to revert them
-  tv_sec = res.timeout.tv_sec;
-  tv_nsec = res.timeout.tv_nsec;
-
-  // If we recently booted, and are using the quota strategy
-  // we need to give the workers some time to register or else
-  // we may have spurious timeouts due to a small number of registered workers.
-  if(res.quota > 0) {
-    semaphore_stat(res.sem_id, &sem_ds);
-    if (difftime(time(0), sem_ds.sem_ctime) < res.quota_grace_period) {
-      ms_to_timespec(res.quota_grace_timeout * 1000, &res.timeout);
-    }
-  }
-
   /* release the GVL to acquire the semaphore */
   acquire_semaphore_without_gvl(&res);
   if (res.error != 0) {
@@ -86,10 +62,6 @@ semian_resource_acquire(int argc, VALUE *argv, VALUE self)
       raise_semian_syscall_error("semop()", res.error);
     }
   }
-
-  // Restore the timeout values, in case they were mutated
-  res.timeout.tv_sec = tv_sec;
-  res.timeout.tv_nsec = tv_nsec;
 
   return rb_ensure(rb_yield, self, cleanup_semian_resource_acquire, self);
 }
@@ -157,12 +129,10 @@ semian_resource_id(VALUE self)
 }
 
 VALUE
-semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VALUE permissions, VALUE default_timeout, VALUE quota_grace_timeout, VALUE quota_grace_period)
+semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VALUE permissions, VALUE default_timeout)
 {
   long c_permissions;
   double c_timeout;
-  double c_quota_grace_timeout;
-  double c_quota_grace_period;
   double c_quota;
   int c_tickets;
   semian_resource_t *res = NULL;
@@ -175,8 +145,6 @@ semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VAL
   c_permissions = check_permissions_arg(permissions);
   c_id_str = check_id_arg(id);
   c_timeout = check_default_timeout_arg(default_timeout);
-  c_quota_grace_timeout = check_quota_grace_timeout_arg(quota_grace_timeout);
-  c_quota_grace_period = check_quota_grace_period_arg(quota_grace_period);
 
   // Build semian resource structure
   TypedData_Get_Struct(self, semian_resource_t, &semian_resource_type, res);
@@ -185,8 +153,6 @@ semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VAL
   ms_to_timespec(c_timeout * 1000, &res->timeout);
   res->name = strdup(c_id_str);
   res->quota = c_quota;
-  res->quota_grace_timeout = c_quota_grace_timeout;
-  res->quota_grace_period = c_quota_grace_period;
   res->sem_id = initialize_semaphore_set(c_id_str, c_permissions, c_tickets, c_quota);
 
   return self;
@@ -296,32 +262,6 @@ check_default_timeout_arg(VALUE default_timeout)
     rb_raise(rb_eArgError, "default timeout must be non-negative value");
   }
   return NUM2DBL(default_timeout);
-}
-
-static double
-check_quota_grace_timeout_arg(VALUE quota_grace_timeout)
-{
-  if (TYPE(quota_grace_timeout) != T_FIXNUM && TYPE(quota_grace_timeout) != T_FLOAT) {
-    rb_raise(rb_eTypeError, "expected numeric type for quota_grace_timeout");
-  }
-
-  if (NUM2DBL(quota_grace_timeout) < 0) {
-    rb_raise(rb_eArgError, "quota grace timeout must be non-negative value");
-  }
-  return NUM2DBL(quota_grace_timeout);
-}
-
-static double
-check_quota_grace_period_arg(VALUE quota_grace_period)
-{
-  if (TYPE(quota_grace_period) != T_FIXNUM && TYPE(quota_grace_period) != T_FLOAT) {
-    rb_raise(rb_eTypeError, "expected numeric type for quota_grace_period");
-  }
-
-  if (NUM2DBL(quota_grace_period) < 0) {
-    rb_raise(rb_eArgError, "quota grace period must be non-negative value");
-  }
-  return NUM2DBL(quota_grace_period);
 }
 
 static void

--- a/ext/semian/resource.h
+++ b/ext/semian/resource.h
@@ -20,7 +20,7 @@ int system_max_semaphore_count;
  * Creates a new Resource. Do not create resources directly. Use Semian.register.
  */
 VALUE
-semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VALUE permissions, VALUE default_timeout, VALUE quota_grace_timeout, VALUE quota_grace_period);
+semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VALUE permissions, VALUE default_timeout);
 
 /*
  * call-seq:

--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -42,7 +42,7 @@ void Init_semian()
   eInternal = rb_const_get(cSemian, rb_intern("InternalError"));
 
   rb_define_alloc_func(cResource, semian_resource_alloc);
-  rb_define_method(cResource, "initialize_semaphore", semian_resource_initialize, 7);
+  rb_define_method(cResource, "initialize_semaphore", semian_resource_initialize, 5);
   rb_define_method(cResource, "acquire", semian_resource_acquire, -1);
   rb_define_method(cResource, "count", semian_resource_count, 0);
   rb_define_method(cResource, "semid", semian_resource_id, 0);

--- a/ext/semian/sysv_semaphores.h
+++ b/ext/semian/sysv_semaphores.h
@@ -106,10 +106,6 @@ get_semaphore(int key);
 void *
 acquire_semaphore_without_gvl(void *p);
 
-// Get stats about the semaphore via IPC_STAT
-void
-semaphore_stat(int sem_id, struct semid_ds *sem_ds);
-
 #ifdef DEBUG
 static inline void
 print_sem_vals(int sem_id)

--- a/ext/semian/tickets.c
+++ b/ext/semian/tickets.c
@@ -66,7 +66,6 @@ update_ticket_count(update_ticket_count_t *tc)
     }
   }
 
-  // This will update the ctime
   if (semctl(tc->sem_id, SI_SEM_CONFIGURED_TICKETS, SETVAL, tc->tickets) == -1) {
     rb_raise(eInternal, "error configuring ticket count, errno: %d (%s)", errno, strerror(errno));
   }

--- a/ext/semian/types.h
+++ b/ext/semian/types.h
@@ -30,8 +30,6 @@ typedef struct {
   int sem_id;
   struct timespec timeout;
   double quota;
-  double quota_grace_period; // Time to wait for workers to boot using the quota strategy
-  double quota_grace_timeout; // Semop timeout to use during grace period
   int error;
   char *name;
 } semian_resource_t;

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -131,12 +131,6 @@ module Semian
   #
   # +timeout+: Default timeout in seconds.
   #
-  # +quota_grace_timeout+: Time in seconds to wait for acquire if during the quota_grace_period
-  #
-  # +quota_grace_period+: Time in seconds to consider the 'grace period', to give quota workers time to boot.
-  # If less than quota_grace_period has elapsed, all acquires will use quota_grace_timeout. This is to help
-  # prevent spurious fails during deploys and initialization.
-  #
   # +error_threshold+: The number of errors that will trigger the circuit opening.
   #
   # +error_timeout+: The duration in seconds since the last error after which the error count is reset to 0.
@@ -146,18 +140,7 @@ module Semian
   # +exceptions+: An array of exception classes that should be accounted as resource errors.
   #
   # Returns the registered resource.
-  def register(name,
-    tickets: nil,
-    quota: nil,
-    permissions: 0660,
-    timeout: 0,
-    quota_grace_timeout: 10,
-    quota_grace_period: 120,
-    error_threshold:,
-    error_timeout:,
-    success_threshold:,
-    exceptions: [])
-
+  def register(name, tickets: nil, quota: nil, permissions: 0660, timeout: 0, error_threshold:, error_timeout:, success_threshold:, exceptions: [])
     circuit_breaker = CircuitBreaker.new(
       name,
       success_threshold: success_threshold,
@@ -166,13 +149,7 @@ module Semian
       exceptions: Array(exceptions) + [::Semian::BaseError],
       implementation: ::Semian::Simple,
     )
-    resource = Resource.instance(name,
-                                 tickets: tickets,
-                                 quota: quota,
-                                 permissions: permissions,
-                                 timeout: timeout,
-                                 quota_grace_timeout: quota_grace_timeout,
-                                 quota_grace_period: quota_grace_period)
+    resource = Resource.instance(name, tickets: tickets, quota: quota, permissions: permissions, timeout: timeout)
     resources[name] = ProtectedResource.new(resource, circuit_breaker)
   end
 

--- a/lib/semian/resource.rb
+++ b/lib/semian/resource.rb
@@ -9,21 +9,9 @@ module Semian
       end
     end
 
-    def initialize(name,
-                   tickets: nil,
-                   quota: nil,
-                   permissions: 0660,
-                   timeout: 0,
-                   quota_grace_timeout: 0,
-                   quota_grace_period: 0)
+    def initialize(name, tickets: nil, quota: nil, permissions: 0660, timeout: 0)
       if Semian.semaphores_enabled?
-        initialize_semaphore(name,
-                             tickets,
-                             quota,
-                             permissions,
-                             timeout,
-                             quota_grace_timeout,
-                             quota_grace_period) if respond_to?(:initialize_semaphore)
+        initialize_semaphore(name, tickets, quota, permissions, timeout) if respond_to?(:initialize_semaphore)
       else
         Semian.issue_disabled_semaphores_warning
       end


### PR DESCRIPTION
# What

Reverts grace periods, as they don't seem to solve the problem we were attempting to solve.

This reverts commit a5a8dce5e111123cad717d44dbf490ca7e33af14.

# Why

We believe that timeouts actually only happen when we transition between the static ticket and quota strategies, because the number of workers running under a static strategy aren't reflected as registered workers. We are going to ship a solution that will mitigate that.