### PR TITLE
Register all workers - not just quota workers

### DIFF
--- a/ext/semian/sysv_semaphores.c
+++ b/ext/semian/sysv_semaphores.c
@@ -51,6 +51,14 @@ initialize_semaphore_set(const char* id_str, long permissions, int tickets, doub
 
   set_semaphore_permissions(sem_id, permissions);
 
+  /*
+    Ensure that a worker for this process is registered.
+    Note that from ruby we ensure that at most one worker may be registered per process.
+  */
+  if (perform_semop(sem_id, SI_SEM_REGISTERED_WORKERS, 1, SEM_UNDO, NULL) == -1) {
+    rb_raise(eInternal, "error incrementing registered workers, errno: %d (%s)", errno, strerror(errno));
+  }
+
   sem_meta_lock(sem_id); // Sets otime for the first time by acquiring the sem lock
   configure_tickets(sem_id, tickets,  quota);
   sem_meta_unlock(sem_id);

--- a/ext/semian/tickets.c
+++ b/ext/semian/tickets.c
@@ -77,15 +77,6 @@ static int
 calculate_quota_tickets (int sem_id, double quota)
 {
   int tickets = 0;
-
-  /*
-    Ensure that a worker for this process is registered.
-    Note that from ruby we ensure that at most one worker may be registered per process.
-  */
-  if (perform_semop(sem_id, SI_SEM_REGISTERED_WORKERS, 1, SEM_UNDO, NULL) == -1) {
-    rb_raise(eInternal, "error incrementing registered workers, errno: %d (%s)", errno, strerror(errno));
-  }
-
   tickets = (int) ceil(get_sem_val(sem_id, SI_SEM_REGISTERED_WORKERS) * quota);
   return tickets;
 }

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -249,6 +249,32 @@ class TestResource < Minitest::Test
     assert_equal 1, resource.tickets
   end
 
+  def test_switch_static_tickets_to_quota
+    workers = 50
+    quota = 0.5
+
+    # Fork a large number of workers using static ticket strategy
+    fork_workers(count: workers - 1, tickets: 5, timeout: 0.1, wait_for_timeout: true) do
+      sleep 1
+    end
+
+    # Signal static workers to shut down
+    signal_workers('TERM')
+
+    # Create a quota based worker, and ensure it accounts for the static
+    # workers that haven't shut down yet
+    resource = create_resource :testing, quota: quota, timeout: 0.1
+    assert_equal((quota * workers).ceil, resource.tickets)
+
+    # Let the static workers shut down
+    sleep 2
+
+    # Create a new resource, and ensure the static workers are no longer
+    # accounted for
+    resource = create_resource :testing, quota: quota, timeout: 0.1
+    assert_equal((quota * 2).ceil, resource.tickets)
+  end
+
   def test_acquire_releases_on_kill
     resource = create_resource :testing, tickets: 1, timeout: 0.1
     acquired = false


### PR DESCRIPTION
# What

Register all workers, regardless of if they are quota-based or static-ticket based workers.

# Why

Currently it's possible to have spurious timeouts when transitioning
between static and quota-based ticket allocation.

This is primarily a problem when switching from static to quota-based,
as there will be a large number of unregistered static-ticket based
workers, who will have a very small number of tickets as the
quota-ticket based workers boot and register.

By registering all workers, we can account for this issue.

# How

During initialization, all workers will register themselves, rather than only quota-based workers.