### PR TITLE
Add ability to manually unregister resources

### DIFF
--- a/ext/semian/resource.c
+++ b/ext/semian/resource.c
@@ -91,6 +91,20 @@ semian_resource_destroy(VALUE self)
 }
 
 VALUE
+semian_resource_unregister_worker(VALUE self)
+{
+  semian_resource_t *res = NULL;
+
+  TypedData_Get_Struct(self, semian_resource_t, &semian_resource_type, res);
+
+  if (perform_semop(res->sem_id, SI_SEM_REGISTERED_WORKERS, -1, SEM_UNDO, NULL) == -1) {
+    rb_raise(eInternal, "error decreasing registered workers, errno: %d (%s)", errno, strerror(errno));
+  }
+
+  return Qtrue;
+}
+
+VALUE
 semian_resource_count(VALUE self)
 {
   int ret;

--- a/ext/semian/resource.h
+++ b/ext/semian/resource.h
@@ -76,6 +76,17 @@ semian_resource_tickets(VALUE self);
 VALUE
 semian_resource_id(VALUE self);
 
+/*
+ * call-seq:
+ *   resource.unregister_worker() -> true
+ *
+ * Unregisters a worker, which will affect quota calculations.
+ *
+ * Be careful to call this only once per process.
+*/
+VALUE
+semian_resource_unregister_worker(VALUE self);
+
 // Allocate a semian_resource_type struct for ruby memory management
 VALUE
 semian_resource_alloc(VALUE klass);

--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -48,6 +48,7 @@ void Init_semian()
   rb_define_method(cResource, "semid", semian_resource_id, 0);
   rb_define_method(cResource, "tickets", semian_resource_tickets, 0);
   rb_define_method(cResource, "destroy", semian_resource_destroy, 0);
+  rb_define_method(cResource, "unregister_worker", semian_resource_unregister_worker, 0);
 
   id_timeout = rb_intern("timeout");
 

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -170,6 +170,13 @@ module Semian
     end
   end
 
+  def unregister(name)
+    if resource = resources.delete(name)
+      # Hack to keep interface between protected / unprotected resource the same
+      resource.bulkhead.unregister_worker
+    end
+  end
+
   # Retrieves a hash of all registered resources.
   def resources
     @resources ||= {}

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -170,9 +170,14 @@ module Semian
     end
   end
 
+  # Unregister will not destroy the semian resource, but it will
+  # remove it from the hash of registered resources, and decrease
+  # the number of registered workers.
+  # Semian.destroy removes the underlying resource, but
+  # Semian.unregister will remove all references, while preserving
+  # the underlying semian resource (and sysV semaphore)
   def unregister(name)
     if resource = resources.delete(name)
-      # Hack to keep interface between protected / unprotected resource the same
       resource.bulkhead.unregister_worker
     end
   end

--- a/lib/semian/resource.rb
+++ b/lib/semian/resource.rb
@@ -21,6 +21,9 @@ module Semian
     def destroy
     end
 
+    def unregister_worker
+    end
+
     def acquire(*)
       yield self
     end


### PR DESCRIPTION
# What

Add the ability to manually unregister a resource without deleting it

# Why

So that clients may choose to unregister a resource, for instance, in a parent process, and then re-register in a child process.