### PR TITLE
Add closed connection to mysql errors

### DIFF
--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -24,6 +24,7 @@ module Semian
       /Lost connection to MySQL server/i,
       /MySQL server has gone away/i,
       /Too many connections/i,
+      /closed MySQL connection/i,
     )
 
     ResourceBusyError = ::Mysql2::ResourceBusyError


### PR DESCRIPTION
During upgrade to Rails5, blocking mysql with toxiproxy returned `closed MySQL connection` which wasn't trapped here.
This PR should fix this.