### PR TITLE
redis: lazily instantiate client on first i/o

### DIFF
--- a/lib/semian/redis.rb
+++ b/lib/semian/redis.rb
@@ -15,17 +15,19 @@ class Redis
   ResourceBusyError = Class.new(SemianError)
   CircuitOpenError = Class.new(SemianError)
 
-  attr_reader :semian_resource
-
   alias_method :_original_initialize, :initialize
 
   def initialize(*args, &block)
     _original_initialize(*args, &block)
 
-    # This alias is necessary because during a `pipelined` block
-    # the client is replaced by an instance of `Redis::Pipeline` and there is
-    # no way to access the original client.
-    @semian_resource = client.semian_resource
+    # This reference is necessary because during a `pipelined` block the client
+    # is replaced by an instance of `Redis::Pipeline` and there is no way to
+    # access the original client which references the Semian resource.
+    @original_client = client
+  end
+
+  def semian_resource
+    @original_client.semian_resource
   end
 
   def semian_identifier


### PR DESCRIPTION
With @dalehamel's changes that allow a quota based on the number of workers which is automatically tracked by Semian (https://github.com/Shopify/semian/issues/98), it's paramount that a resource is registered as many times as there are workers operating on that resource. In forking web-servers (such as Unicorn) you may instantiate Redis clients _before_ `fork`ing, causing only `1` worker to be registered with Semian (in master), instead of `n`.

Since you _shouldn't_ do I/O in the master, we can fix this problem by lazily registering the resource the first time we do I/O. I've tested this by raising in `Semian.retrieve_or_register` and booting Unicorn for our app, and it was successful (i.e. it didn't retrieve or register Semian while booting).

I'd like to have a test for this but I don't have a working development environment, I envision we can simply mock `#register` to ensure that's not called on `Redis.new`.