### PR TITLE
Add ability to unregister all resources, and clear all semian_resources

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -111,3 +111,7 @@ Style/IfUnlessModifier:
 
 Style/CaseIndentation:
   IndentWhenRelativeTo: end
+
+Lint/UselessAssignment:
+  Exclude:
+    - 'test/adapter_test.rb'

--- a/ext/semian/resource.c
+++ b/ext/semian/resource.c
@@ -97,8 +97,12 @@ semian_resource_unregister_worker(VALUE self)
 
   TypedData_Get_Struct(self, semian_resource_t, &semian_resource_type, res);
 
-  if (perform_semop(res->sem_id, SI_SEM_REGISTERED_WORKERS, -1, SEM_UNDO, NULL) == -1) {
-    rb_raise(eInternal, "error decreasing registered workers, errno: %d (%s)", errno, strerror(errno));
+  if (perform_semop(res->sem_id, SI_SEM_REGISTERED_WORKERS, -1, IPC_NOWAIT, NULL) == -1) {
+    // Allow EAGAIN with IPC_NOWAIT, as this signals that all workers were unregistered
+    // Otherwise, we might block forever or throw an unintended timeout
+    if (errno != EAGAIN) {
+      rb_raise(eInternal, "error decreasing registered workers, errno: %d (%s)", errno, strerror(errno));
+    }
   }
 
   return Qtrue;

--- a/lib/semian/adapter.rb
+++ b/lib/semian/adapter.rb
@@ -16,10 +16,15 @@ module Semian
       else
         options = semian_options.dup
         options.delete(:name)
+        options[:consumer] = self
         options[:exceptions] ||= []
         options[:exceptions] += resource_exceptions
         ::Semian.retrieve_or_register(semian_identifier, **options)
       end
+    end
+
+    def clear_semian_resource
+      @semian_resource = nil
     end
 
     private

--- a/test/adapter_test.rb
+++ b/test/adapter_test.rb
@@ -1,0 +1,91 @@
+require 'test_helper'
+
+class TestSemianAdapter < Minitest::Test
+  def setup
+    Semian.unregister_all_resources
+    # Consumers registered in other test files must be cleared
+    Semian.reset!
+  end
+
+  def teardown
+    Semian.unregister_all_resources
+  end
+
+  def test_adapter_registers_consumer
+    assert_empty(Semian.resources)
+    assert_empty(Semian.consumers)
+    client = Semian::AdapterTestClient.new(quota: 0.5)
+    resource = client.semian_resource
+    assert_equal(resource, Semian.resources[client.semian_identifier])
+    assert_equal(client, Semian.consumers[client.semian_identifier].first)
+  end
+
+  def test_unregister
+    client = Semian::AdapterTestClient.new(quota: 0.5)
+    assert_nil(Semian.resources[:testing])
+    resource = Semian.register(:testing, tickets: 2, error_threshold: 0, error_timeout: 0, success_threshold: 0)
+    assert_equal(Semian.resources[:testing], resource)
+
+    assert_equal 1, resource.registered_workers
+
+    without_gc do
+      Semian.unregister(:testing)
+      assert_equal 0, resource.registered_workers
+
+      assert_empty(Semian.resources)
+      assert_empty(Semian.consumers)
+
+      # The first call to client.semian_resource after unregistering all resources,
+      # should return a *different* (new) resource.
+      refute_equal(resource, client.semian_resource)
+    end
+    assert_nil(Semian.resources[:testing])
+  end
+
+  def test_unregister_all_resources
+    client = Semian::AdapterTestClient.new(quota: 0.5)
+    resource = client.semian_resource
+    assert_equal(resource, Semian.resources[client.semian_identifier])
+    assert_equal(client, Semian.consumers[client.semian_identifier].first)
+
+    # need to disable GC to ensure client weak reference is alive for assertion below
+    without_gc do
+      assert_equal(resource, client.semian_resource)
+      Semian.unregister_all_resources
+
+      assert_empty(Semian.resources)
+      assert_empty(Semian.consumers)
+
+      # The first call to client.semian_resource after unregistering all resources,
+      # should return a *different* (new) resource.
+      refute_equal(resource, client.semian_resource)
+    end
+  end
+
+  def test_consumer_registration_does_not_prevent_gc
+    client = Semian::AdapterTestClient.new(quota: 0.5)
+    client.semian_resource
+    identifier = client.semian_identifier
+
+    # Release the only strong reference to the client object
+    # so that it will be cleared on the forced GC run below
+    client = nil
+    weak_ref = Semian.consumers[identifier].first
+    assert_equal(true, weak_ref.weakref_alive?)
+
+    GC.start
+
+    assert_nil weak_ref.weakref_alive?
+
+    assert_raises WeakRef::RefError do
+      weak_ref.any_method_call
+    end
+  end
+
+  def without_gc
+    GC.disable
+    yield
+  ensure
+    GC.enable
+  end
+end

--- a/test/helpers/adapter_helper.rb
+++ b/test/helpers/adapter_helper.rb
@@ -1,0 +1,27 @@
+module Semian
+  module AdapterTest
+    include Semian::Adapter
+
+    def semian_identifier
+      :semian_adapter_test
+    end
+
+    def raw_semian_options
+      @client_options
+    end
+  end
+
+  class AdapterTestClient
+    include AdapterTest
+
+    def initialize(**args)
+      @client_options = args.merge(success_threshold: 1,
+                                   error_threshold: 1,
+                                   error_timeout: 1)
+    end
+
+    def ==(other)
+      inspect == other.inspect
+    end
+  end
+end

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -47,6 +47,20 @@ class TestResource < Minitest::Test
     create_resource :testing, quota: 0.5
   end
 
+  def test_unregister_past_0
+    workers = 10
+    resource = Semian.register(:testing, tickets: workers * 2, error_threshold: 0, error_timeout: 0, success_threshold: 0)
+
+    fork_workers(count: workers, tickets: 0, timeout: 0.5, wait_for_timeout: true) do
+      Semian.unregister(:testing)
+    end
+
+    signal_workers('TERM')
+    Process.waitall
+
+    assert_equal 0, resource.registered_workers
+  end
+
   def test_exactly_one_register_with_quota
     r = Semian::Resource.instance(:testing, quota: 0.5)
 

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -47,18 +47,6 @@ class TestResource < Minitest::Test
     create_resource :testing, quota: 0.5
   end
 
-  def test_unregister
-    assert_nil(Semian.resources[:testing])
-    resource = Semian.register(:testing, tickets: 2, error_threshold: 0, error_timeout: 0, success_threshold: 0)
-    assert_equal(Semian.resources[:testing], resource)
-
-    assert_equal 1, resource.registered_workers
-    Semian.unregister(:testing)
-    assert_equal 0, resource.registered_workers
-
-    assert_nil(Semian.resources[:testing])
-  end
-
   def test_exactly_one_register_with_quota
     r = Semian::Resource.instance(:testing, quota: 0.5)
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,7 @@ require 'fileutils'
 require 'helpers/background_helper'
 require 'helpers/circuit_breaker_helper'
 require 'helpers/resource_helper'
+require 'helpers/adapter_helper'
 
 Semian.logger = Logger.new(nil)
 Toxiproxy.populate([


### PR DESCRIPTION
# What

Functionality to track references to resource consumers - instances of
semian adaptors - has been added. Any time an instance of a semian adaptor
retrieves a semian resource, it will register itself as a consumer of the resource.

# Why

Some situations will necessitate clearing all semian resource references without actually destroying the underlying resource.

We need to clear the reference both globally (from the list of semian resources) but also any references that semian consumers may have.

An example case would be if a semian resource were initialized by a parent process before forking. In order for each child to receive their own unique resource reference (so that worker registration is accurate), clearing all semian resource references before forking is necessary.

# How

It is assumed that the resources are registered by an instance of a Semian::Adaptor. If that is the case, it will pass along a consumer reference (itself). If a resource is retrieved in another way, it is not supported and will not have its references cleared.

To avoid this preventing GC on the semian adaptor object, this reference is intentionally weak, and the weak reference is handled safely as it is indeed volatile.

On calling `Semian.unregister_all_resources`, every resource name will be unregistered and all consumers will have their references to the semian resource cleared.

