### PR TITLE
Stringkey and worker count

### DIFF
--- a/ext/semian/resource.h
+++ b/ext/semian/resource.h
@@ -69,12 +69,34 @@ semian_resource_tickets(VALUE self);
 
 /*
  * call-seq:
+ *    resource.registered_workers -> count
+ *
+ * Returns the number of workers (processes) registered to use the resource
+ */
+VALUE
+semian_resource_workers(VALUE self);
+
+/*
+ * call-seq:
  *    resource.semid -> id
  *
  * Returns the SysV semaphore id of a resource.
+ * Note: This value varies from system to system, and between
+ * instances of semian.
  */
 VALUE
 semian_resource_id(VALUE self);
+
+/*
+ * call-seq:
+ *    resource.key -> id
+ *
+ * Returns the hex string representation of SysV semaphore key of a resource.
+ * Note: This is a unique identifier that is portable across system
+ * and instances of semian.
+ */
+VALUE
+semian_resource_key(VALUE self);
 
 /*
  * call-seq:

--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -46,7 +46,9 @@ void Init_semian()
   rb_define_method(cResource, "acquire", semian_resource_acquire, -1);
   rb_define_method(cResource, "count", semian_resource_count, 0);
   rb_define_method(cResource, "semid", semian_resource_id, 0);
+  rb_define_method(cResource, "key", semian_resource_key, 0);
   rb_define_method(cResource, "tickets", semian_resource_tickets, 0);
+  rb_define_method(cResource, "registered_workers", semian_resource_workers, 0);
   rb_define_method(cResource, "destroy", semian_resource_destroy, 0);
   rb_define_method(cResource, "unregister_worker", semian_resource_unregister_worker, 0);
 

--- a/ext/semian/sysv_semaphores.h
+++ b/ext/semian/sysv_semaphores.h
@@ -70,8 +70,8 @@ void
 raise_semian_syscall_error(const char *syscall, int error_num);
 
 // Initialize the sysv semaphore structure
-int
-initialize_semaphore_set(const char* id_str, long permissions, int tickets, double quota);
+void
+initialize_semaphore_set(semian_resource_t* res, const char* id_str, long permissions, int tickets, double quota);
 
 // Set semaphore UNIX octal permissions
 void

--- a/ext/semian/types.h
+++ b/ext/semian/types.h
@@ -4,6 +4,7 @@ For custom type definitions specific to semian
 #ifndef SEMIAN_TYPES_H
 #define SEMIAN_TYPES_H
 
+#include <stdint.h>
 #include <sys/types.h>
 #include <sys/ipc.h>
 #include <sys/sem.h>
@@ -31,6 +32,8 @@ typedef struct {
   struct timespec timeout;
   double quota;
   int error;
+  uint64_t key;
+  char *strkey;
   char *name;
 } semian_resource_t;
 

--- a/lib/semian/resource.rb
+++ b/lib/semian/resource.rb
@@ -36,8 +36,16 @@ module Semian
       0
     end
 
+    def registered_workers
+      0
+    end
+
     def semid
       0
+    end
+
+    def key
+      '0x00000000'
     end
   end
 end

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -52,9 +52,9 @@ class TestResource < Minitest::Test
     resource = Semian.register(:testing, tickets: 2, error_threshold: 0, error_timeout: 0, success_threshold: 0)
     assert_equal(Semian.resources[:testing], resource)
 
-    assert_equal '1', resource.bulkhead.registered_workers
+    assert_equal 1, resource.bulkhead.registered_workers
     Semian.unregister(:testing)
-    assert_equal '0', resource.bulkhead.registered_workers
+    assert_equal 0, resource.bulkhead.registered_workers
 
     assert_nil(Semian.resources[:testing])
   end

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -52,9 +52,9 @@ class TestResource < Minitest::Test
     resource = Semian.register(:testing, tickets: 2, error_threshold: 0, error_timeout: 0, success_threshold: 0)
     assert_equal(Semian.resources[:testing], resource)
 
-    assert_equal '1', count_registered_workers(resource.semid)
+    assert_equal '1', resource.bulkhead.registered_workers
     Semian.unregister(:testing)
-    assert_equal '0', count_registered_workers(resource.semid)
+    assert_equal '0', resource.bulkhead.registered_workers
 
     assert_nil(Semian.resources[:testing])
   end
@@ -524,14 +524,6 @@ class TestResource < Minitest::Test
 
   def count_worker_timeouts
     Process.waitall.count { |s| s.last.exitstatus == 100 }
-  end
-
-  def count_registered_workers(semid)
-    `ipcs -si #{semid}`.lines.each do |line|
-      if /^3/.match(line) # 3 is the index of the registered workers
-        return line.split[1]
-      end
-    end
   end
 
   # Signals all workers

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -318,6 +318,18 @@ class TestResource < Minitest::Test
     FileUtils.rm_f(path) if path
   end
 
+  def test_get_resource_key
+    resource = create_resource :testing, tickets: 2
+    assert_equal('0x874714f2', resource.key)
+  end
+
+  def test_get_worker_count
+    workers = rand(5..20)
+    fork_workers(count: workers - 1, tickets: 1, timeout: 0.1, wait_for_timeout: true)
+    resource = create_resource :testing, tickets: 1
+    assert_equal(workers, resource.registered_workers)
+  end
+
   def test_count
     resource = create_resource :testing, tickets: 2
     acquired = false


### PR DESCRIPTION
# What

Expose two new useful internals of semian:

* Sysv IPC key for the resource, represented as a hex string.
* Current count of the number of registered workers

# Why

* The sysv IPC key - extremely useful for manually diagnosing and debugging via `ipcs` as it is portable across systems. I had previously been manually adding an `sprintf` on a regular basis in order to debug, so may as well make this a first class citizen
* A count of the current number of registered workers. In particular, this is useful as a metric to be emitted via statsd, so exposing it as a resource method makes sense.

# How

Some minor code reorganization, adding new members to the resource struct and passing it in and referencing it to the sysv_semaphore initializer.

A couple of accessor functions exposed to ruby to be able to read these values directly.