### PR TITLE
Expose sysv IPC key to semian resource in ruby.

### DIFF
--- a/ext/semian/resource.c
+++ b/ext/semian/resource.c
@@ -158,6 +158,14 @@ semian_resource_id(VALUE self)
 }
 
 VALUE
+semian_resource_key(VALUE self)
+{
+  semian_resource_t *res = NULL;
+  TypedData_Get_Struct(self, semian_resource_t, &semian_resource_type, res);
+  return rb_str_new_cstr(res->strkey);
+}
+
+VALUE
 semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VALUE permissions, VALUE default_timeout)
 {
   long c_permissions;
@@ -182,7 +190,9 @@ semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VAL
   ms_to_timespec(c_timeout * 1000, &res->timeout);
   res->name = strdup(c_id_str);
   res->quota = c_quota;
-  res->sem_id = initialize_semaphore_set(c_id_str, c_permissions, c_tickets, c_quota);
+
+  // Initialize the semaphore set
+  initialize_semaphore_set(res, c_id_str, c_permissions, c_tickets, c_quota);
 
   return self;
 }

--- a/ext/semian/resource.h
+++ b/ext/semian/resource.h
@@ -81,9 +81,22 @@ semian_resource_workers(VALUE self);
  *    resource.semid -> id
  *
  * Returns the SysV semaphore id of a resource.
+ * Note: This value varies from system to system, and between
+ * instances of semian.
  */
 VALUE
 semian_resource_id(VALUE self);
+
+/*
+ * call-seq:
+ *    resource.key -> id
+ *
+ * Returns the hex string representation of SysV semaphore key of a resource.
+ * Note: This is a unique identifier that is portable across system
+ * and instances of semian.
+ */
+VALUE
+semian_resource_key(VALUE self);
 
 /*
  * call-seq:

--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -46,6 +46,7 @@ void Init_semian()
   rb_define_method(cResource, "acquire", semian_resource_acquire, -1);
   rb_define_method(cResource, "count", semian_resource_count, 0);
   rb_define_method(cResource, "semid", semian_resource_id, 0);
+  rb_define_method(cResource, "key", semian_resource_key, 0);
   rb_define_method(cResource, "tickets", semian_resource_tickets, 0);
   rb_define_method(cResource, "registered_workers", semian_resource_workers, 0);
   rb_define_method(cResource, "destroy", semian_resource_destroy, 0);

--- a/ext/semian/sysv_semaphores.c
+++ b/ext/semian/sysv_semaphores.c
@@ -23,47 +23,45 @@ raise_semian_syscall_error(const char *syscall, int error_num)
   rb_raise(eSyscall, "%s failed, errno: %d (%s)", syscall, error_num, strerror(error_num));
 }
 
-int
-initialize_semaphore_set(const char* id_str, long permissions, int tickets, double quota)
+void
+initialize_semaphore_set(semian_resource_t* res, const char* id_str, long permissions, int tickets, double quota)
 {
-  int sem_id;
-  key_t key;
 
-  key = generate_key(id_str);
-  sem_id = semget(key, SI_NUM_SEMAPHORES, IPC_CREAT | IPC_EXCL | permissions);
+  res->key = generate_key(id_str);
+  res->strkey = (char*)  malloc((2 /*for 0x*/+ sizeof(uint64_t) /*actual key*/+ 1 /*null*/) * sizeof(char));
+  sprintf(res->strkey, "0x%08x", (unsigned int) res->key);
+  res->sem_id = semget(res->key, SI_NUM_SEMAPHORES, IPC_CREAT | IPC_EXCL | permissions);
 
   /*
   This approach is based on http://man7.org/tlpi/code/online/dist/svsem/svsem_good_init.c.html
   which avoids race conditions when initializing semaphore sets.
   */
-  if (sem_id != -1) {
+  if (res->sem_id != -1) {
     // Happy path - we are the first worker, initialize the semaphore set.
-    initialize_new_semaphore_values(sem_id, permissions);
+    initialize_new_semaphore_values(res->sem_id, permissions);
   } else {
     // Something went wrong
     if (errno != EEXIST) {
       raise_semian_syscall_error("semget() failed to initialize semaphore values", errno);
     } else {
       // The semaphore set already exists, ensure it is initialized
-      sem_id = wait_for_new_semaphore_set(key, permissions);
+      res->sem_id = wait_for_new_semaphore_set(res->key, permissions);
     }
   }
 
-  set_semaphore_permissions(sem_id, permissions);
+  set_semaphore_permissions(res->sem_id, permissions);
 
   /*
     Ensure that a worker for this process is registered.
     Note that from ruby we ensure that at most one worker may be registered per process.
   */
-  if (perform_semop(sem_id, SI_SEM_REGISTERED_WORKERS, 1, SEM_UNDO, NULL) == -1) {
+  if (perform_semop(res->sem_id, SI_SEM_REGISTERED_WORKERS, 1, SEM_UNDO, NULL) == -1) {
     rb_raise(eInternal, "error incrementing registered workers, errno: %d (%s)", errno, strerror(errno));
   }
 
-  sem_meta_lock(sem_id); // Sets otime for the first time by acquiring the sem lock
-  configure_tickets(sem_id, tickets,  quota);
-  sem_meta_unlock(sem_id);
-
-  return sem_id;
+  sem_meta_lock(res->sem_id); // Sets otime for the first time by acquiring the sem lock
+  configure_tickets(res->sem_id, tickets,  quota);
+  sem_meta_unlock(res->sem_id);
 }
 
 void

--- a/ext/semian/sysv_semaphores.h
+++ b/ext/semian/sysv_semaphores.h
@@ -70,8 +70,8 @@ void
 raise_semian_syscall_error(const char *syscall, int error_num);
 
 // Initialize the sysv semaphore structure
-int
-initialize_semaphore_set(const char* id_str, long permissions, int tickets, double quota);
+void
+initialize_semaphore_set(semian_resource_t* res, const char* id_str, long permissions, int tickets, double quota);
 
 // Set semaphore UNIX octal permissions
 void

--- a/ext/semian/types.h
+++ b/ext/semian/types.h
@@ -4,6 +4,7 @@ For custom type definitions specific to semian
 #ifndef SEMIAN_TYPES_H
 #define SEMIAN_TYPES_H
 
+#include <stdint.h>
 #include <sys/types.h>
 #include <sys/ipc.h>
 #include <sys/sem.h>
@@ -31,6 +32,8 @@ typedef struct {
   struct timespec timeout;
   double quota;
   int error;
+  uint64_t key;
+  char *strkey;
   char *name;
 } semian_resource_t;
 

--- a/lib/semian/resource.rb
+++ b/lib/semian/resource.rb
@@ -43,5 +43,9 @@ module Semian
     def semid
       0
     end
+
+    def key
+      '0x00000000'
+    end
   end
 end

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -325,6 +325,11 @@ class TestResource < Minitest::Test
     assert_equal(workers, resource.registered_workers)
   end
 
+  def test_get_resource_key
+    resource = create_resource :testing, tickets: 2
+    assert_equal('0x874714f2', resource.key)
+  end
+
   def test_count
     resource = create_resource :testing, tickets: 2
     acquired = false


### PR DESCRIPTION
# What

Exposes the string representation of the hexadecimal sysvIPC key.

The Sysv IPC resource key is a portable hexadecimal string that uniquely identifies a particular resource.

# Why

The sysv IPC key is extremely useful for manually diagnosing and debugging via `ipcs` as it is portable across systems. I had previously been manually adding an `sprintf` on a regular basis in order to debug, so may as well make this a first class citizen

# How

Some minor code reorganization, adding new members to the resource struct and passing it in and referencing it to the sysv_semaphore initializer.


