### PR TITLE
Expose registered worker count to resource in rubyland

### DIFF
--- a/ext/semian/resource.c
+++ b/ext/semian/resource.c
@@ -135,6 +135,21 @@ semian_resource_tickets(VALUE self)
 }
 
 VALUE
+semian_resource_workers(VALUE self)
+{
+  int ret;
+  semian_resource_t *res = NULL;
+
+  TypedData_Get_Struct(self, semian_resource_t, &semian_resource_type, res);
+  ret = semctl(res->sem_id, SI_SEM_REGISTERED_WORKERS, GETVAL);
+  if (ret == -1) {
+    raise_semian_syscall_error("semctl()", errno);
+  }
+
+  return LONG2FIX(ret);
+}
+
+VALUE
 semian_resource_id(VALUE self)
 {
   semian_resource_t *res = NULL;

--- a/ext/semian/resource.h
+++ b/ext/semian/resource.h
@@ -69,6 +69,15 @@ semian_resource_tickets(VALUE self);
 
 /*
  * call-seq:
+ *    resource.registered_workers -> count
+ *
+ * Returns the number of workers (processes) registered to use the resource
+ */
+VALUE
+semian_resource_workers(VALUE self);
+
+/*
+ * call-seq:
  *    resource.semid -> id
  *
  * Returns the SysV semaphore id of a resource.

--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -47,6 +47,7 @@ void Init_semian()
   rb_define_method(cResource, "count", semian_resource_count, 0);
   rb_define_method(cResource, "semid", semian_resource_id, 0);
   rb_define_method(cResource, "tickets", semian_resource_tickets, 0);
+  rb_define_method(cResource, "registered_workers", semian_resource_workers, 0);
   rb_define_method(cResource, "destroy", semian_resource_destroy, 0);
   rb_define_method(cResource, "unregister_worker", semian_resource_unregister_worker, 0);
 

--- a/lib/semian/resource.rb
+++ b/lib/semian/resource.rb
@@ -36,6 +36,10 @@ module Semian
       0
     end
 
+    def registered_workers
+      0
+    end
+
     def semid
       0
     end


### PR DESCRIPTION
# What

Expose the registered worker count to the ruby

# Why

The number of registered workers is extremely important to keep track of for the quota strategy. Exposing it to the resource allows for it to be emitted as a statsd metric very easily.

# How

Essentially, this is just a standard accessor pattern.