### PR TITLE
Expose registered workers

### DIFF
--- a/lib/semian/protected_resource.rb
+++ b/lib/semian/protected_resource.rb
@@ -2,7 +2,7 @@ module Semian
   class ProtectedResource
     extend Forwardable
 
-    def_delegators :@bulkhead, :destroy, :count, :semid, :tickets, :name
+    def_delegators :@bulkhead, :destroy, :count, :semid, :tickets, :registered_workers, :name
     def_delegators :@circuit_breaker, :reset, :mark_failed, :mark_success, :request_allowed?,
                    :open?, :closed?, :half_open?
 

--- a/lib/semian/unprotected_resource.rb
+++ b/lib/semian/unprotected_resource.rb
@@ -8,6 +8,10 @@ module Semian
       @name = name
     end
 
+    def registered_workers
+      0
+    end
+
     def tickets
       -1
     end

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -52,9 +52,9 @@ class TestResource < Minitest::Test
     resource = Semian.register(:testing, tickets: 2, error_threshold: 0, error_timeout: 0, success_threshold: 0)
     assert_equal(Semian.resources[:testing], resource)
 
-    assert_equal 1, resource.bulkhead.registered_workers
+    assert_equal 1, resource.registered_workers
     Semian.unregister(:testing)
-    assert_equal 0, resource.bulkhead.registered_workers
+    assert_equal 0, resource.registered_workers
 
     assert_nil(Semian.resources[:testing])
   end


### PR DESCRIPTION
# What

Expose registered_workers to resources through bulkheads.

# Why

Easier access, in line with other accessors.