### PR TITLE
Specify a minimum number of tickets of 2 using quota strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ In this case, we'd allow 50% of the workers on a particular host to connect to t
 
 - You must pass **exactly** one of ticket or quota.
 - Tickets available will be the ceiling of the quota ratio to the number of workers
- - So, with one worker, there will always be a minimum of 1 ticket
 - Workers in different processes will automatically unregister when the process exits.
+- The `quota_min_tickets` value specifies the minimum tickets to allocate using this strategy, defaulting to 2.
 
 #### Net::HTTP
 For the `Net::HTTP` specific Semian adapter, since many external libraries may create

--- a/ext/semian/resource.h
+++ b/ext/semian/resource.h
@@ -20,7 +20,7 @@ int system_max_semaphore_count;
  * Creates a new Resource. Do not create resources directly. Use Semian.register.
  */
 VALUE
-semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VALUE permissions, VALUE default_timeout);
+semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VALUE quota_min_tickets, VALUE permissions, VALUE default_timeout);
 
 /*
  * call-seq:

--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -42,7 +42,7 @@ void Init_semian()
   eInternal = rb_const_get(cSemian, rb_intern("InternalError"));
 
   rb_define_alloc_func(cResource, semian_resource_alloc);
-  rb_define_method(cResource, "initialize_semaphore", semian_resource_initialize, 5);
+  rb_define_method(cResource, "initialize_semaphore", semian_resource_initialize, 6);
   rb_define_method(cResource, "acquire", semian_resource_acquire, -1);
   rb_define_method(cResource, "count", semian_resource_count, 0);
   rb_define_method(cResource, "semid", semian_resource_id, 0);

--- a/ext/semian/sysv_semaphores.c
+++ b/ext/semian/sysv_semaphores.c
@@ -60,7 +60,7 @@ initialize_semaphore_set(semian_resource_t* res, const char* id_str, long permis
   }
 
   sem_meta_lock(res->sem_id); // Sets otime for the first time by acquiring the sem lock
-  configure_tickets(res->sem_id, tickets,  quota);
+  configure_tickets(res);
   sem_meta_unlock(res->sem_id);
 }
 

--- a/ext/semian/tickets.h
+++ b/ext/semian/tickets.h
@@ -8,6 +8,6 @@ For logic specific to manipulating semian ticket counts
 
 // Set initial ticket values upon resource creation
 void
-configure_tickets(int sem_id, int tickets, double quota);
+configure_tickets(semian_resource_t *res);
 
 #endif // SEMIAN_TICKETS_H

--- a/ext/semian/types.h
+++ b/ext/semian/types.h
@@ -31,6 +31,8 @@ typedef struct {
   int sem_id;
   struct timespec timeout;
   double quota;
+  unsigned int quota_min_tickets;
+  int tickets;
   int error;
   uint64_t key;
   char *strkey;

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -132,6 +132,9 @@ module Semian
   # Mutually exclusive with the 'ticket' argument.
   # but the resource must have been previously registered otherwise an error will be raised. (bulkhead)
   #
+  # +quota_min_tickets+: The minimum number of tickets to use when tickets are calculated by quota.
+  # this is primarily to prevent over-sensitive bulkheads when there is a very small number of workers.
+  #
   # +permissions+: Octal permissions of the resource. Default 0660. (bulkhead)
   #
   # +timeout+: Default timeout in seconds. Default 0. (bulkhead)

--- a/lib/semian/resource.rb
+++ b/lib/semian/resource.rb
@@ -9,9 +9,9 @@ module Semian
       end
     end
 
-    def initialize(name, tickets: nil, quota: nil, permissions: 0660, timeout: 0)
+    def initialize(name, tickets: nil, quota: nil, quota_min_tickets: 2, permissions: 0660, timeout: 0)
       if Semian.semaphores_enabled?
-        initialize_semaphore(name, tickets, quota, permissions, timeout) if respond_to?(:initialize_semaphore)
+        initialize_semaphore(name, tickets, quota, quota_min_tickets, permissions, timeout) if respond_to?(:initialize_semaphore)
       else
         Semian.issue_disabled_semaphores_warning
       end


### PR DESCRIPTION
# What

Provide a value for the minimum number of tickets using the ticket quota strategy.

We default this to 2, to prevent issues where there is a small number of registered workers. It may be overridden.

This may be overridden by the user, but 2 is likely to be a reasonable default to prevent an overly-sensitive bulkhead.

# Why

If we have a very small number of registered workers, the bulkhead may be overly sensitive. For instance, if we have 2 workers with a quota of 0.5:

* 2 * 0.5 = 1 ticket
* Worker 1 acquires the ticket, but needs X time before it can release it
* During this, worker 2 tries to acquire the ticket, but has a timeout of Y

If X > Y in this situation, worker 2 will time out. 

This could be the case for resources that are accessed very infrequently or have a very small number of workers that might access them.

# How

If the number of workers calculated by the quota is less than the minimum, use the minimum instead.