### PR TITLE
Prevent races while unregistering

### DIFF
--- a/ext/semian/resource.c
+++ b/ext/semian/resource.c
@@ -97,13 +97,15 @@ semian_resource_unregister_worker(VALUE self)
 
   TypedData_Get_Struct(self, semian_resource_t, &semian_resource_type, res);
 
-  if (perform_semop(res->sem_id, SI_SEM_REGISTERED_WORKERS, -1, IPC_NOWAIT, NULL) == -1) {
+  sem_meta_lock(res->sem_id);
+  if (perform_semop(res->sem_id, SI_SEM_REGISTERED_WORKERS, -1, IPC_NOWAIT | SEM_UNDO, NULL) == -1) {
     // Allow EAGAIN with IPC_NOWAIT, as this signals that all workers were unregistered
     // Otherwise, we might block forever or throw an unintended timeout
     if (errno != EAGAIN) {
       rb_raise(eInternal, "error decreasing registered workers, errno: %d (%s)", errno, strerror(errno));
     }
   }
+  sem_meta_unlock(res->sem_id);
 
   return Qtrue;
 }

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -55,6 +55,7 @@ class TestResource < Minitest::Test
       Semian.unregister(:testing)
     end
 
+    Semian.unregister(:testing)
     signal_workers('TERM')
     Process.waitall
 


### PR DESCRIPTION
# What

This fixes a bug with unregister where if unregister is not done with SEM_UNDO.

This can cause the worker count to be incorrect if the decrementing of the worker count is done from a parent process before forking, as it can decrement a value that was actually incremented by a child, causing this to never be incremented again because it will disappear when the parent exits.

# How

The addition of SEM_UNDO will cause the parent to undo the deregistration when it exits, so that if it had taken a child's ticket it will return it when it exits.

Also, sem_meta_lock added to make this easier to reason about.