### PR TITLE
Add helper to forcefully reset worker counts

### DIFF
--- a/ext/semian/resource.c
+++ b/ext/semian/resource.c
@@ -91,6 +91,24 @@ semian_resource_destroy(VALUE self)
 }
 
 VALUE
+semian_resource_reset_workers(VALUE self)
+{
+
+  semian_resource_t *res = NULL;
+
+  TypedData_Get_Struct(self, semian_resource_t, &semian_resource_type, res);
+
+  sem_meta_lock(res->sem_id);
+  // This SETVAL will purge the SEM_UNDO table
+  if (semctl(res->sem_id, SI_SEM_REGISTERED_WORKERS, SETVAL, 0) == -1) {
+    raise_semian_syscall_error("semctl()", errno);
+  }
+  sem_meta_unlock(res->sem_id);
+
+  return Qtrue;
+}
+
+VALUE
 semian_resource_unregister_worker(VALUE self)
 {
   semian_resource_t *res = NULL;

--- a/ext/semian/resource.h
+++ b/ext/semian/resource.h
@@ -51,6 +51,18 @@ semian_resource_destroy(VALUE self);
 
 /*
  * call-seq:
+ *   resource.reset_registered_workers!() -> true
+ *
+ * Unregisters all registered workers for a resource, forcefully setting the worker count back to 0.
+ * This will purge the SEM_UNDO table.
+ *
+ * Use this method very carefully.
+ */
+VALUE
+semian_resource_reset_workers(VALUE self);
+
+/*
+ * call-seq:
  *    resource.count -> count
  *
  * Returns the current ticket count for a resource.

--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -50,6 +50,7 @@ void Init_semian()
   rb_define_method(cResource, "tickets", semian_resource_tickets, 0);
   rb_define_method(cResource, "registered_workers", semian_resource_workers, 0);
   rb_define_method(cResource, "destroy", semian_resource_destroy, 0);
+  rb_define_method(cResource, "reset_registered_workers!", semian_resource_reset_workers, 0);
   rb_define_method(cResource, "unregister_worker", semian_resource_unregister_worker, 0);
 
   id_timeout = rb_intern("timeout");

--- a/lib/semian/resource.rb
+++ b/lib/semian/resource.rb
@@ -18,6 +18,9 @@ module Semian
       @name = name
     end
 
+    def reset_registered_workers!
+    end
+
     def destroy
     end
 

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -62,6 +62,21 @@ class TestResource < Minitest::Test
     assert_equal 0, resource.registered_workers
   end
 
+  def test_reset_registered_workers
+    workers = 10
+    resource = Semian.register(:testing, tickets: 1, error_threshold: 0, error_timeout: 0, success_threshold: 0)
+
+    fork_workers(count: workers - 1, tickets: 0, timeout: 0.5, wait_for_timeout: true)
+
+    assert_equal workers, resource.registered_workers
+    resource.bulkhead.reset_registered_workers!
+    assert_equal 0, resource.registered_workers
+
+    signal_workers('TERM')
+    Process.waitall
+    assert_equal 0, resource.registered_workers
+  end
+
   def test_exactly_one_register_with_quota
     r = Semian::Resource.instance(:testing, quota: 0.5)
 


### PR DESCRIPTION
# What

Add a helper to forcefully reset registered worker counts to zero.

# Why

In case if the worker count gets corrupted, this is safe to do for resources using static tickets.

# How

This method would need to be manually invoked, and then the next time the workers restart they should correctly register themselves. semctl with SETVAL will clear the SEM_UNDO table, which should cause the next registration to proceed correctly.

This is only safe on resources that are using static tickets or for debugging / diagnostic purposes, and should not be called regularly.