### PR TITLE
Must be able to access name without a bulkhead

### DIFF
--- a/lib/semian/circuit_breaker.rb
+++ b/lib/semian/circuit_breaker.rb
@@ -2,6 +2,8 @@ module Semian
   class CircuitBreaker #:nodoc:
     extend Forwardable
 
+    attr_reader :name
+
     def_delegators :@state, :closed?, :open?, :half_open?
 
     def initialize(name, exceptions:, success_threshold:, error_threshold:, error_timeout:, implementation:)

--- a/lib/semian/protected_resource.rb
+++ b/lib/semian/protected_resource.rb
@@ -2,15 +2,16 @@ module Semian
   class ProtectedResource
     extend Forwardable
 
-    def_delegators :@bulkhead, :destroy, :count, :semid, :tickets, :registered_workers, :name
+    def_delegators :@bulkhead, :destroy, :count, :semid, :tickets, :registered_workers
     def_delegators :@circuit_breaker, :reset, :mark_failed, :mark_success, :request_allowed?,
                    :open?, :closed?, :half_open?
 
-    attr_reader :bulkhead, :circuit_breaker
+    attr_reader :bulkhead, :circuit_breaker, :name
 
     def initialize(bulkhead, circuit_breaker)
       @bulkhead = bulkhead
       @circuit_breaker = circuit_breaker
+      assign_name
     end
 
     def destroy
@@ -53,6 +54,11 @@ module Semian
     rescue ::Semian::TimeoutError
       Semian.notify(:busy, self, scope, adapter)
       raise
+    end
+
+    def assign_name
+      @name = @bulkhead.name if @bulkhead
+      @name ||= @circuit_breaker.name if @circuit_breaker
     end
   end
 end

--- a/test/protected_resource_test.rb
+++ b/test/protected_resource_test.rb
@@ -16,6 +16,33 @@ class TestProtectedResource < Minitest::Test
     super
   end
 
+  def test_get_name_without_bulkhead
+    Semian.register(
+      :testing,
+      exceptions: [SomeError],
+      error_threshold: 2,
+      error_timeout: 5,
+      success_threshold: 1,
+      bulkhead: false,
+    )
+
+    refute_nil Semian.resources[:testing].name
+  end
+
+  def test_get_name_without_bulkhead_or_circuit_breaker
+    Semian.register(
+      :testing,
+      exceptions: [SomeError],
+      error_threshold: 2,
+      error_timeout: 5,
+      success_threshold: 1,
+      bulkhead: false,
+      circuit_breaker: false,
+    )
+
+    assert_nil Semian.resources[:testing].name
+  end
+
   def test_acquire_without_bulkhead
     Semian.register(
       :testing,


### PR DESCRIPTION
# What

Prevent a nil pointer dereference if attempting to read the name of a protected resource without a bulkhead.

# Why

Since bulkheads are now optional, we shouldn't delegate name explicitly to them, as this can result in a nil pointer dereference.

# How

The name is attempted to be read from the bulkhead first, falling back to the circuit breaker. If neither works, it will be nil, but it won't cause an exception to be raised from a nil pointer dereference.