### PR TITLE
Add new mysql connection error

### DIFF
--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -25,6 +25,7 @@ module Semian
       /MySQL server has gone away/i,
       /Too many connections/i,
       /closed MySQL connection/i,
+      /MySQL client is not connected/i,
     )
 
     ResourceBusyError = ::Mysql2::ResourceBusyError


### PR DESCRIPTION
During our gem bump of `mysql2` (to 0.4.5), we noticed that we weren't throwing any `Mysql2::CircuitOpenError` exceptions, since a new mysql exception message was being used: `MySQL client is not connected`.

cc @georgetzavelas @bibstha 