### PR TITLE
circuit_breaker: thread-safe by default

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -115,3 +115,6 @@ Style/CaseIndentation:
 Lint/UselessAssignment:
   Exclude:
     - 'test/adapter_test.rb'
+
+Style/ModuleLength:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -127,9 +127,16 @@ client = Redis.new(semian: {
 })
 ```
 
-#### Warning: Thread unsafe
+#### Thread Safety
 
-Semian is currently known to be thread-unsafe, and is intended to be used by *separate processes*.
+Semian's circuit breaker implementation is thread-safe by default as of
+`v0.7.0`. If you'd like to disable it for performance reasons, pass
+`thread_safety_disabled: true` to the resource options.
+
+Bulkheads should be disabled (pass `tickets: false`) in a threaded environment
+(e.g. Puma or Sidekiq), but can safely be enabled in non-threaded environments
+(e.g. Resque and Unicorn). As described in this document, circuit breakers alone
+should be adequate in most environments with reasonably low timeouts.
 
 Internally, semian uses `SEM_UNDO` for several sysv semaphore operations:
 

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -1,6 +1,7 @@
 require 'forwardable'
 require 'logger'
 require 'weakref'
+require 'thread'
 
 require 'semian/version'
 require 'semian/instrumentable'
@@ -78,7 +79,6 @@ require 'semian/simple_state'
 #    end
 #
 # This is the same as the previous example, but overrides the timeout from the default value of 500 milliseconds to 1 second.
-#
 module Semian
   extend self
   extend Instrumentable
@@ -235,6 +235,7 @@ module Semian
     circuit_breaker = options.fetch(:circuit_breaker, true)
     return unless circuit_breaker
     raise ArgumentError unless required_keys?([:success_threshold, :error_threshold, :error_timeout], options)
+    implementation = options[:thread_safety_disabled] ? ::Semian::Simple : ::Semian::ThreadSafe
 
     exceptions = options[:exceptions] || []
     CircuitBreaker.new(
@@ -243,7 +244,7 @@ module Semian
       error_threshold: options[:error_threshold],
       error_timeout: options[:error_timeout],
       exceptions: Array(exceptions) + [::Semian::BaseError],
-      implementation: ::Semian::Simple,
+      implementation: implementation,
     )
   end
 

--- a/lib/semian/simple_integer.rb
+++ b/lib/semian/simple_integer.rb
@@ -1,3 +1,5 @@
+require 'thread'
+
 module Semian
   module Simple
     class Integer #:nodoc:
@@ -17,6 +19,19 @@ module Semian
 
       def destroy
         reset
+      end
+    end
+  end
+
+  module ThreadSafe
+    class Integer < Simple::Integer
+      def initialize(*)
+        super
+        @lock = Mutex.new
+      end
+
+      def increment(*)
+        @lock.synchronize { super }
       end
     end
   end

--- a/lib/semian/simple_state.rb
+++ b/lib/semian/simple_state.rb
@@ -40,4 +40,11 @@ module Semian
       end
     end
   end
+
+  module ThreadSafe
+    class State < Simple::State
+      # These operations are already safe for a threaded environment since it's
+      # a simple assignment.
+    end
+  end
 end

--- a/test/simple_integer_test.rb
+++ b/test/simple_integer_test.rb
@@ -1,10 +1,8 @@
 require 'test_helper'
 
 class TestSimpleInteger < Minitest::Test
-  CLASS = ::Semian::Simple::Integer
-
   def setup
-    @integer = CLASS.new
+    @integer = ::Semian::ThreadSafe::Integer.new
   end
 
   def teardown

--- a/test/simple_sliding_window_test.rb
+++ b/test/simple_sliding_window_test.rb
@@ -1,10 +1,8 @@
 require 'test_helper'
 
 class TestSimpleSlidingWindow < Minitest::Test
-  CLASS = ::Semian::Simple::SlidingWindow
-
   def setup
-    @sliding_window = CLASS.new(max_size: 6)
+    @sliding_window = ::Semian::ThreadSafe::SlidingWindow.new(max_size: 6)
     @sliding_window.clear
   end
 
@@ -12,54 +10,32 @@ class TestSimpleSlidingWindow < Minitest::Test
     @sliding_window.destroy
   end
 
-  module SlidingWindowTestCases
-    def test_sliding_window_push
-      assert_equal(0, @sliding_window.size)
-      @sliding_window << 1
-      assert_sliding_window(@sliding_window, [1], 6)
-      @sliding_window << 5
-      assert_sliding_window(@sliding_window, [1, 5], 6)
-    end
-
-    def test_sliding_window_resize
-      assert_equal(0, @sliding_window.size)
-      @sliding_window << 1 << 2 << 3 << 4 << 5 << 6
-      assert_sliding_window(@sliding_window, [1, 2, 3, 4, 5, 6], 6)
-      @sliding_window.resize_to 6
-      assert_sliding_window(@sliding_window, [1, 2, 3, 4, 5, 6], 6)
-      @sliding_window.resize_to 5
-      assert_sliding_window(@sliding_window, [2, 3, 4, 5, 6], 5)
-      @sliding_window.resize_to 6
-      assert_sliding_window(@sliding_window, [2, 3, 4, 5, 6], 6)
-    end
-
-    def test_sliding_window_edge_falloff
-      assert_equal(0, @sliding_window.size)
-      @sliding_window << 0 << 1 << 2 << 3 << 4 << 5 << 6 << 7
-      assert_sliding_window(@sliding_window, [2, 3, 4, 5, 6, 7], 6)
-      @sliding_window.shift
-      assert_sliding_window(@sliding_window, [3, 4, 5, 6, 7], 6)
-    end
-
-    def resize_to_less_than_1_raises
-      assert_raises ArgumentError do
-        @sliding_window.resize_to 0
-      end
-    end
+  def test_sliding_window_push
+    assert_equal(0, @sliding_window.size)
+    @sliding_window << 1
+    assert_sliding_window(@sliding_window, [1], 6)
+    @sliding_window << 5
+    assert_sliding_window(@sliding_window, [1, 5], 6)
   end
 
-  module SlidingWindowUtilityMethods
-    def assert_sliding_window(sliding_window, array, max_size)
-      # Get private member, the sliding_window doesn't expose the entire array
-      data = sliding_window.instance_variable_get("@window")
-      assert_equal(array, data)
-      assert_equal(max_size, sliding_window.max_size)
-    end
+  def test_sliding_window_edge_falloff
+    assert_equal(0, @sliding_window.size)
+    @sliding_window << 0 << 1 << 2 << 3 << 4 << 5 << 6 << 7
+    assert_sliding_window(@sliding_window, [2, 3, 4, 5, 6, 7], 6)
   end
 
-  include SlidingWindowTestCases
+  def resize_to_less_than_1_raises
+    assert_raises ArgumentError do
+      @sliding_window.resize_to 0
+    end
+  end
 
   private
 
-  include SlidingWindowUtilityMethods
+  def assert_sliding_window(sliding_window, array, max_size)
+    # Get private member, the sliding_window doesn't expose the entire array
+    data = sliding_window.instance_variable_get("@window")
+    assert_equal(array, data)
+    assert_equal(max_size, sliding_window.max_size)
+  end
 end

--- a/test/simple_state_test.rb
+++ b/test/simple_state_test.rb
@@ -1,10 +1,8 @@
 require 'test_helper'
 
 class TestSimpleEnum < Minitest::Test
-  CLASS = ::Semian::Simple::State
-
   def setup
-    @state = CLASS.new
+    @state = ::Semian::ThreadSafe::State.new
   end
 
   def teardown


### PR DESCRIPTION
This is a stab at making Semian thread-safe for circuit breakers. It's not absolutely perfect, I'm sure—but I'm reasonably confident this is _good enough_ (and it's hard to do more than that with the limited concurrency tooling for Ruby).

This is coming out of a need for internal applications to adopt Semian for Sidekiq and Puma.

**How did you determine it's thread-safe?** I went through the logic from boot (creation of the resource) to checking the circuit breaker. The major culprit for races is around adding entries to the sliding window and trimming it. The rest of the races fixed are fairly harmless.

**Why didn't you make bulkheads thread-safe as well?** As outlined in the README, this is not trivial. However, I believe that for most applications—and especially threaded ones—circuit breakers will be enough if you have a reasonably low timeout (see the README for more details about why that is). Thus the recommendation is to disable bulkheads for threaded apps.

**Why did you enable thread-safety by default?** It's not a breaking change, but it may have performance implications. Semian is a major hotspot, so we want a way to disable it, which I'll use in e.g. Shopify Core. People can disable it as desired.

**Why are there no new tests?** Testing for race conditions in Ruby is very tricky, and generally not worth the effort—it brings as much confidence in your ability to write sketchy signaling tests as it does actually test for races. The existing test suite is quite good, and all the mutex code is hit.

**What's with all this `::Simple` and `::ThreadSafe` stuff?** In preparation in the past for different adapters (e.g. a SysV-based circuit breaker), this was all abstracted out. This actually serves me nicely now. I don't want to create a ton of files, so I just kept it like this—we don't autoload in this library, so I think it's OK.

\cc @gigr @shelsen @meagar @jacobbednarz