### PR TITLE
change name delegator from bulkhead to circuit_breaker

### DIFF
--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -153,7 +153,11 @@ module Semian
     circuit_breaker = create_circuit_breaker(name, **options)
     bulkhead = create_bulkhead(name, **options)
 
-    resources[name] = ProtectedResource.new(bulkhead, circuit_breaker)
+    if circuit_breaker.nil? && bulkhead.nil?
+      raise ArgumentError, 'Both bulkhead and circuitbreaker cannot be disabled.'
+    end
+
+    resources[name] = ProtectedResource.new(name, bulkhead, circuit_breaker)
   end
 
   def retrieve_or_register(name, **args)

--- a/lib/semian/circuit_breaker.rb
+++ b/lib/semian/circuit_breaker.rb
@@ -4,6 +4,8 @@ module Semian
 
     def_delegators :@state, :closed?, :open?, :half_open?
 
+    attr_reader :name
+
     def initialize(name, exceptions:, success_threshold:, error_threshold:, error_timeout:, implementation:)
       @name = name.to_sym
       @success_count_threshold = success_threshold

--- a/lib/semian/protected_resource.rb
+++ b/lib/semian/protected_resource.rb
@@ -2,13 +2,14 @@ module Semian
   class ProtectedResource
     extend Forwardable
 
-    def_delegators :@bulkhead, :destroy, :count, :semid, :tickets, :registered_workers, :name
+    def_delegators :@bulkhead, :destroy, :count, :semid, :tickets, :registered_workers
     def_delegators :@circuit_breaker, :reset, :mark_failed, :mark_success, :request_allowed?,
                    :open?, :closed?, :half_open?
 
-    attr_reader :bulkhead, :circuit_breaker
+    attr_reader :bulkhead, :circuit_breaker, :name
 
-    def initialize(bulkhead, circuit_breaker)
+    def initialize(name, bulkhead, circuit_breaker)
+      @name = name
       @bulkhead = bulkhead
       @circuit_breaker = circuit_breaker
     end

--- a/test/protected_resource_test.rb
+++ b/test/protected_resource_test.rb
@@ -82,4 +82,34 @@ class TestProtectedResource < Minitest::Test
 
     assert acquired
   end
+
+  def test_register_without_any_resource_fails
+    assert_raises ArgumentError do
+      Semian.register(
+        :testing,
+        circuit_breaker: false,
+      )
+    end
+  end
+
+  def test_responds_to_name_when_bulkhead_or_circuit_breaker_disabled
+    Semian.register(
+      :no_bulkhead,
+      error_threshold: 2,
+      error_timeout: 5,
+      success_threshold: 1,
+      bulkhead: false,
+      circuit_breaker: true,
+    )
+
+    Semian.register(
+      :no_circuit_breaker,
+      tickets: 2,
+      bulkhead: true,
+      circuit_breaker: false,
+    )
+
+    assert_equal :no_bulkhead, Semian[:no_bulkhead].name
+    assert_equal :no_circuit_breaker, Semian[:no_circuit_breaker].name
+  end
 end


### PR DESCRIPTION
Before now, `:name` was delegated to `Bulkhead`. Because both bulkheads and circuit breakers are now optional, it makes sense that `:name` lives in `ProtectedResource`.

Before this change, any attempt to grab a resources name if bulkheads were turned off would result in an exception.

I also added a test to make sure no one initializes a resource without a circuit breaker nor a bulkhead.

r: @sirupsen 