### PR TITLE
Include time spend waiting for bulkhead in notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Feature: Include time spend waiting for bulkhead in notification (#154)
+
 # v0.7.1
 
 *  Feature: Add the behaviour to enable open circuiting on 5xxs conditionally  (#149)

--- a/test/instrumentation_test.rb
+++ b/test/instrumentation_test.rb
@@ -38,6 +38,18 @@ class TestInstrumentation < Minitest::Test
     end
   end
 
+  def test_success_instrumentation_wait_time
+    hit = false
+    subscription = Semian.subscribe do |*_, wait_time:|
+      hit = true
+      assert(wait_time.is_a?(Integer))
+    end
+    Semian[:testing].acquire {}
+    assert(hit)
+  ensure
+    Semian.unsubscribe(subscription)
+  end
+
   def test_success_instrumentation_when_unknown_exceptions_occur
     assert_notify(:success) do
       assert_raises RuntimeError do


### PR DESCRIPTION
This adds the time that it took to acquire the bulkhead to the success notification. The goal of this is to instrument how much contention there is on the tickets.

I merged it in the success notification, but I could also have added it to acquire in a separate benchmark notification.