### PR TITLE
Use prepend when monkey-patching Net::HTTP.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Feature: Use prepend when monkey-patching Net::HTTP. (#157)
 * Feature: Include time spend waiting for bulkhead in notification (#154)
 
 # v0.7.1


### PR DESCRIPTION
This PR changes `Semian::NetHTTP` to use `prepend` instead of `alias_method_chain`-style method renaming. This is done so that it does not conflict with [`aws-sdk-core`, which also monkey-patches `transport_request`,](https://github.com/aws/aws-sdk-ruby/blob/85c08538c53cf5e76aa7d4b275a1d88b80fbb2ed/aws-sdk-core/lib/seahorse/client/net_http/patches.rb#L22-L71) when included in the "wrong" order.

The downside is that we lose the `raw_*` methods which are useful for instrumentation, though it is nothing that cannot be solved by requiring instrumentation code earlier.