### PR TITLE
Use built-in option to read the monotonic clock in ms.

### DIFF
--- a/lib/semian/protected_resource.rb
+++ b/lib/semian/protected_resource.rb
@@ -59,7 +59,7 @@ module Semian
     end
 
     def current_milliseconds
-      (Process.clock_gettime(Process::CLOCK_MONOTONIC) * 1000).to_i
+      Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
     end
   end
 end


### PR DESCRIPTION
Turns out there was an option to return the right format all along.

https://ruby-doc.org/core-2.2.1/Process.html#method-c-clock_gettime