### PR TITLE
More reliable way to measure wait time.

### DIFF
--- a/ext/semian/resource.c
+++ b/ext/semian/resource.c
@@ -63,7 +63,12 @@ semian_resource_acquire(int argc, VALUE *argv, VALUE self)
     }
   }
 
-  return rb_ensure(rb_yield, self, cleanup_semian_resource_acquire, self);
+  VALUE wait_time = Qnil;
+  if (res.wait_time >= 0) {
+    wait_time = LONG2NUM(res.wait_time);
+  }
+
+  return rb_ensure(rb_yield, wait_time, cleanup_semian_resource_acquire, self);
 }
 
 VALUE
@@ -219,6 +224,7 @@ semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VAL
   ms_to_timespec(c_timeout * 1000, &res->timeout);
   res->name = strdup(c_id_str);
   res->quota = c_quota;
+  res->wait_time = -1;
 
   // Initialize the semaphore set
   initialize_semaphore_set(res, c_id_str, c_permissions, c_tickets, c_quota);

--- a/ext/semian/resource.h
+++ b/ext/semian/resource.h
@@ -10,6 +10,7 @@ Functions here are associated with rubyland operations.
 #include "sysv_semaphores.h"
 
 // Ruby variables
+ID id_wait_time;
 ID id_timeout;
 int system_max_semaphore_count;
 

--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -53,6 +53,7 @@ void Init_semian()
   rb_define_method(cResource, "reset_registered_workers!", semian_resource_reset_workers, 0);
   rb_define_method(cResource, "unregister_worker", semian_resource_unregister_worker, 0);
 
+  id_wait_time = rb_intern("wait_time");
   id_timeout = rb_intern("timeout");
 
   if (semctl(0, 0, SEM_INFO, &info_buf) == -1) {

--- a/ext/semian/types.h
+++ b/ext/semian/types.h
@@ -35,6 +35,7 @@ typedef struct {
   uint64_t key;
   char *strkey;
   char *name;
+  long wait_time;
 } semian_resource_t;
 
 #endif // SEMIAN_TYPES_H

--- a/lib/semian/protected_resource.rb
+++ b/lib/semian/protected_resource.rb
@@ -46,20 +46,14 @@ module Semian
       if @bulkhead.nil?
         yield self
       else
-        acquisition_start = current_milliseconds
-        @bulkhead.acquire(timeout: timeout) do
-          wait_time = current_milliseconds - acquisition_start
-          Semian.notify(:success, self, scope, adapter, wait_time: wait_time)
+        @bulkhead.acquire(timeout: timeout) do |wait_time|
+          Semian.notify(:success, self, scope, adapter, wait_time)
           yield self
         end
       end
     rescue ::Semian::TimeoutError
       Semian.notify(:busy, self, scope, adapter)
       raise
-    end
-
-    def current_milliseconds
-      Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
     end
   end
 end

--- a/test/instrumentation_test.rb
+++ b/test/instrumentation_test.rb
@@ -40,7 +40,7 @@ class TestInstrumentation < Minitest::Test
 
   def test_success_instrumentation_wait_time
     hit = false
-    subscription = Semian.subscribe do |*_, wait_time:|
+    subscription = Semian.subscribe do |*_, wait_time|
       hit = true
       assert(wait_time.is_a?(Integer))
     end


### PR DESCRIPTION
This moves the benchmarking code for ticket acquisition as close as possible to the system call to eliminate anything that could artificially inflate the numbers.