### PR TITLE
Have resource consistently yield wait_time.

### DIFF
--- a/lib/semian/resource.rb
+++ b/lib/semian/resource.rb
@@ -28,7 +28,8 @@ module Semian
     end
 
     def acquire(*)
-      yield self
+      wait_time = 0
+      yield wait_time
     end
 
     def count


### PR DESCRIPTION
A recent change (#161) made ProtectedResource#acquire yield the amount of time during
which the thread was block acquiring the semaphore. This change updates
ProtectedResorce to do the same (with a value of 0).