### PR TITLE
Make sure internal semaphore release is protected.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix: Protect internal semaphore when adjusting resource count (#164)
 * Feature: Use prepend when monkey-patching Net::HTTP. (#157)
 * Feature: Include time spend waiting for bulkhead in notification (#154)
 

--- a/ext/semian/tickets.c
+++ b/ext/semian/tickets.c
@@ -2,20 +2,19 @@
 
 // Update the ticket count for static ticket tracking
 static VALUE
-update_ticket_count(update_ticket_count_t *tc);
+update_ticket_count(int sem_id, int count);
 
 static int
 calculate_quota_tickets(int sem_id, double quota);
 
 // Must be called with the semaphore meta lock already acquired
-void
-configure_tickets(int sem_id, int tickets, double quota)
+VALUE
+configure_tickets(VALUE value)
 {
-  int state = 0;
-  update_ticket_count_t tc;
+  configure_tickets_args_t *args = (configure_tickets_args_t *)value;
 
-  if (quota > 0) {
-    tickets = calculate_quota_tickets(sem_id, quota);
+  if (args->quota > 0) {
+    args->tickets = calculate_quota_tickets(args->sem_id, args->quota);
   }
 
   /*
@@ -23,10 +22,10 @@ configure_tickets(int sem_id, int tickets, double quota)
     We need to throw an error if we set it to 0 during initialization.
     Otherwise, we back out of here completely.
   */
-  if (get_sem_val(sem_id, SI_SEM_CONFIGURED_TICKETS) == 0 && tickets == 0) {
+  if (get_sem_val(args->sem_id, SI_SEM_CONFIGURED_TICKETS) == 0 && args->tickets == 0) {
     rb_raise(eSyscall, "More than 0 tickets must be specified when initializing semaphore");
-  } else if (tickets == 0) {
-    return;
+  } else if (args->tickets == 0) {
+    return Qnil;
   }
 
   /*
@@ -34,31 +33,26 @@ configure_tickets(int sem_id, int tickets, double quota)
      count, we need to resize the count. We do this by adding the delta of
      (tickets - current_configured_tickets) to the semaphore value.
   */
-  if (get_sem_val(sem_id, SI_SEM_CONFIGURED_TICKETS) != tickets) {
-
-    tc.sem_id = sem_id;
-    tc.tickets = tickets;
-    rb_protect((VALUE (*)(VALUE)) update_ticket_count, (VALUE) &tc, &state);
-
-    if (state) {
-      rb_jump_tag(state);
-    }
+  if (get_sem_val(args->sem_id, SI_SEM_CONFIGURED_TICKETS) != args->tickets) {
+    update_ticket_count(args->sem_id, args->tickets);
   }
+
+  return Qnil;
 }
 
 static VALUE
-update_ticket_count(update_ticket_count_t *tc)
+update_ticket_count(int sem_id, int tickets)
 {
   short delta;
   struct timespec ts = { 0 };
   ts.tv_sec = INTERNAL_TIMEOUT;
 
-  delta = tc->tickets - get_sem_val(tc->sem_id, SI_SEM_CONFIGURED_TICKETS);
+  delta = tickets - get_sem_val(sem_id, SI_SEM_CONFIGURED_TICKETS);
 
 #ifdef DEBUG
-  print_sem_vals(tc->sem_id);
+  print_sem_vals(sem_id);
 #endif
-  if (perform_semop(tc->sem_id, SI_SEM_TICKETS, delta, 0, &ts) == -1) {
+  if (perform_semop(sem_id, SI_SEM_TICKETS, delta, 0, &ts) == -1) {
     if (delta < 0 && errno == EAGAIN) {
       rb_raise(eTimeout, "timeout while trying to update ticket count");
     } else {
@@ -66,7 +60,7 @@ update_ticket_count(update_ticket_count_t *tc)
     }
   }
 
-  if (semctl(tc->sem_id, SI_SEM_CONFIGURED_TICKETS, SETVAL, tc->tickets) == -1) {
+  if (semctl(sem_id, SI_SEM_CONFIGURED_TICKETS, SETVAL, tickets) == -1) {
     rb_raise(eInternal, "error configuring ticket count, errno: %d (%s)", errno, strerror(errno));
   }
 

--- a/ext/semian/tickets.h
+++ b/ext/semian/tickets.h
@@ -7,7 +7,7 @@ For logic specific to manipulating semian ticket counts
 #include "sysv_semaphores.h"
 
 // Set initial ticket values upon resource creation
-void
-configure_tickets(int sem_id, int tickets, double quota);
+VALUE
+configure_tickets(VALUE);
 
 #endif // SEMIAN_TICKETS_H

--- a/ext/semian/types.h
+++ b/ext/semian/types.h
@@ -20,11 +20,11 @@ union semun {
                              (Linux-specific) */
 };
 
-// To update the ticket count
 typedef struct {
   int sem_id;
   int tickets;
-} update_ticket_count_t;
+  double quota;
+} configure_tickets_args_t;
 
 // Internal semaphore structure
 typedef struct {

--- a/test/adapter_test.rb
+++ b/test/adapter_test.rb
@@ -73,7 +73,7 @@ class TestSemianAdapter < Minitest::Test
     weak_ref = Semian.consumers[identifier].first
     assert_equal(true, weak_ref.weakref_alive?)
 
-    GC.start
+    GC.start(full_mark: true, immediate_sweep: true)
 
     assert_nil weak_ref.weakref_alive?
 


### PR DESCRIPTION
A code change moved `sem_meta_unlock` outside of the protected scope. This PR brings it back inside.