### PR TITLE
Add drop trigger to the whitelisted queries.

### DIFF
--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -37,6 +37,7 @@ module Semian
       /\A\s*ROLLBACK/i,
       /\A\s*COMMIT/i,
       /\A\s*RELEASE\s+SAVEPOINT/i,
+      /\A\s*DROP\s+TRIGGER/i,
     )
 
     # The naked methods are exposed as `raw_query` and `raw_connect` for instrumentation purpose


### PR DESCRIPTION
# What is this?

This is an attempt at solving a very punctual problem, so I'm not even sure if this is something we want to add to the library. I can alternatively create a configuration bit and put it in the hands of the users ( that might just be even worse?).

In any case, the punctual problem is; some schema change strategies rely on triggers to be able to move "live data" as the schema changes. We have observed the `DROP TRIGGER` command get killed which can be dangerous (or at the very least very annoying) when cleaning after the schema has changed.