### PR TITLE
Including Timeout error for mysql2 adapter

### DIFF
--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -28,6 +28,10 @@ module Semian
       /MySQL client is not connected/i,
     )
 
+    TIMEOUT_ERROR = Regexp.union(
+      /Timeout waiting for a response/i
+    )
+
     ResourceBusyError = ::Mysql2::ResourceBusyError
     CircuitOpenError = ::Mysql2::CircuitOpenError
     PingFailure = Class.new(::Mysql2::Error)
@@ -102,7 +106,7 @@ module Semian
     def acquire_semian_resource(*)
       super
     rescue ::Mysql2::Error => error
-      if error.message =~ CONNECTION_ERROR || error.is_a?(PingFailure)
+      if error.message =~ CONNECTION_ERROR || error.message =~ TIMEOUT_ERROR || error.is_a?(PingFailure)
         semian_resource.mark_failed(error)
         error.semian_identifier = semian_identifier
       end

--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -29,7 +29,7 @@ module Semian
     )
 
     TIMEOUT_ERROR = Regexp.union(
-      /Timeout waiting for a response/i
+      /Timeout waiting for a response/i,
     )
 
     ResourceBusyError = ::Mysql2::ResourceBusyError


### PR DESCRIPTION
A MySQL Semian resource can be a bad resource if the queries are taking a longer time to respond and are exceeding the timeout options configured in database.yml of the application. Under such scenarios instead of waiting for a longer time and increasing the request queue it is good to have a circuit breaker in place and fail faster.

In the current implementation a Semian resource is not marked as failed when there is a MySQL timeout for the query.

Sample error trace for a long running query looks like -
  Mysql2::Error: [mysql_192.16.10.158:3306] Timeout waiting for a response from the last query. (waited 18 seconds): select sleep(30)
   ActiveRecord::StatementInvalid (Mysql2::Error: [mysql_192.16.10.158:3306] Lost connection to MySQL server during query: select sleep(30)):

