### PR TITLE
 Introduce a Vagrantfile with Ubuntu Xenial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ vendor/
 *.swp
 *.swo
 nohup.out
+.vagrant

--- a/README.md
+++ b/README.md
@@ -678,6 +678,40 @@ trivial but it works well.
 to going to the network. Don't worry about it unless you're instrumenting
 non-IO.
 
+# Developing Semian
+
+Semian requires a Linux environment.  We provide a [Vagrantfile](Vagrantfile)
+that installs MySQL, Redis and Ruby in an Ubuntu 16.04 virtual machine.  Use
+the steps below to work on Semian from a Mac OS environment.
+
+```bash
+# install Vagrant and VirtualBox
+$ brew cask install vagrant virtualbox
+
+# clone Semian
+$ git clone https://github.com/Shopify/semian.git
+$ cd semian
+
+# build the virtual machine (can take a while for ruby to compile)
+$ vagrant up
+
+# shell in to the virtual machine
+$ vagrant ssh
+
+# start the toxiproxy-server inside the virtual machine
+$ toxiproxy-server > /dev/null &
+# TODO: provide a systemd unit for toxiproxy
+
+# run the tests inside the virtual machine
+$ cd /vagrant && bundle exec rake
+```
+
+Be careful not to run `bundle install` from Mac OS.  The folder is shared with
+the virtual machine and this can overwrite Linux libraries with incompatible Mac
+OS versions.  If you run in to problems with the machine, you can run `vagrant
+up --provision` to execute the provision script again; or you can run `vagrant
+destroy -f && vagrant up` to rebuild it from scratch.
+
 [hystrix]: https://github.com/Netflix/Hystrix
 [release-it]: https://pragprog.com/book/mnee/release-it
 [shopify]: http://www.shopify.com/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,87 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "ubuntu/xenial64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", privileged: true, inline: <<-SHELL
+    export DEBIAN_FRONTEND=noninteractive
+
+    set -ue
+
+    apt-get update
+    apt-get upgrade -y
+    apt-get install -y build-essential libmysqlclient-dev libssl-dev mysql-server redis-server ruby-build
+
+    printf "create user vagrant;\n" | mysql
+
+    mkdir -p /usr/local/share/ruby-build/
+    curl -Lo /usr/local/share/ruby-build/2.4.3 https://raw.githubusercontent.com/rbenv/ruby-build/master/share/ruby-build/2.4.3
+    ruby-build /usr/local/share/ruby-build/2.4.3 /usr/local/
+
+    curl -Lo /var/tmp/toxiproxy-2.1.2.deb https://github.com/Shopify/toxiproxy/releases/download/v2.1.2/toxiproxy_2.1.2_amd64.deb
+    dpkg -i /var/tmp/toxiproxy-2.1.2.deb
+
+    /usr/local/bin/gem install bundler
+    (cd /vagrant && sudo -u vagrant bundle install)
+  SHELL
+end


### PR DESCRIPTION
This allows people to work on Semian from non-Linux machines.  The base image is Ubuntu Xenial, and Ruby 2.4.3 is installed from source using ruby-build.

Inside the image, Toxiproxy is not started because the deb package doesn't provide a systemd service.  This means toxiproxy-server has to be started before the tests can be run inside the virtual machine.