### PR TITLE
Update for Redis 4

### DIFF
--- a/lib/semian/redis.rb
+++ b/lib/semian/redis.rb
@@ -35,7 +35,7 @@ class Redis
   end
 
   # Compatibility with old versions of the Redis gem
-  unless respond_to?(:_client)
+  unless instance_methods.include?(:_client)
     def _client
       @client
     end

--- a/lib/semian/redis.rb
+++ b/lib/semian/redis.rb
@@ -23,7 +23,7 @@ class Redis
     # This reference is necessary because during a `pipelined` block the client
     # is replaced by an instance of `Redis::Pipeline` and there is no way to
     # access the original client which references the Semian resource.
-    @original_client = client
+    @original_client = _client
   end
 
   def semian_resource
@@ -32,6 +32,13 @@ class Redis
 
   def semian_identifier
     semian_resource.name
+  end
+
+  # Compatibility with old versions of the Redis gem
+  unless respond_to?(:_client)
+    def _client
+      @client
+    end
   end
 end
 

--- a/test/redis_test.rb
+++ b/test/redis_test.rb
@@ -19,19 +19,19 @@ class TestRedis < Minitest::Test
   end
 
   def test_semian_identifier
-    assert_equal :redis_foo, new_redis(semian: {name: 'foo'}).client.semian_identifier
-    assert_equal :"redis_#{SemianConfig['toxiproxy_upstream_host']}:16379/1", new_redis(semian: {name: nil}).client.semian_identifier
-    assert_equal :'redis_example.com:42/1', new_redis(host: 'example.com', port: 42, semian: {name: nil}).client.semian_identifier
+    assert_equal :redis_foo, new_redis(semian: {name: 'foo'})._client.semian_identifier
+    assert_equal :"redis_#{SemianConfig['toxiproxy_upstream_host']}:16379/1", new_redis(semian: {name: nil})._client.semian_identifier
+    assert_equal :'redis_example.com:42/1', new_redis(host: 'example.com', port: 42, semian: {name: nil})._client.semian_identifier
   end
 
   def test_client_alias
     redis = connect_to_redis!
-    assert_equal redis.client.semian_resource, redis.semian_resource
-    assert_equal redis.client.semian_identifier, redis.semian_identifier
+    assert_equal redis._client.semian_resource, redis.semian_resource
+    assert_equal redis._client.semian_identifier, redis.semian_identifier
   end
 
   def test_semian_can_be_disabled
-    resource = Redis.new(semian: false).client.semian_resource
+    resource = Redis.new(semian: false)._client.semian_resource
     assert_instance_of Semian::UnprotectedResource, resource
   end
 
@@ -99,7 +99,8 @@ class TestRedis < Minitest::Test
   def test_redis_connection_errors_are_tagged_with_the_resource_identifier
     @proxy.downstream(:latency, latency: 600).apply do
       error = assert_raises ::Redis::TimeoutError do
-        connect_to_redis!
+        redis = connect_to_redis!
+        redis.get('foo')
       end
       assert_equal :redis_testing, error.semian_identifier
     end
@@ -231,7 +232,7 @@ class TestRedis < Minitest::Test
 
   def connect_to_redis!(semian_options = {})
     redis = new_redis(semian: semian_options)
-    redis.client.connect
+    redis._client.connect
     redis
   end
 end


### PR DESCRIPTION
New versions of the Redis gem have `client` defined as the Redis CLIENT command itself.  The Redis client configuration is available as `_client`.  I've added a mock implementation to preserve compatibility with old Redis versions.

Old version of the code: https://github.com/redis/redis-rb/blob/3.3/lib/redis.rb#L10

New version of the code: https://github.com/redis/redis-rb/blob/b362cf23173bd2fea8b4cbd63bfff696fffbb84c/lib/redis.rb#L109