### PR TITLE
Allow to disable circuit breaker

### DIFF
--- a/lib/semian/circuit_breaker.rb
+++ b/lib/semian/circuit_breaker.rb
@@ -19,6 +19,8 @@ module Semian
     end
 
     def acquire
+      return yield if disabled?
+
       half_open if open? && error_timeout_expired?
 
       raise OpenCircuitError unless request_allowed?
@@ -115,6 +117,10 @@ module Semian
       str << " success_count_threshold=#{@success_count_threshold} error_count_threshold=#{@error_count_threshold}"
       str << " error_timeout=#{@error_timeout} error_last_at=\"#{@errors.last}\""
       Semian.logger.info(str)
+    end
+
+    def disabled?
+      ENV['SEMIAN_CIRCUIT_BREAKER_DISABLED'] || ENV['SEMIAN_DISABLED']
     end
   end
 end

--- a/lib/semian/platform.rb
+++ b/lib/semian/platform.rb
@@ -11,6 +11,6 @@ module Semian
   end
 
   def disabled?
-    ENV['SEMIAN_SEMAPHORES_DISABLED']
+    ENV['SEMIAN_SEMAPHORES_DISABLED'] || ENV['SEMIAN_DISABLED']
   end
 end

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -97,4 +97,20 @@ class TestCircuitBreaker < Minitest::Test
     assert_predicate @resource, :request_allowed?
     assert_predicate @resource, :open?
   end
+
+  def test_env_var_disables_circuit_breaker
+    ENV['SEMIAN_CIRCUIT_BREAKER_DISABLED'] = '1'
+    open_circuit!
+    assert_circuit_closed
+  ensure
+    ENV.delete('SEMIAN_CIRCUIT_BREAKER_DISABLED')
+  end
+
+  def test_semian_wide_env_var_disables_circuit_breaker
+    ENV['SEMIAN_DISABLED'] = '1'
+    open_circuit!
+    assert_circuit_closed
+  ensure
+    ENV.delete('SEMIAN_DISABLED')
+  end
 end

--- a/test/semian_test.rb
+++ b/test/semian_test.rb
@@ -49,4 +49,12 @@ class TestSemian < Minitest::Test
   ensure
     ENV.delete('SEMIAN_SEMAPHORES_DISABLED')
   end
+
+  def test_disabled_via_semian_wide_env_var
+    ENV['SEMIAN_DISABLED'] = '1'
+
+    refute Semian.semaphores_enabled?
+  ensure
+    ENV.delete('SEMIAN_DISABLED')
+  end
 end


### PR DESCRIPTION
For specific units of work (like LHM), we want to disable Semian. We've been running workers with `SEMIAN_SEMAPHORES_DISABLED=1` for that reason, but that option only disables the semaphores part. As I can see from LHMs logs it's still possible that Semian stops execution with circuit breaker:

```
param_queue_name: lhm	
payload: Started Job CrossPodJobs::PoddedLhmProcessingJob at 2018-03-06 ..., job_id=..., rev=ea71e5f, section=recurring_job
Parameters: {...}
[Semian::CircuitBreaker] State transition from closed to open. success_count=0 error_count=3 success_count_threshold=2 error_count_threshold=3 error_timeout=10 error_last_at="1520370901"
...
Job Error: Mysql2::CircuitOpenError: [mysql_shard_4] Semian::OpenCircuitError: drop trigger if exists `lhmt_del_payments_accounts` /* large hadron migration */
Completed ERROR (ActiveRecord::StatementInvalid) in 0.927s | job_class=CrossPodJobs::PoddedLhmProcessingJob job_id=... job_processing_time=0.927
```

Maybe I misunderstand it, but it sounds like we need `SEMIAN_CIRCUIT_BREAKER_DISABLED` as well as `SEMIAN_SEMAPHORES_DISABLED`.

This PR introduces support for `SEMIAN_CIRCUIT_BREAKER_DISABLED` as well as a test for it.

ref https://github.com/Shopify/cookbooks/pull/15153#issuecomment-326804169