### PR TITLE
Provide more details when raising ArgumentError over missing options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Feature: More informative error messages when initializing Semian with missing
+  arguments
+
 # v0.7.5
 
 * Fix: Repaired compatibility with dependent Redis library

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -234,7 +234,7 @@ module Semian
   def create_circuit_breaker(name, **options)
     circuit_breaker = options.fetch(:circuit_breaker, true)
     return unless circuit_breaker
-    raise ArgumentError unless required_keys?([:success_threshold, :error_threshold, :error_timeout], options)
+    require_keys!([:success_threshold, :error_threshold, :error_timeout], options)
     implementation = options[:thread_safety_disabled] ? ::Semian::Simple : ::Semian::ThreadSafe
 
     exceptions = options[:exceptions] || []
@@ -257,8 +257,11 @@ module Semian
     Resource.new(name, tickets: options[:tickets], quota: options[:quota], permissions: permissions, timeout: timeout)
   end
 
-  def required_keys?(required = [], **options)
-    required.all? { |key| options.key? key }
+  def require_keys!(required = [], **options)
+    diff = required - options.keys
+    unless diff.empty?
+      raise ArgumentError, "Missing required arguments for Semian: #{diff}"
+    end
   end
 end
 

--- a/test/semian_test.rb
+++ b/test/semian_test.rb
@@ -15,7 +15,7 @@ class TestSemian < Minitest::Test
   end
 
   def test_register_with_circuit_breaker_missing_options
-    assert_raises ArgumentError do
+    exception = assert_raises ArgumentError do
       Semian.register(
         :testing,
         error_threshold: 2,
@@ -23,15 +23,18 @@ class TestSemian < Minitest::Test
         bulkhead: false,
       )
     end
+    assert_equal exception.message,
+      "Missing required arguments for Semian: [:success_threshold]"
   end
 
   def test_register_with_bulkhead_missing_options
-    assert_raises ArgumentError do
+    exception = assert_raises ArgumentError do
       Semian.register(
         :testing,
         circuit_breaker: false,
       )
     end
+    assert_equal exception.message, "Must pass exactly one of ticket or quota"
   end
 
   def test_unsuported_constants

--- a/test/semian_test.rb
+++ b/test/semian_test.rb
@@ -15,7 +15,7 @@ class TestSemian < Minitest::Test
   end
 
   def test_register_with_circuit_breaker_missing_options
-    assert_raises ArgumentError, "CI stub" do
+    assert_raises ArgumentError do
       Semian.register(
         :testing,
         error_threshold: 2,

--- a/test/semian_test.rb
+++ b/test/semian_test.rb
@@ -15,7 +15,7 @@ class TestSemian < Minitest::Test
   end
 
   def test_register_with_circuit_breaker_missing_options
-    assert_raises ArgumentError do
+    assert_raises ArgumentError, "CI stub" do
       Semian.register(
         :testing,
         error_threshold: 2,

--- a/test/semian_test.rb
+++ b/test/semian_test.rb
@@ -23,7 +23,8 @@ class TestSemian < Minitest::Test
         bulkhead: false,
       )
     end
-    assert_equal exception.message,
+    assert_equal \
+      exception.message,
       "Missing required arguments for Semian: [:success_threshold]"
   end
 


### PR DESCRIPTION
Unfortunately, I'm not sure how to test this.  :{