### PR TITLE
Pass in the error message when initializing a SemianError

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,9 @@ rvm:
   - '2.4'
   - '2.5'
 
+gemfile:
+  - gemfiles/mysql2-0-4-10.gemfile
+  - gemfiles/mysql2-0-5-0.gemfile
+
 services:
   - redis-server

--- a/gemfiles/mysql2-0-4-10.gemfile
+++ b/gemfiles/mysql2-0-4-10.gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'mysql2', '~> 0.4.10'
+
+group :development, :test do
+  gem 'rubocop', '~> 0.34.2'
+end

--- a/gemfiles/mysql2-0-5-0.gemfile
+++ b/gemfiles/mysql2-0-5-0.gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'mysql2', '~> 0.5.0'
+
+group :development, :test do
+  gem 'rubocop', '~> 0.34.2'
+end

--- a/lib/semian/adapter.rb
+++ b/lib/semian/adapter.rb
@@ -35,9 +35,9 @@ module Semian
         mark_resource_as_acquired(&block)
       end
     rescue ::Semian::OpenCircuitError => error
-      raise self.class::CircuitOpenError.new(semian_identifier, error)
+      raise self.class::CircuitOpenError.new(semian_identifier, error.message)
     rescue ::Semian::BaseError => error
-      raise self.class::ResourceBusyError.new(semian_identifier, error)
+      raise self.class::ResourceBusyError.new(semian_identifier, error.message)
     rescue *resource_exceptions => error
       error.semian_identifier = semian_identifier if error.respond_to?(:semian_identifier=)
       raise


### PR DESCRIPTION
We need to pass the message to `SemianError` not an Error object:

- When rescuing exception https://github.com/Shopify/semian/blob/4e15669c538d3671bfcb25c2edf7f9e29278da89/lib/semian/adapter.rb#L38-L40 we are passing the error to the SemianError constructor
- This was going to cause an issue at some point and it's now the case on mysql2 0.5.0. https://github.com/brianmario/mysql2/pull/632/files#diff-634fc29a00423da17966525049aa8877L62 because of this change

