### PR TITLE
Handle DNS resolution failures on connect

### DIFF
--- a/test/redis_test.rb
+++ b/test/redis_test.rb
@@ -125,9 +125,19 @@ class TestRedis < Minitest::Test
     end
   end
 
-  def test_connect_resolve_error
-    assert_raises Redis::ResolveError do
+  def test_dns_resolution_failures_open_circuit
+    ERROR_THRESHOLD.times do
+      assert_raises Redis::ResolveError do
+        connect_to_redis!(host: 'thisdoesnotresolve')
+      end
+    end
+
+    assert_raises Redis::CircuitOpenError do
       connect_to_redis!(host: 'thisdoesnotresolve')
+    end
+
+    Timecop.travel(ERROR_TIMEOUT + 1) do
+      connect_to_redis!
     end
   end
 


### PR DESCRIPTION
This allows Semian to track DNS resolution failures during `connect`. With the `redis` gem, this manifests as a `SocketError`.

Unfortunately, `hiredis-rb` masks the error by raising a generic `RuntimeError` on any connection failure (including DNS resolution): https://github.com/redis/hiredis-rb/blob/2b46b19dda98ba487e61884087b60d692bd0753e/ext/hiredis_ext/connection.c#L193. Also, the vendor'd `hiredis` gem also obscures the resolution error: https://github.com/redis/hiredis/blob/3d8709d19d7fa67d203a33c969e69f0f1a4eab02/net.c#L330-L335.

I don't really like this solution, but it's the best I can come up with, without having to make a bunch of upstream PRs. I wasn't able to come up with a test for the `hiredis` path, because I couldn't determine if there's a way to use both `redis` and `hiredis` gems separately in test.