### PR TITLE
circuit: introduce half_open_resource_timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ There are three configuration parameters for circuit breakers in Semian:
   again.
 * **success_threshold**. The amount of successes on the circuit until closing it
   again, that is to start accepting all requests to the circuit.
+* **half_open_resource_timeout**. Timeout for the resource when the circuit is half-open (only supported for MySQL).
 
 ### Bulkheading
 

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -244,6 +244,7 @@ module Semian
       error_threshold: options[:error_threshold],
       error_timeout: options[:error_timeout],
       exceptions: Array(exceptions) + [::Semian::BaseError],
+      half_open_resource_timeout: options[:half_open_resource_timeout],
       implementation: implementation,
     )
   end

--- a/lib/semian/adapter.rb
+++ b/lib/semian/adapter.rb
@@ -31,7 +31,7 @@ module Semian
 
     def acquire_semian_resource(scope:, adapter:, &block)
       return yield if resource_already_acquired?
-      semian_resource.acquire(scope: scope, adapter: adapter) do
+      semian_resource.acquire(scope: scope, adapter: adapter, resource: self) do
         mark_resource_as_acquired(&block)
       end
     rescue ::Semian::OpenCircuitError => error

--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -83,6 +83,22 @@ module Semian
       end
     end
 
+    # TODO: write_timeout and connect_timeout can't be configured currently
+    # dynamically, await https://github.com/brianmario/mysql2/pull/955
+    def with_resource_timeout(temp_timeout)
+      prev_read_timeout = @read_timeout
+
+      begin
+        # C-ext reads this directly, writer method will configure
+        # properly on the client but based on my read--this is good enough
+        # until we get https://github.com/brianmario/mysql2/pull/955 in
+        @read_timeout = temp_timeout
+        yield
+      ensure
+        @read_timeout = prev_read_timeout
+      end
+    end
+
     private
 
     def query_whitelisted?(sql, *)

--- a/lib/semian/protected_resource.rb
+++ b/lib/semian/protected_resource.rb
@@ -19,8 +19,8 @@ module Semian
       @circuit_breaker.destroy unless @circuit_breaker.nil?
     end
 
-    def acquire(timeout: nil, scope: nil, adapter: nil)
-      acquire_circuit_breaker(scope, adapter) do
+    def acquire(timeout: nil, scope: nil, adapter: nil, resource: nil)
+      acquire_circuit_breaker(scope, adapter, resource) do
         acquire_bulkhead(timeout, scope, adapter) do
           yield self
         end
@@ -29,11 +29,11 @@ module Semian
 
     private
 
-    def acquire_circuit_breaker(scope, adapter)
+    def acquire_circuit_breaker(scope, adapter, resource)
       if @circuit_breaker.nil?
         yield self
       else
-        @circuit_breaker.acquire do
+        @circuit_breaker.acquire(resource) do
           yield self
         end
       end

--- a/semian.gemspec
+++ b/semian.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '< 11.0'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'minitest'
+  s.add_development_dependency 'byebug'
   s.add_development_dependency 'mysql2'
   s.add_development_dependency 'redis'
   s.add_development_dependency 'thin', '~> 1.6.4'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ require 'toxiproxy'
 require 'timecop'
 require 'tempfile'
 require 'fileutils'
+require 'byebug'
 
 require 'helpers/background_helper'
 require 'helpers/circuit_breaker_helper'


### PR DESCRIPTION
When a circuit is busy (for those at Shopify, see https://github.com/Shopify/shopify/pull/164168) you may reduce a substantial amount of capacity if you have large timeouts (see https://github.com/Shopify/semian/pull/145). One way to circumvent this is to have very large `error_threshold` timeouts, as a multiple of your timeout. E.g. if your resource timeout is 30s, then an error_timeout of 30s will make sure you have 50% of capacity available, and 60s will make sure you have 25% available (assuming that the circuits trigger equally over the timeout period, which is not an unreasonable assumption in production). However, this has obvious drawbacks, making recovering from incidents take longer for the affected resource.

Instead, we can reduce the resource timeout in the `half_open?` state to achieve something similar. Normally, timeouts are to allow outlier queries to go through—in the face of an incident, we can eat that (we'd want to kill those anyway) and reduce the timeout dramatically while `half_open?` on the circuit.

The ugly thing about this, is that it couples the circuit with the resource. However, I think it makes more sense for the circuit to know about the resource, than for the resource to know about the circuit—that's why I chose to implement it this way.

This will need to be implemented per adapter, by implementing `with_resource_timeout`.

cc @Shopify/servcomm 