### PR TITLE
circuit: half_open? returns true when about to transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.8.1
+
+* Fix: Expose `half_open?` when the circuit state has not transitioned but will. This allows consumers further up the stack to know if the circuit
+is half open.
+
 # v0.8.0
 
 * Feature: Introduce `half_open_resource_timeout` which changes the resource timeout when the circuit is in a half-open state (#188)

--- a/lib/semian/simple_state.rb
+++ b/lib/semian/simple_state.rb
@@ -27,7 +27,7 @@ module Semian
         @value = :closed
       end
 
-      def half_open
+      def half_open!
         @value = :half_open
       end
 

--- a/test/net_http_test.rb
+++ b/test/net_http_test.rb
@@ -446,7 +446,7 @@ class TestNetHTTP < Minitest::Test
       uri = URI("http://#{hostname}:#{toxic_port}/200")
       http.raw_semian_options[:error_threshold].times do
         # Cause error error_threshold times so circuit opens
-        Toxiproxy[toxic_name].downstream(:latency, latency: 150).apply do
+        Toxiproxy[toxic_name].downstream(:latency, latency: 500).apply do
           request = Net::HTTP::Get.new(uri)
           assert_raises Net::ReadTimeout do
             http.request(request)

--- a/test/protected_resource_test.rb
+++ b/test/protected_resource_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'securerandom'
 
 class TestProtectedResource < Minitest::Test
   include CircuitBreakerHelper

--- a/test/simple_state_test.rb
+++ b/test/simple_state_test.rb
@@ -27,7 +27,7 @@ class TestSimpleEnum < Minitest::Test
     end
 
     def test_half_open
-      @state.half_open
+      @state.half_open!
       assert @state.half_open?
       assert_equal @state.value, :half_open
     end


### PR DESCRIPTION
The circuit maintains its state on `@state`. Before this change, the definition of `half_open?` was that `@state == :half_open`. This changes the definition of `half_open?` to that _either_ `@state == :half_open` or the error timeout window has passed—so we're effectively `half_open?`.

**Why not just get rid of `@state == :half_open`?** If the circuit stays in the `half_open` state a while, `error_timeout_expired?` is no longer possible to use, i.e. you can't remove that `open?` conditional easily, I don't think.

**Why do you need this?** I'd like to be able to add in Marginalia the state of the circuit further up the stack (since Marginalia works at the AR-level). However, with Semian patching the MySQL client (and not AR)—this information is not present that far up the stack. It makes sense to me to be able to call `Semian[resource_name].circuit_breaker.half_open?` if it's going to transition on the `#acquire` of the circuit.