### PR TITLE
Make OOM an adapter error

### DIFF
--- a/lib/semian/redis.rb
+++ b/lib/semian/redis.rb
@@ -13,6 +13,7 @@ class Redis
   end
 
   class OutOfMemoryError < Redis::CommandError
+    include ::Semian::AdapterError
   end
 
   ResourceBusyError = Class.new(SemianError)

--- a/test/redis_test.rb
+++ b/test/redis_test.rb
@@ -73,9 +73,11 @@ class TestRedis < Minitest::Test
 
     with_maxmemory(1) do
       ERROR_THRESHOLD.times do
-        assert_raises ::Redis::OutOfMemoryError do
+        exception = assert_raises ::Redis::OutOfMemoryError do
           client.set('foo', 'bar')
         end
+
+        assert_equal :redis_testing, exception.semian_identifier
       end
 
       assert_raises ::Redis::CircuitOpenError do


### PR DESCRIPTION
Follow-up to https://github.com/Shopify/semian/pull/172.

Fixes an oversight from the previous PR. This essentially makes it so that `OutOfMemoryError#semian_identifier` is a thing, which is necessary to properly integrate this type of error into Shopify core's fallback evaluation logic.