### PR TITLE
Fix flaky test

### DIFF
--- a/lib/semian/redis.rb
+++ b/lib/semian/redis.rb
@@ -85,7 +85,7 @@ module Semian
         begin
           raw_connect
         rescue SocketError, RuntimeError => e
-          raise ResolveError.new(semian_identifier) if e.message =~ /(can't resolve)|(name or service not known)/i
+          raise ResolveError.new(semian_identifier) if e.cause.to_s =~ /(can't resolve)|(name or service not known)/i
           raise
         end
       end

--- a/test/net_http_test.rb
+++ b/test/net_http_test.rb
@@ -496,6 +496,7 @@ class TestNetHTTP < Minitest::Test
         @proxy = Toxiproxy[:semian_test_net_http]
         yield(hostname, port.to_i)
       ensure
+        server&.stop
         server_thread.kill
         poll_until_gone(hostname: hostname, port: port)
       end


### PR DESCRIPTION
Redis error:
```
> e.message
"Error connecting to Redis on thisdoesnotresolve:16379 (SocketError)"
> e.cause
#<SocketError: getaddrinfo: Name or service not known>
```

net_http_test flaky test
> Could still reach the service on hostname #{hostname} port #{port} after #{time_to_wait}s

Adding `server.stop` makes sure the server is stopped. Will monitor to make sure it did fix the flakiness.