### PR TITLE
Memcached 1.8.0 bulkhead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ gemfile:
 
 services:
   - redis-server
+  - memcached

--- a/README.md
+++ b/README.md
@@ -721,6 +721,7 @@ destroy -f && vagrant up` to rebuild it from scratch.
 [semian-adapter]: lib/semian/adapter.rb
 [nethttp-semian-adapter]: lib/semian/net_http.rb
 [nethttp-default-errors]: lib/semian/net_http.rb#L35-L45
+[memcached-adapter]: lib/semian/memcached.rb
 [semian-instrumentable]: lib/semian/instrumentable.rb
 [statsd-instrument]: http://github.com/shopify/statsd-instrument
 [resiliency-blog-post]: https://engineering.shopify.com/blogs/engineering/building-and-testing-resilient-ruby-on-rails-applications

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -70,7 +70,7 @@ Vagrant.configure("2") do |config|
 
     apt-get update
     apt-get upgrade -y
-    apt-get install -y build-essential libmysqlclient-dev libssl-dev mysql-server redis-server ruby-build
+    apt-get install -y build-essential libmysqlclient-dev libssl-dev mysql-server redis-server ruby-build libsasl2-dev memcached
 
     printf "create user vagrant;\n" | mysql
 

--- a/lib/semian/memcached.rb
+++ b/lib/semian/memcached.rb
@@ -1,0 +1,67 @@
+require 'semian/adapter'
+require 'memcached'
+
+module Semian
+  module Memcached
+    include Semian::Adapter
+
+    class SemianError < ::Memcached::Error
+      def initialize(semian_identifier, *args)
+        super(*args)
+        @semian_identifier = semian_identifier
+      end
+    end
+
+    ResourceBusyError = Class.new(SemianError)
+
+    def semian_identifier
+      name = semian_options && semian_options[:name]
+      ["memcached", name].compact.join("_").to_sym
+    end
+
+    def raw_semian_options
+      # disable semian when host ejection is enabled.
+      return false if !!@options[:auto_eject_hosts]
+      @options[:semian].merge(circuit_breaker: false)
+    end
+
+    # patch all the methods that actually interacts with memcached, not their higher level abstractions such
+    # as #get or #cas.
+    %i(
+      set
+      add
+      increment
+      decrement
+      replace
+      append
+      prepend
+      delete
+      exist
+      single_get
+      single_cas
+      multi_get
+      multi_cas
+    ).each do |meth|
+      define_method(meth) do |*args|
+        acquire_semian_resource(adapter: :memcached, scope: :query) do
+          super(*args)
+        end
+      end
+    end
+
+    # Preserve single_get and single_cas private visibility
+    private(
+      :single_get,
+      :single_cas,
+      :multi_get,
+      :multi_cas,
+    )
+  end
+end
+
+if Memcached::VERSION == "1.8.0"
+  # Hack to go around the DEFAULTS arguments check
+  Memcached::DEFAULTS.merge!(semian: nil)
+
+  Memcached.prepend(Semian::Memcached)
+end

--- a/semian.gemspec
+++ b/semian.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'mysql2'
   s.add_development_dependency 'redis'
+  s.add_development_dependency 'memcached', '~> 1.8.0'
   s.add_development_dependency 'thin', '~> 1.6.4'
   s.add_development_dependency 'toxiproxy', '~> 1.0.0'
 end

--- a/test/config/hosts.yml
+++ b/test/config/hosts.yml
@@ -12,3 +12,7 @@ redis_toxiproxy_port: 16379
 http_host: 127.0.0.1
 http_port: 31050
 http_toxiproxy_port: 31051
+
+memcached_host: 127.0.0.1
+memcached_port: 11211
+memcached_toxiproxy_port: 34323

--- a/test/memcached_test.rb
+++ b/test/memcached_test.rb
@@ -23,8 +23,8 @@ class MemcachedTest < Minitest::Test
   end
 
   def test_semian_identifier
-    assert_equal(:memcached_foo, new_memcached(semian: { name: :foo }).semian_identifier)
-    assert_equal(:memcached, new_memcached(semian: { name: nil }).semian_identifier)
+    assert_equal(:memcached_foo, new_memcached(semian: {name: :foo}).semian_identifier)
+    assert_equal(:memcached, new_memcached(semian: {name: nil}).semian_identifier)
   end
 
   def test_query_instrumentation

--- a/test/memcached_test.rb
+++ b/test/memcached_test.rb
@@ -1,0 +1,101 @@
+require 'test_helper'
+require 'semian/memcached'
+
+class MemcachedTest < Minitest::Test
+  def setup
+    Semian.destroy(:memcached_testing)
+  end
+
+  def test_bulkheads_tickets_are_working
+    semian_options = SEMIAN_OPTIONS.merge(
+      tickets: 2,
+    )
+
+    memcached_1 = new_memcached(semian: semian_options)
+    memcached_1.semian_resource.acquire do
+      memcached_2 = new_memcached(semian: semian_options)
+      memcached_2.semian_resource.acquire do
+        assert_raises Memcached::ResourceBusyError do
+          new_memcached(semian: semian_options).set("foo", "bar")
+        end
+      end
+    end
+  end
+
+  def test_semian_identifier
+    assert_equal(:memcached_foo, new_memcached(semian: { name: :foo }).semian_identifier)
+    assert_equal(:memcached, new_memcached(semian: { name: nil }).semian_identifier)
+  end
+
+  def test_query_instrumentation
+    client = new_memcached
+
+    notified = false
+    subscriber = Semian.subscribe do |event, resource, scope, adapter|
+      notified = true
+      assert_equal :success, event
+      assert_equal Semian[:memcached_testing], resource
+      assert_equal :query, scope
+      assert_equal :memcached, adapter
+    end
+
+    client.set("foo", "bar")
+
+    assert notified, "No notifications has been emitted"
+  ensure
+    Semian.unsubscribe(subscriber)
+  end
+
+  def test_resource_acquisition_for_query
+    client = new_memcached
+    client.set("foo", "bar")
+
+    Semian[:memcached_testing].acquire do
+      assert_raises(Memcached::ResourceBusyError) do
+        client.get("foo")
+      end
+    end
+  end
+
+  # def test_resource_timeout_on_query
+  #   memcached_1 = new_memcached
+  #   memcached_2 = new_memcached
+
+  #   Toxiproxy[:semian_test_memcached].downstream(:latency, latency: 600).apply do
+  #     background { memcached_1.set("foo", "bar") }
+
+  #     assert_raises(Memcached::ResourceBusyError) do
+  #       memcached_2.set("foo", "bar")
+  #     end
+  #   end
+  # end
+
+  def test_circuit_breaker_is_disabled
+    client = new_memcached
+    assert_nil client.semian_resource.circuit_breaker
+  end
+
+  def test_semian_is_disabled_when_ejecting_hosts
+    client = new_memcached(auto_eject_hosts: true)
+    assert_instance_of Semian::UnprotectedResource, client.semian_resource
+  end
+
+  private
+
+  TOXIPROXY_MEMCACHED = "#{SemianConfig['toxiproxy_upstream_host']}:#{SemianConfig['memcached_toxiproxy_port']}"
+  SEMIAN_OPTIONS = {
+    name: :testing,
+    tickets: 1,
+    timeout: 0,
+  }
+  MEMCACHED_OPTIONS = {
+    auto_eject_hosts: false,
+    timeout: 0.5,
+    semian: SEMIAN_OPTIONS,
+  }
+
+  def new_memcached(**options)
+    servers = Array(options.fetch(:servers, TOXIPROXY_MEMCACHED))
+    Memcached.new(servers, MEMCACHED_OPTIONS.merge(options))
+  end
+end

--- a/test/memcached_test.rb
+++ b/test/memcached_test.rb
@@ -57,27 +57,22 @@ class MemcachedTest < Minitest::Test
     end
   end
 
-  # def test_resource_timeout_on_query
-  #   memcached_1 = new_memcached
-  #   memcached_2 = new_memcached
+  def test_resource_timeout_on_query
+    memcached_1 = new_memcached
+    memcached_2 = new_memcached
 
-  #   Toxiproxy[:semian_test_memcached].downstream(:latency, latency: 600).apply do
-  #     background { memcached_1.set("foo", "bar") }
+    Toxiproxy[:semian_test_memcached].downstream(:latency, latency: 500).apply do
+      background { memcached_1.set("foo", "bar") }
 
-  #     assert_raises(Memcached::ResourceBusyError) do
-  #       memcached_2.set("foo", "bar")
-  #     end
-  #   end
-  # end
+      assert_raises(Memcached::ResourceBusyError) do
+        memcached_2.set("foo", "bar")
+      end
+    end
+  end
 
   def test_circuit_breaker_is_disabled
     client = new_memcached
     assert_nil client.semian_resource.circuit_breaker
-  end
-
-  def test_semian_is_disabled_when_ejecting_hosts
-    client = new_memcached(auto_eject_hosts: true)
-    assert_instance_of Semian::UnprotectedResource, client.semian_resource
   end
 
   private

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,7 +36,7 @@ Toxiproxy.populate([
   {
     name: 'semian_test_memcached',
     upstream: "#{SemianConfig['memcached_host']}:#{SemianConfig['memcached_port']}",
-    listen: "#{SemianConfig["toxiproxy_upstream_host"]}:#{SemianConfig["memcached_toxiproxy_port"]}",
+    listen: "#{SemianConfig['toxiproxy_upstream_host']}:#{SemianConfig['memcached_toxiproxy_port']}",
   },
   {
     name: 'semian_test_net_http',

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,6 +34,11 @@ Toxiproxy.populate([
     listen: "#{SemianConfig['toxiproxy_upstream_host']}:#{SemianConfig['redis_toxiproxy_port']}",
   },
   {
+    name: 'semian_test_memcached',
+    upstream: "#{SemianConfig['memcached_host']}:#{SemianConfig['memcached_port']}",
+    listen: "#{SemianConfig["toxiproxy_upstream_host"]}:#{SemianConfig["memcached_toxiproxy_port"]}",
+  },
+  {
     name: 'semian_test_net_http',
     upstream: "#{SemianConfig['http_host']}:#{SemianConfig['http_port']}",
     listen: "#{SemianConfig['toxiproxy_upstream_host']}:#{SemianConfig['http_toxiproxy_port']}",


### PR DESCRIPTION
First stab at implementing bulkheading for `memcached@1.8.0`. Since the lib already implements circuit breaking, this only adds bulkheading based on a given name.

If we want to be more granular, I can inject the current peer in the semian identifier, but this will be problematic for multi-* operations.

@csfrancis @dylanahsmith Any thoughts?