### PR TITLE
Addressing comments from #192

### DIFF
--- a/lib/semian/circuit_breaker.rb
+++ b/lib/semian/circuit_breaker.rb
@@ -76,13 +76,13 @@ module Semian
 
     def transition_to_close
       log_state_transition(:closed)
-      @state.close
+      @state.close!
       @errors.clear
     end
 
     def transition_to_open
       log_state_transition(:open)
-      @state.open
+      @state.open!
     end
 
     def transition_to_half_open

--- a/lib/semian/simple_state.rb
+++ b/lib/semian/simple_state.rb
@@ -19,11 +19,11 @@ module Semian
         value == :half_open
       end
 
-      def open
+      def open!
         @value = :open
       end
 
-      def close
+      def close!
         @value = :closed
       end
 
@@ -32,7 +32,7 @@ module Semian
       end
 
       def reset
-        close
+        close!
       end
 
       def destroy

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -101,12 +101,10 @@ class TestCircuitBreaker < Minitest::Test
   def test_open_close_open_cycle
     resource = Semian.register(:open_close, tickets: 1, exceptions: [SomeError], error_threshold: 2, error_timeout: 5, success_threshold: 2)
 
-    half_open_future_travel = -> { Time.now + resource.circuit_breaker.error_timeout + 1 }
-
     open_circuit!(resource)
     assert_circuit_opened(resource)
 
-    Timecop.travel(half_open_future_travel.call) do
+    Timecop.travel(resource.circuit_breaker.error_timeout + 1) do
       assert_circuit_closed(resource)
 
       assert resource.half_open?
@@ -117,7 +115,7 @@ class TestCircuitBreaker < Minitest::Test
       open_circuit!(resource)
       assert_circuit_opened(resource)
 
-      Timecop.travel(half_open_future_travel.call) do
+      Timecop.travel(resource.circuit_breaker.error_timeout + 1) do
         assert_circuit_closed(resource)
 
         assert resource.half_open?

--- a/test/simple_state_test.rb
+++ b/test/simple_state_test.rb
@@ -15,13 +15,13 @@ class TestSimpleEnum < Minitest::Test
     end
 
     def test_open
-      @state.open
+      @state.open!
       assert @state.open?
       assert_equal @state.value, :open
     end
 
     def test_close
-      @state.close
+      @state.close!
       assert @state.closed?
       assert_equal @state.value, :closed
     end


### PR DESCRIPTION
Follow up on https://github.com/Shopify/semian/pull/192

- Test the logging from one state to another.
- Make `open` and `close` consistent with `half_open!`
- Use `Timecop.travel` without `Time.now`