### PR TITLE
Add half_open_resource_timeout for net http

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,6 +42,8 @@ Metrics/MethodLength:
 
 Metrics/ClassLength:
   Max: 500
+  Exclude:
+    - test/**/*
 
 Metrics/AbcSize:
   Max: 50

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ There are three configuration parameters for circuit breakers in Semian:
   again.
 * **success_threshold**. The amount of successes on the circuit until closing it
   again, that is to start accepting all requests to the circuit.
-* **half_open_resource_timeout**. Timeout for the resource in seconds when the circuit is half-open (only supported for MySQL).
+* **half_open_resource_timeout**. Timeout for the resource in seconds when the circuit is half-open (only supported for MySQL and Net::HTTP).
 
 ### Bulkheading
 

--- a/lib/semian/circuit_breaker.rb
+++ b/lib/semian/circuit_breaker.rb
@@ -125,15 +125,14 @@ module Semian
     end
 
     def maybe_with_half_open_resource_timeout(resource, &block)
-      result = nil
-
-      if half_open? && @half_open_resource_timeout && resource.respond_to?(:with_resource_timeout)
-        resource.with_resource_timeout(@half_open_resource_timeout) do
-          result = block.call
+      result =
+        if half_open? && @half_open_resource_timeout && resource.respond_to?(:with_resource_timeout)
+          resource.with_resource_timeout(@half_open_resource_timeout) do
+            block.call
+          end
+        else
+          block.call
         end
-      else
-        result = block.call
-      end
 
       result
     end

--- a/lib/semian/net_http.rb
+++ b/lib/semian/net_http.rb
@@ -90,6 +90,19 @@ module Semian
       end
     end
 
+    def with_resource_timeout(timeout)
+      prev_read_timeout = read_timeout
+      prev_open_timeout = open_timeout
+      begin
+        self.read_timeout = timeout
+        self.open_timeout = timeout
+        yield
+      ensure
+        self.read_timeout = prev_read_timeout
+        self.open_timeout = prev_open_timeout
+      end
+    end
+
     private
 
     def handle_error_responses(result)


### PR DESCRIPTION
The `half_open_resource_timeout` feature was introduced here https://github.com/Shopify/semian/pull/188 but only for mysql2. 

This PR adds it for the `net_http` adapter. `Net::HTTP` let us assign the timeout by using [`read_timeout=` ](https://github.com/ruby/ruby/blob/trunk/lib/net/http.rb#L769).