### PR TITLE
Add last error message to circuit breaker

### DIFF
--- a/lib/semian/adapter.rb
+++ b/lib/semian/adapter.rb
@@ -35,7 +35,8 @@ module Semian
         mark_resource_as_acquired(&block)
       end
     rescue ::Semian::OpenCircuitError => error
-      raise self.class::CircuitOpenError.new(semian_identifier, error.message)
+      last_error_message = semian_resource.circuit_breaker.last_error_message
+      raise self.class::CircuitOpenError.new(semian_identifier, "#{error.message} caused by #{last_error_message}")
     rescue ::Semian::BaseError => error
       raise self.class::ResourceBusyError.new(semian_identifier, error.message)
     rescue *resource_exceptions => error

--- a/lib/semian/circuit_breaker.rb
+++ b/lib/semian/circuit_breaker.rb
@@ -4,7 +4,7 @@ module Semian
 
     def_delegators :@state, :closed?, :open?, :half_open?
 
-    attr_reader :name, :half_open_resource_timeout, :error_timeout, :state
+    attr_reader :name, :half_open_resource_timeout, :error_timeout, :state, :last_error_message
 
     def initialize(name, exceptions:, success_threshold:, error_threshold:, error_timeout:, implementation:, half_open_resource_timeout: nil)
       @name = name.to_sym
@@ -45,7 +45,8 @@ module Semian
       closed? || half_open? || transition_to_half_open?
     end
 
-    def mark_failed(_error)
+    def mark_failed(error)
+      push_error_message(error)
       push_time(@errors)
       if closed?
         transition_to_open if error_threshold_reached?
@@ -103,6 +104,10 @@ module Semian
       last_error_time = @errors.last
       return false unless last_error_time
       Time.at(last_error_time) + @error_timeout < Time.now
+    end
+
+    def push_error_message(error)
+      @last_error_message = error.to_s
     end
 
     def push_time(window, time: Time.now)

--- a/lib/semian/circuit_breaker.rb
+++ b/lib/semian/circuit_breaker.rb
@@ -4,7 +4,7 @@ module Semian
 
     def_delegators :@state, :closed?, :open?, :half_open?
 
-    attr_reader :name, :half_open_resource_timeout, :error_timeout, :state, :last_error_message
+    attr_reader :name, :half_open_resource_timeout, :error_timeout, :state, :last_error
 
     def initialize(name, exceptions:, success_threshold:, error_threshold:, error_timeout:, implementation:, half_open_resource_timeout: nil)
       @name = name.to_sym
@@ -46,7 +46,7 @@ module Semian
     end
 
     def mark_failed(error)
-      push_error_message(error)
+      push_error(error)
       push_time(@errors)
       if closed?
         transition_to_open if error_threshold_reached?
@@ -106,8 +106,8 @@ module Semian
       Time.at(last_error_time) + @error_timeout < Time.now
     end
 
-    def push_error_message(error)
-      @last_error_message = error.to_s
+    def push_error(error)
+      @last_error = error
     end
 
     def push_time(window, time: Time.now)

--- a/test/net_http_test.rb
+++ b/test/net_http_test.rb
@@ -51,7 +51,7 @@ class TestNetHTTP < Minitest::Test
         exception = assert_raises Net::CircuitOpenError do
           Net::HTTP.get(uri)
         end
-        assert_match(/caused by Net::ReadTimeout/, exception.message)
+        assert_equal "Net::ReadTimeout", exception.cause.to_s
       end
     end
   end

--- a/test/net_http_test.rb
+++ b/test/net_http_test.rb
@@ -48,9 +48,10 @@ class TestNetHTTP < Minitest::Test
         open_circuit!
 
         uri = URI("http://#{SemianConfig['toxiproxy_upstream_host']}:#{SemianConfig['http_toxiproxy_port']}/200")
-        assert_raises Net::CircuitOpenError do
+        exception = assert_raises Net::CircuitOpenError do
           Net::HTTP.get(uri)
         end
+        assert_match(/caused by Net::ReadTimeout/, exception.message)
       end
     end
   end


### PR DESCRIPTION
Related to https://github.com/Shopify/cusco/issues/193

As of now, here's what a Semian error will look like while debugging:
error_class: `CircuitOpenError`
error_message: `[service.website.com] CircuitOpenError`

With this change, we would add the last error message to the error_message, it would become something similar to `CircuitOpenError caused by Net::ReadTimeout`

Let me know what you think.