### PR TITLE
Also support a variant of resolve errors (hiredis)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,5 @@ end
 group :development, :test do
   gem 'rubocop', '~> 0.34.2'
 end
+
+gem 'hiredis', github: "maximebedard/hiredis-rb", branch: "bump-to-014", submodules: true

--- a/lib/semian/redis.rb
+++ b/lib/semian/redis.rb
@@ -85,7 +85,7 @@ module Semian
         begin
           raw_connect
         rescue SocketError, RuntimeError => e
-          raise ResolveError.new(semian_identifier) if e.cause.to_s =~ /(can't resolve)|(name or service not known)/i
+          raise ResolveError.new(semian_identifier) if e.cause.to_s =~ /(can't resolve)|(name or service not known)|(nodename nor servname provided, or not known)/i
           raise
         end
       end


### PR DESCRIPTION
Hiredis also returns a different error message in case of resolving errors. This make sure this use case is also handled.