### PR TITLE
Test hiredis on CI & fix resolve errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ rvm:
 gemfile:
   - gemfiles/mysql2-0-4-10.gemfile
   - gemfiles/mysql2-0-5-0.gemfile
+  - gemfiles/hiredis-0-6.gemfile
 
 services:
   - redis-server

--- a/gemfiles/hiredis-0-6.gemfile
+++ b/gemfiles/hiredis-0-6.gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'hiredis', '~> 0.6'
+
+group :development, :test do
+  gem 'rubocop', '~> 0.34.2'
+end

--- a/lib/semian/redis.rb
+++ b/lib/semian/redis.rb
@@ -85,7 +85,7 @@ module Semian
         begin
           raw_connect
         rescue SocketError, RuntimeError => e
-          raise ResolveError.new(semian_identifier) if e.cause.to_s =~ /(can't resolve)|(name or service not known)/i
+          raise ResolveError.new(semian_identifier) if (e.cause || e).to_s =~ /(can't resolve)|(name or service not known)/i
           raise
         end
       end

--- a/test/redis_test.rb
+++ b/test/redis_test.rb
@@ -3,8 +3,9 @@ require 'test_helper'
 begin
   require "hiredis"
   require "redis/connection/hiredis"
+  puts "running tests with hiredis driver"
 rescue LoadError
-  # noop
+  puts "running test with default redis driver"
 end
 
 class TestRedis < Minitest::Test

--- a/test/redis_test.rb
+++ b/test/redis_test.rb
@@ -1,5 +1,12 @@
 require 'test_helper'
 
+begin
+  require "hiredis"
+  require "redis/connection/hiredis"
+rescue LoadError
+  # noop
+end
+
 class TestRedis < Minitest::Test
   ERROR_TIMEOUT = 5
   ERROR_THRESHOLD = 1


### PR DESCRIPTION
Hi redis returns RuntimeError, but `#cause` always returns nil. This makes sure we support all the scenarios simply by to_s'ing the error an matching on that string which should cover all cases.

I've also added a gemfile to travis test matrix to make sure this never happens anymore.