### PR TITLE
Resolve CI warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,9 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Max: 40
 
+Metrics/ModuleLength:
+  Enabled: false
+
 Metrics/ClassLength:
   Max: 500
   Exclude:
@@ -117,6 +120,3 @@ Style/CaseIndentation:
 Lint/UselessAssignment:
   Exclude:
     - 'test/adapter_test.rb'
-
-Style/ModuleLength:
-  Enabled: false

--- a/semian.gemspec
+++ b/semian.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'mysql2'
   s.add_development_dependency 'redis'
-  s.add_development_dependency 'thin', '~> 1.6.4'
+  s.add_development_dependency 'thin', '~> 1.7.2'
   s.add_development_dependency 'toxiproxy', '~> 1.0.0'
 end


### PR DESCRIPTION
Three small tweaks to reduce the noise for CI.

* Bump development_dependency for thin to 1.7.2 remove `Fixnum` warning
* Capture stderr for test_initialize_with_float and explicit assert warning message
* Rename rubocop definition whose namespace has changed

This PR should have no effect on runtime.