### PR TITLE
Instrument success on `acquire_circuit_breaker`

### DIFF
--- a/lib/semian/protected_resource.rb
+++ b/lib/semian/protected_resource.rb
@@ -22,7 +22,7 @@ module Semian
     def acquire(timeout: nil, scope: nil, adapter: nil, resource: nil)
       acquire_circuit_breaker(scope, adapter, resource) do
         acquire_bulkhead(timeout, scope, adapter) do |_, wait_time|
-          Semian.notify(:success, self, scope, adapter, wait_time || 0)
+          Semian.notify(:success, self, scope, adapter, wait_time)
           yield self
         end
       end
@@ -45,7 +45,7 @@ module Semian
 
     def acquire_bulkhead(timeout, scope, adapter)
       if @bulkhead.nil?
-        yield self
+        yield self, 0
       else
         @bulkhead.acquire(timeout: timeout) do |wait_time|
           yield self, wait_time

--- a/lib/semian/protected_resource.rb
+++ b/lib/semian/protected_resource.rb
@@ -34,6 +34,7 @@ module Semian
         yield self
       else
         @circuit_breaker.acquire(resource) do
+          Semian.notify(:success, self, scope, adapter) if @bulkhead.nil?
           yield self
         end
       end

--- a/test/instrumentation_test.rb
+++ b/test/instrumentation_test.rb
@@ -38,6 +38,13 @@ class TestInstrumentation < Minitest::Test
     end
   end
 
+  def test_success_instrumentation_without_bulkhead
+    Semian.register(:no_bulkhead, bulkhead: false, error_threshold: 1, error_timeout: 5, success_threshold: 1)
+    assert_notify(:success) do
+      Semian[:no_bulkhead].acquire {}
+    end
+  end
+
   def test_success_instrumentation_wait_time
     hit = false
     subscription = Semian.subscribe do |*_, wait_time|


### PR DESCRIPTION
We currently only emit a `success` event on the `acquire_bulkhead` method, this causes a problem when we want to deactivate the bulkheads and still keep track of the successes.

[Event](https://github.com/Shopify/semian/blob/47bee8756cc84a198073acc0e148baed1b57d6fa/lib/semian/protected_resource.rb#L41) on circuit open for `acquire_circuit_breaker`.

Success [event](https://github.com/Shopify/semian/blob/47bee8756cc84a198073acc0e148baed1b57d6fa/lib/semian/protected_resource.rb#L50) on `acquire_bulkead`.


I've added `if @bulkhead.nil?` to avoid emitting two successes.

Related graph that went to 0 once bulkhead were disabled:
![image](https://user-images.githubusercontent.com/5659685/49454502-485c1100-f7b3-11e8-9555-53be87839cd5.png)
