### PR TITLE
If an error responds to #marks_semian_circuits? don't mark the circuit if it returns false

### DIFF
--- a/lib/semian/circuit_breaker.rb
+++ b/lib/semian/circuit_breaker.rb
@@ -29,7 +29,9 @@ module Semian
       begin
         result = maybe_with_half_open_resource_timeout(resource, &block)
       rescue *@exceptions => error
-        mark_failed(error)
+        if !error.respond_to?(:marks_semian_circuits?) || error.marks_semian_circuits?
+          mark_failed(error)
+        end
         raise error
       else
         mark_success

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -214,4 +214,26 @@ class TestCircuitBreaker < Minitest::Test
 
     assert triggered
   end
+
+  class SomeErrorThatMarksCircuits < SomeError
+    def marks_semian_circuits?
+      true
+    end
+  end
+
+  class SomeSubErrorThatDoesNotMarkCircuits < SomeErrorThatMarksCircuits
+    def marks_semian_circuits?
+      false
+    end
+  end
+
+  def test_opens_circuit_when_error_has_marks_semian_circuits_equal_to_true
+    2.times { trigger_error!(@resource, SomeErrorThatMarksCircuits) }
+    assert_circuit_opened
+  end
+
+  def test_does_not_open_circuit_when_error_has_marks_semian_circuits_equal_to_false
+    2.times { trigger_error!(@resource, SomeSubErrorThatDoesNotMarkCircuits) }
+    assert_circuit_closed
+  end
 end

--- a/test/helpers/circuit_breaker_helper.rb
+++ b/test/helpers/circuit_breaker_helper.rb
@@ -13,9 +13,9 @@ module CircuitBreakerHelper
     end
   end
 
-  def trigger_error!(resource = @resource)
-    resource.acquire { raise SomeError }
-  rescue SomeError
+  def trigger_error!(resource = @resource, error = SomeError)
+    resource.acquire { raise error }
+  rescue error
   end
 
   def assert_circuit_closed(resource = @resource)


### PR DESCRIPTION
We would like to avoid marking the circuit for specific errors that are naturally subclasses of an error that should mark the circuit. In particular, for GraphQL, any HTTP non-success is considered a "transport error" and should generally mark the circuit, but some 4xx statuses occur for non-operational reasons and should not mark circuits. The cleanest way to express this is with a "trait."