### PR TITLE
Bump version to 0.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.8.7
+* Fix: Instrument success for `acquire_circuit_breaker` (#209)
+
 # v0.8.6
 * Feature: If an error instance responds to `#marks_semian_circuits?` don't mark the circuit if it returns false (#210)
 

--- a/lib/semian/version.rb
+++ b/lib/semian/version.rb
@@ -1,3 +1,3 @@
 module Semian
-  VERSION = '0.8.6'
+  VERSION = '0.8.7'
 end


### PR DESCRIPTION
Bump the gem version to 0.8.7. Includes the #209 PR which fixes instrumentation for the acquire circuit breaker method.