### PR TITLE
Don't modify the last error if it already exist

### DIFF
--- a/lib/semian/circuit_breaker.rb
+++ b/lib/semian/circuit_breaker.rb
@@ -109,7 +109,7 @@ module Semian
     end
 
     def push_error(error)
-      @last_error = error
+      @last_error ||= error
     end
 
     def push_time(window, time: Time.now)


### PR DESCRIPTION
Fixes https://github.com/Shopify/semian/issues/211

Since a circuit open error can trigger a circuit open error, the problem was that we were always adding a Circuit open error as a cause to new circuit open error which was getting in an infinite loop and it made reading logs really hard.
