### PR TITLE
Fix resolve errors when using hi-redis + OSX

### DIFF
--- a/lib/semian/redis.rb
+++ b/lib/semian/redis.rb
@@ -85,7 +85,7 @@ module Semian
         begin
           raw_connect
         rescue SocketError, RuntimeError => e
-          raise ResolveError.new(semian_identifier) if (e.cause || e).to_s =~ /(can't resolve)|(name or service not known)/i
+          raise ResolveError.new(semian_identifier) if (e.cause || e).to_s =~ /(can't resolve)|(name or service not known)|(nodename nor servname provided, or not known)/i
           raise
         end
       end


### PR DESCRIPTION
The error message on OSX is actually different when the host can't be resolved.

```
SemianTest#test_redis_raises_resolve_errors
    [Redis::ResolveError] exception expected, not
Class: <RuntimeError>
Message: <"nodename nor servname provided, or not known">
---Backtrace---
test/unit/semian_test.rb:80:in `block (2 levels) in <class:SemianTest>'
test/support/initializers/active_support_test_case.rb:56:in `block in assert_raises'
test/support/initializers/active_support_test_case.rb:56:in `assert_raises'
test/unit/semian_test.rb:79:in `block in <class:SemianTest>'
---------------
```

Since the test suite is all running on linux containers, this is hard to test reliably, so this is probably good enough for now 😓 