### PR TITLE
Instrument the LRU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ vendor/
 nohup.out
 .vagrant
 .byebug_history
+.idea

--- a/lib/semian/instrumentable.rb
+++ b/lib/semian/instrumentable.rb
@@ -9,6 +9,12 @@ module Semian
       subscribers.delete(name)
     end
 
+    # Args:
+    #   event (string)
+    #   resource (Object)
+    #   scope (string)
+    #   adapter (string)
+    #   payload (optional)
     def notify(*args)
       subscribers.values.each { |subscriber| subscriber.call(*args) }
     end

--- a/test/grpc_test.rb
+++ b/test/grpc_test.rb
@@ -85,6 +85,7 @@ class TestGRPC < Minitest::Test
   def test_instrumentation
     notified = false
     subscriber = Semian.subscribe do |event, resource, scope, adapter|
+      next if event == :lru_hash_gc
       notified = true
       assert_equal :success, event
       assert_equal Semian[@host], resource

--- a/test/lru_hash_test.rb
+++ b/test/lru_hash_test.rb
@@ -133,6 +133,61 @@ class TestLRUHash < Minitest::Test
     Semian.unsubscribe(subscriber)
   end
 
+  def test_monotonically_increasing
+    start_time = Time.now
+
+    notification = 0
+    subscriber = Semian.subscribe do |event, _resource, _scope, _adapter, payload|
+      next unless event == :lru_hash_gc
+
+      notification += 1
+      if notification < 5
+        assert_equal notification, payload[:size]
+        assert_equal 1, payload[:examined]
+      elsif notification == 5
+        # At this point, the table looks like: [a, c, b, d, e]
+        assert_equal notification, payload[:size]
+        assert_equal 3, payload[:examined]
+      else
+        assert_nil true
+      end
+    end
+
+    assert_monotonic = lambda do
+      previous_timestamp = start_time
+      @lru_hash.table.each do |key, val|
+        assert val.updated_at > previous_timestamp, "Timestamp for #{key} was not monotonically increasing"
+      end
+    end
+
+    @lru_hash.set('a', create_circuit_breaker('a'))
+    @lru_hash.set('b', create_circuit_breaker('b'))
+    @lru_hash.set('c', create_circuit_breaker('c'))
+
+    # Before: [a, b, c]
+    # After: [a, c, b]
+    Timecop.travel(60) do
+      @lru_hash.get('b')
+      assert_monotonic.call
+    end
+
+    # Before: [a, c, b]
+    # After: [a, c, b, d]
+    Timecop.travel(60) do
+      @lru_hash.set('d', create_circuit_breaker('d'))
+      assert_monotonic.call
+    end
+
+    # Before: [a, c, b, d]
+    # After: [b, d, e]
+    Timecop.travel(LRUHash::MINIMUM_TIME_IN_LRU) do
+      @lru_hash.set('e', create_circuit_breaker('e'))
+      assert_monotonic.call
+    end
+  ensure
+    Semian.unsubscribe(subscriber)
+  end
+
   private
 
   def create_circuit_breaker(name, exceptions = true, bulkhead = false, error_timeout = 0)

--- a/test/mysql2_test.rb
+++ b/test/mysql2_test.rb
@@ -59,7 +59,7 @@ class TestMysql2 < Minitest::Test
   def test_connect_instrumentation
     notified = false
     subscriber = Semian.subscribe do |event, resource, scope, adapter|
-      next if event == :lru_hash_cleaned
+      next if event == :lru_hash_gc
       notified = true
       assert_equal :success, event
       assert_equal Semian[:mysql_testing], resource

--- a/test/redis_test.rb
+++ b/test/redis_test.rb
@@ -115,7 +115,7 @@ class TestRedis < Minitest::Test
   def test_connect_instrumentation
     notified = false
     subscriber = Semian.subscribe do |event, resource, scope, adapter|
-      next if event == :lru_hash_cleaned
+      next if event == :lru_hash_gc
       notified = true
       assert_equal :success, event
       assert_equal Semian[:redis_testing], resource


### PR DESCRIPTION
## What

Our current hypothesis is that on average, `clear_unused_resources` behaves like an amortized O(1) operation, rather than an O(n) one. Without a robust simulator, however, we need to collect some runtime data to disprove the hypothesis.

## How

This PR adds to the `implement_lru_cache` branch by instrumenting the `lru_hash_gc` event with stats about the garbage collection operation.

This PR also changes the signature of the `notify` method to have `payload` as the final argument so we can pass arbitrary data to subscribers.