### PR TITLE
Added a max_size to the LRU cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,22 @@ The best resource is looking at the [already implemented adapters](#adapters).
 
 ### Configuration
 
+There are some global configuration options that can be set for Semian:
+
+```ruby
+# Maximum size of the LRU cache (default: 500)
+# Note: Setting this to 0 enables aggressive garbage collection. 
+Semian.maximum_lru_size = 0
+
+# Minimum time a resource should be resident in the LRU cache (default: 300s)
+Semian.minimum_lru_time = 60
+```
+
+Note: `minimum_lru_time` is a stronger guarantee than `maximum_lru_size`. That
+is, if a resource has been updated more recently than `minimum_lru_time` it
+will not be garbage collected, even if it would cause the LRU cache to grow
+larger than `maximum_lru_size`.
+
 When instantiating a resource it now needs to be configured for Semian. This is
 done by passing `semian` as an argument when initializing the client. Examples
 built in adapters:

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -90,6 +90,10 @@ module Semian
   InternalError = Class.new(BaseError)
   OpenCircuitError = Class.new(BaseError)
 
+  attr_accessor :maximum_lru_size, :minimum_lru_time
+  self.maximum_lru_size = 500
+  self.minimum_lru_time = 300
+
   def issue_disabled_semaphores_warning
     return if defined?(@warning_issued)
     @warning_issued = true

--- a/lib/semian/lru_hash.rb
+++ b/lib/semian/lru_hash.rb
@@ -8,8 +8,6 @@ class LRUHash
   extend Forwardable
   def_delegators :@table, :size, :count, :empty?, :values
   attr_reader :table
-  MAXIMUM_SIZE_OF_LRU = 1000
-  MINIMUM_TIME_IN_LRU = 300
 
   class NoopMutex
     def synchronize(*)
@@ -49,7 +47,7 @@ class LRUHash
   #   circuits to disparate endpoints (or your circuit names are bad).
   #   If the max_size is 0, the garbage collection will be very aggressive and
   #   potentially computationally expensive.
-  def initialize(max_size: MAXIMUM_SIZE_OF_LRU, min_time: MINIMUM_TIME_IN_LRU)
+  def initialize(max_size: Semian.maximum_lru_size, min_time: Semian.minimum_lru_time)
     @max_size = max_size
     @min_time = min_time
     @table = {}

--- a/test/lru_hash_test.rb
+++ b/test/lru_hash_test.rb
@@ -166,21 +166,21 @@ class TestLRUHash < Minitest::Test
 
     # Before: [a, b, c]
     # After: [a, c, b]
-    Timecop.travel(60) do
+    Timecop.travel(Semian.minimum_lru_time - 1) do
       @lru_hash.get('b')
       assert_monotonic.call
     end
 
     # Before: [a, c, b]
     # After: [a, c, b, d]
-    Timecop.travel(60) do
+    Timecop.travel(Semian.minimum_lru_time - 1) do
       @lru_hash.set('d', create_circuit_breaker('d'))
       assert_monotonic.call
     end
 
     # Before: [a, c, b, d]
     # After: [b, d, e]
-    Timecop.travel(LRUHash::MINIMUM_TIME_IN_LRU) do
+    Timecop.travel(Semian.minimum_lru_time) do
       @lru_hash.set('e', create_circuit_breaker('e'))
       assert_monotonic.call
     end
@@ -195,7 +195,7 @@ class TestLRUHash < Minitest::Test
     lru_hash.set('c', create_circuit_breaker('c'))
     assert_equal 3, lru_hash.table.length
 
-    Timecop.travel(LRUHash::MINIMUM_TIME_IN_LRU) do
+    Timecop.travel(Semian.minimum_lru_time) do
       # [a, b, c] are older than the min_time, so they get garbage collected.
       lru_hash.set('d', create_circuit_breaker('d'))
       assert_equal 1, lru_hash.table.length
@@ -208,14 +208,14 @@ class TestLRUHash < Minitest::Test
     lru_hash.set('b', create_circuit_breaker('b'))
     assert_equal 2, lru_hash.table.length
 
-    Timecop.travel(LRUHash::MINIMUM_TIME_IN_LRU) do
+    Timecop.travel(Semian.minimum_lru_time) do
       # [a, b] are older than the min_time, but the hash isn't full, so
       # there's no garbage collection.
       lru_hash.set('c', create_circuit_breaker('c'))
       assert_equal 3, lru_hash.table.length
     end
 
-    Timecop.travel(LRUHash::MINIMUM_TIME_IN_LRU + 1) do
+    Timecop.travel(Semian.minimum_lru_time + 1) do
       # [a, b] are beyond the min_time, but [c] isn't.
       lru_hash.set('d', create_circuit_breaker('d'))
       assert_equal 2, lru_hash.table.length


### PR DESCRIPTION
# What

Implement a `max_size` in the LRU cache.

# Why

The data ([dashboard](https://shopify.datadoghq.com/dashboard/mzg-id4-5rp/semian-lru)) we're seeing from core suggests that the LRU cache has a p99 garbage collection time of 1.5ms, and that garbage collection is run quite frequently.

<img width="957" alt="Screen Shot 2019-05-30 at 11 04 16 AM" src="https://user-images.githubusercontent.com/24932723/58642164-c153a580-82ca-11e9-95b9-ec07f3387586.png">

<img width="955" alt="Screen Shot 2019-05-30 at 11 04 40 AM" src="https://user-images.githubusercontent.com/24932723/58642165-c153a580-82ca-11e9-8cf8-54af8cab37d8.png">

<img width="956" alt="Screen Shot 2019-05-30 at 11 04 31 AM" src="https://user-images.githubusercontent.com/24932723/58642166-c153a580-82ca-11e9-8d53-47dca2e7ea17.png">

(Note: I'm not sure how frequently, but the average number of evictions is 5 while the average size of the cache is about 150 and we have to examine over 100 of them every time.)

# How

This PR adds a `max_size` parameter with a sensible default based on what we've observed in core. It's my expectation that we'll do fewer garbage collections until the cache fills, and then amortize one large garbage collection. This should lead to better Semian performance on average.



