### PR TITLE
[DRAFT] Share circuit breakers between workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ vendor/
 nohup.out
 .vagrant
 .byebug_history
+*.log
 .idea

--- a/ext/semian/circuit_breaker.c
+++ b/ext/semian/circuit_breaker.c
@@ -1,0 +1,67 @@
+#include "circuit_breaker.h"
+
+#include <errno.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
+#include "types.h"
+#include "util.h"
+
+static const rb_data_type_t semian_circuit_breaker_type;
+
+void Init_CircuitBreaker() {
+  printf("[DEBUG] Init_CircuitBreaker\n");
+
+  VALUE cSemian = rb_const_get(rb_cObject, rb_intern("Semian"));
+  VALUE cCircuitBreaker = rb_const_get(cSemian, rb_intern("CircuitBreaker"));
+
+  rb_define_alloc_func(cCircuitBreaker, semian_circuit_breaker_alloc);
+  rb_define_method(cCircuitBreaker, "initialize_circuit_breaker", semian_circuit_breaker_initialize, 1);
+}
+
+VALUE semian_circuit_breaker_alloc(VALUE klass)
+{
+  printf("[DEBUG] semian_circuit_breaker_alloc\n");
+
+  semian_circuit_breaker_t *res;
+  VALUE obj = TypedData_Make_Struct(klass, semian_circuit_breaker_t, &semian_circuit_breaker_type, res);
+  return obj;
+}
+
+VALUE semian_circuit_breaker_initialize(VALUE self, VALUE id)
+{
+  const char *c_id_str = check_id_arg(id);
+
+  printf("[DEBUG] semian_circuit_breaker_initialize('%s')\n", c_id_str);
+
+  // Build semian resource structure
+  semian_circuit_breaker_t *res = NULL;
+  TypedData_Get_Struct(self, semian_circuit_breaker_t, &semian_circuit_breaker_type, res);
+
+  // Initialize the semaphore set
+  // initialize_semaphore_set(res, c_id_str, c_permissions, c_tickets, c_quota);
+  res->name = strdup(c_id_str);
+
+  key_t key = generate_key(res->name);
+  printf("[DEBUG] Creating shared memory for '%s' (id %u)\n", res->name, key);
+  const int permissions = 0664;
+  int shmid = shmget(key, 1024, IPC_CREAT | permissions);
+  if (shmid == -1) {
+    rb_raise(rb_eArgError, "could not create shared memory (%s)", strerror(errno));
+  }
+
+  printf("[DEBUG] Getting shared memory (id %u)\n", shmid);
+  void *val = shmat(shmid, NULL, 0);
+  if (val == (void*)-1) {
+    rb_raise(rb_eArgError, "could not get shared memory (%s)", strerror(errno));
+  }
+
+  semian_circuit_breaker_shared_t *data = (semian_circuit_breaker_shared_t*)val;
+  if (data == NULL) {
+    rb_raise(rb_eArgError, "could not get shared memory (%s)", strerror(errno));
+  }
+
+  printf("[DEBUG] successes = %d\n", data->successes);
+  data->successes = 0;
+
+  return self;
+}

--- a/ext/semian/circuit_breaker.h
+++ b/ext/semian/circuit_breaker.h
@@ -1,0 +1,12 @@
+#ifndef CIRCUIT_BREAKER_H
+#define CIRCUIT_BREAKER_H
+
+#include <ruby.h>
+
+void Init_CircuitBreaker();
+
+VALUE semian_circuit_breaker_alloc(VALUE klass);
+VALUE semian_circuit_breaker_initialize(VALUE self, VALUE id);
+VALUE semian_circuit_breaker_successes(VALUE self);
+
+#endif // CIRCUIT_BREAKER_H

--- a/ext/semian/resource.c
+++ b/ext/semian/resource.c
@@ -1,5 +1,7 @@
 #include "resource.h"
 
+#include "util.h"
+
 static VALUE
 cleanup_semian_resource_acquire(VALUE self);
 
@@ -14,9 +16,6 @@ check_tickets_arg(VALUE tickets);
 
 static long
 check_permissions_arg(VALUE permissions);
-
-static const
-char *check_id_arg(VALUE id);
 
 static double
 check_default_timeout_arg(VALUE default_timeout);
@@ -312,23 +311,6 @@ check_tickets_arg(VALUE tickets)
   }
 
   return c_tickets;
-}
-
-static const char*
-check_id_arg(VALUE id)
-{
-  const char *c_id_str = NULL;
-
-  if (TYPE(id) != T_SYMBOL && TYPE(id) != T_STRING) {
-    rb_raise(rb_eTypeError, "id must be a symbol or string");
-  }
-  if (TYPE(id) == T_SYMBOL) {
-    c_id_str = rb_id2name(rb_to_id(id));
-  } else if (TYPE(id) == T_STRING) {
-    c_id_str = RSTRING_PTR(id);
-  }
-
-  return c_id_str;
 }
 
 static double

--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -66,5 +66,6 @@ void Init_semian()
   rb_define_const(cSemian, "MAX_TICKETS", INT2FIX(system_max_semaphore_count));
 
   Init_SimpleInteger();
+  Init_SlidingWindow();
   Init_CircuitBreaker();
 }

--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -64,4 +64,7 @@ void Init_semian()
 
   /* Maximum number of tickets available on this system. */
   rb_define_const(cSemian, "MAX_TICKETS", INT2FIX(system_max_semaphore_count));
+
+  Init_SimpleInteger();
+  Init_CircuitBreaker();
 }

--- a/ext/semian/semian.h
+++ b/ext/semian/semian.h
@@ -10,6 +10,7 @@ Implements Init_semian, which is used as C/Ruby entrypoint.
 #include "circuit_breaker.h"
 #include "resource.h"
 #include "simple_integer.h"
+#include "sliding_window.h"
 
 void Init_semian();
 

--- a/ext/semian/semian.h
+++ b/ext/semian/semian.h
@@ -7,7 +7,9 @@ Implements Init_semian, which is used as C/Ruby entrypoint.
 #ifndef SEMIAN_H
 #define SEMIAN_H
 
+#include "circuit_breaker.h"
 #include "resource.h"
+#include "simple_integer.h"
 
 void Init_semian();
 

--- a/ext/semian/simple_integer.c
+++ b/ext/semian/simple_integer.c
@@ -92,7 +92,10 @@ VALUE semian_simple_integer_value_get(VALUE self) {
 
 VALUE semian_simple_integer_value_set(VALUE self, VALUE val) {
   int *data = get_value(self);
-  *data = RB_NUM2INT(val);
+
+  // TODO(michaelkipper): Check for respond_to?(:to_i) before calling.
+  VALUE to_i = rb_funcall(val, rb_intern("to_i"), 0);
+  *data = RB_NUM2INT(to_i);
 
   return RB_INT2NUM(*data);
 }

--- a/ext/semian/simple_integer.c
+++ b/ext/semian/simple_integer.c
@@ -8,19 +8,8 @@
 
 static const rb_data_type_t semian_simple_integer_type;
 
-static const char* get_string(VALUE obj) {
-  if (RB_TYPE_P(obj, T_STRING)) {
-    return RSTRING_PTR(obj);
-  } else if (RB_TYPE_P(obj, T_SYMBOL)) {
-    return rb_id2name(SYM2ID(obj));
-  }
-
-  rb_raise(rb_eArgError, "could not convert object to string");
-  return NULL;
-}
-
 static int* get_value(VALUE self) {
-  const char* name = get_string(rb_iv_get(self, "@name"));
+  const char* name = to_s(rb_iv_get(self, "@name"));
   if (name == NULL) {
     rb_raise(rb_eArgError, "could not get object name");
   }

--- a/ext/semian/simple_integer.c
+++ b/ext/semian/simple_integer.c
@@ -1,0 +1,98 @@
+#include "simple_integer.h"
+
+#include <errno.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
+#include "types.h"
+#include "util.h"
+
+static const rb_data_type_t semian_simple_integer_type;
+
+static const char* get_string(VALUE obj) {
+  if (RB_TYPE_P(obj, T_STRING)) {
+    return RSTRING_PTR(obj);
+  } else if (RB_TYPE_P(obj, T_SYMBOL)) {
+    return rb_id2name(SYM2ID(obj));
+  }
+
+  rb_raise(rb_eArgError, "could not convert object to string");
+  return NULL;
+}
+
+static int* get_value(VALUE self) {
+  const char* name = get_string(rb_iv_get(self, "@name"));
+  if (name == NULL) {
+    rb_raise(rb_eArgError, "could not get object name");
+  }
+
+  key_t key = generate_key(name);
+
+  const int permissions = 0664;
+  int shmid = shmget(key, sizeof(int), IPC_CREAT | permissions);
+  if (shmid == -1) {
+    rb_raise(rb_eArgError, "could not create shared memory (%s)", strerror(errno));
+  }
+
+  void *val = shmat(shmid, NULL, 0);
+  if (val == (void*)-1) {
+    rb_raise(rb_eArgError, "could not get shared memory (%s)", strerror(errno));
+  }
+
+  return (int*)val;
+}
+
+void Init_SimpleInteger()
+{
+  VALUE cSemian = rb_const_get(rb_cObject, rb_intern("Semian"));
+  VALUE cSimple = rb_const_get(cSemian, rb_intern("Simple"));
+  VALUE cSimpleInteger = rb_const_get(cSimple, rb_intern("Integer"));
+
+  rb_define_alloc_func(cSimpleInteger, semian_simple_integer_alloc);
+  rb_define_method(cSimpleInteger, "initialize_simple_integer", semian_simple_integer_initialize, 0);
+  rb_define_method(cSimpleInteger, "increment", semian_simple_integer_increment, 1);
+  rb_define_method(cSimpleInteger, "reset", semian_simple_integer_reset, 0);
+  rb_define_method(cSimpleInteger, "value", semian_simple_integer_value_get, 0);
+  rb_define_method(cSimpleInteger, "value=", semian_simple_integer_value_set, 1);
+}
+
+VALUE semian_simple_integer_alloc(VALUE klass)
+{
+  semian_simple_integer_t *res;
+  VALUE obj = TypedData_Make_Struct(klass, semian_simple_integer_t, &semian_simple_integer_type, res);
+  return obj;
+}
+
+
+VALUE semian_simple_integer_initialize(VALUE self)
+{
+  int* data = get_value(self);
+  *data = 0;
+
+  return self;
+}
+
+VALUE semian_simple_integer_increment(VALUE self, VALUE val) {
+  int *data = get_value(self);
+  *data += rb_num2int(val);
+
+  return RB_INT2NUM(*data);
+}
+
+VALUE semian_simple_integer_reset(VALUE self) {
+  int *data = get_value(self);
+  *data = 0;
+
+  return RB_INT2NUM(*data);
+}
+
+VALUE semian_simple_integer_value_get(VALUE self) {
+  int *data = get_value(self);
+  return RB_INT2NUM(*data);
+}
+
+VALUE semian_simple_integer_value_set(VALUE self, VALUE val) {
+  int *data = get_value(self);
+  *data = RB_NUM2INT(val);
+
+  return RB_INT2NUM(*data);
+}

--- a/ext/semian/simple_integer.h
+++ b/ext/semian/simple_integer.h
@@ -1,0 +1,15 @@
+#ifndef EXT_SEMIAN_SIMPLE_INTEGER_H
+#define EXT_SEMIAN_SIMPLE_INTEGER_H
+
+#include <ruby.h>
+
+void Init_SimpleInteger();
+
+VALUE semian_simple_integer_alloc(VALUE klass);
+VALUE semian_simple_integer_initialize(VALUE self);
+VALUE semian_simple_integer_increment(VALUE self, VALUE val);
+VALUE semian_simple_integer_reset(VALUE self);
+VALUE semian_simple_integer_value_get(VALUE self);
+VALUE semian_simple_integer_value_set(VALUE self, VALUE val);
+
+#endif // EXT_SEMIAN_SIMPLE_INTEGER_H

--- a/ext/semian/sliding_window.c
+++ b/ext/semian/sliding_window.c
@@ -1,0 +1,4 @@
+#include "sliding_window.h"
+
+void Init_SlidingWindow() {
+}

--- a/ext/semian/sliding_window.c
+++ b/ext/semian/sliding_window.c
@@ -1,4 +1,212 @@
 #include "sliding_window.h"
 
+#include <errno.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
+#include "util.h"
+
+static const rb_data_type_t semian_simple_sliding_window_type;
+
+static semian_simple_sliding_window_shared_t* get_window(uint64_t key) {
+  const int permissions = 0664;
+  int shmid = shmget(key, sizeof(int), IPC_CREAT | permissions);
+  if (shmid == -1) {
+    rb_raise(rb_eArgError, "could not create shared memory (%s)", strerror(errno));
+  }
+
+  void *val = shmat(shmid, NULL, 0);
+  if (val == (void*)-1) {
+    rb_raise(rb_eArgError, "could not get shared memory (%s)", strerror(errno));
+  }
+
+  return (semian_simple_sliding_window_shared_t*)val;
+}
+
+static int check_max_size_arg(VALUE max_size)
+{
+  int retval = -1;
+  switch (TYPE(max_size)) {
+  case T_NIL:
+    retval = SLIDING_WINDOW_MAX_SIZE; break;
+  case T_FLOAT:
+    rb_warn("semian sliding window max_size is a float, converting to fixnum");
+    retval = (int)(RFLOAT_VALUE(max_size)); break;
+  default:
+    retval = RB_NUM2INT(max_size); break;
+  }
+
+  if (retval <= 0) {
+    rb_raise(rb_eArgError, "max_size must be greater than zero");
+  } else if (retval > SLIDING_WINDOW_MAX_SIZE) {
+    rb_raise(rb_eArgError, "max_size must be less than %d", SLIDING_WINDOW_MAX_SIZE);
+  }
+
+  return retval;
+}
+
 void Init_SlidingWindow() {
+  printf("[DEBUG] Init_SlidingWindow\n");
+
+  VALUE cSemian = rb_const_get(rb_cObject, rb_intern("Semian"));
+  VALUE cSimple = rb_const_get(cSemian, rb_intern("Simple"));
+  VALUE cSlidingWindow = rb_const_get(cSimple, rb_intern("SlidingWindow"));
+
+  rb_define_alloc_func(cSlidingWindow, semian_simple_sliding_window_alloc);
+  rb_define_method(cSlidingWindow, "initialize_sliding_window", semian_simple_sliding_window_initialize, 2);
+  rb_define_method(cSlidingWindow, "size", semian_simple_sliding_window_size, 0);
+  rb_define_method(cSlidingWindow, "max_size", semian_simple_sliding_window_max_size, 0);
+  rb_define_method(cSlidingWindow, "values", semian_simple_sliding_window_values, 0);
+  rb_define_method(cSlidingWindow, "last", semian_simple_sliding_window_last, 0);
+  rb_define_method(cSlidingWindow, "<<", semian_simple_sliding_window_push, 1);
+  rb_define_method(cSlidingWindow, "destroy", semian_simple_sliding_window_clear, 0);
+  rb_define_method(cSlidingWindow, "reject!", semian_simple_sliding_window_reject, 0);
+}
+
+VALUE semian_simple_sliding_window_alloc(VALUE klass) {
+  semian_simple_sliding_window_t *res;
+  VALUE obj = TypedData_Make_Struct(klass, semian_simple_sliding_window_t, &semian_simple_sliding_window_type, res);
+  return obj;
+}
+
+VALUE semian_simple_sliding_window_initialize(VALUE self, VALUE name, VALUE max_size) {
+  printf("[DEBUG] semian_simple_sliding_window_initialize\n");
+
+  semian_simple_sliding_window_t *res;
+  TypedData_Get_Struct(self, semian_simple_sliding_window_t, &semian_simple_sliding_window_type, res);
+
+  const char *id_str = check_id_arg(name);
+  res->key = generate_key(id_str);
+
+  semian_simple_sliding_window_shared_t *window = get_window(res->key);
+  window->max_size = check_max_size_arg(max_size);
+  window->length = 0;
+  window->start = 0;
+  window->end = 0;
+
+  printf("[DEBUG]   key:%lu addr:0x%p max_size:%d length:%d start:%d end:%d\n", res->key, window, window->max_size, window->length, window->start, window->end);
+
+  return self;
+}
+
+VALUE semian_simple_sliding_window_size(VALUE self) {
+  printf("[DEBUG] semian_simple_sliding_window_size\n");
+
+  semian_simple_sliding_window_t *res;
+  TypedData_Get_Struct(self, semian_simple_sliding_window_t, &semian_simple_sliding_window_type, res);
+
+  semian_simple_sliding_window_shared_t *window = get_window(res->key);
+  printf("[DEBUG]   key:%lu addr:0x%p max_size:%d length:%d start:%d end:%d\n", res->key, window, window->max_size, window->length, window->start, window->end);
+
+  return RB_INT2NUM(window->length);
+}
+
+VALUE semian_simple_sliding_window_max_size(VALUE self) {
+  printf("[DEBUG] semian_simple_sliding_window_max_size\n");
+
+  semian_simple_sliding_window_t *res;
+  TypedData_Get_Struct(self, semian_simple_sliding_window_t, &semian_simple_sliding_window_type, res);
+
+  semian_simple_sliding_window_shared_t *window = get_window(res->key);
+  printf("[DEBUG]   key:%lu addr:0x%p max_size:%d length:%d start:%d end:%d\n", res->key, window, window->max_size, window->length, window->start, window->end);
+
+  return RB_INT2NUM(window->max_size);
+}
+
+VALUE semian_simple_sliding_window_values(VALUE self) {
+  printf("[DEBUG] semian_simple_sliding_window_values\n");
+
+  semian_simple_sliding_window_t *res;
+  TypedData_Get_Struct(self, semian_simple_sliding_window_t, &semian_simple_sliding_window_type, res);
+  semian_simple_sliding_window_shared_t *window = get_window(res->key);
+
+  VALUE retval = rb_ary_new_capa(window->length);
+  for (int i = 0; i < window->length; ++i) {
+    int index = (window->start + i) % window->max_size;
+    int value = window->data[index];
+    printf("[DEBUG]   i:%d index: %d value:%d max_size:%d length:%d start:%d end:%d\n", i, index, value, window->max_size, window->length, window->start, window->end);
+    rb_ary_store(retval, i, RB_INT2NUM(value));
+  }
+
+  return retval;
+}
+
+VALUE semian_simple_sliding_window_last(VALUE self) {
+  printf("[DEBUG] semian_simple_sliding_window_last\n");
+
+  semian_simple_sliding_window_t *res;
+  TypedData_Get_Struct(self, semian_simple_sliding_window_t, &semian_simple_sliding_window_type, res);
+  semian_simple_sliding_window_shared_t *window = get_window(res->key);
+
+  int index = (window->start + window->length - 1) % window->max_size;
+  printf("[DEBUG]   index:%d last:%d\n", index, window->data[index]);
+
+  return RB_INT2NUM(window->data[index]);
+}
+
+VALUE semian_simple_sliding_window_clear(VALUE self) {
+  printf("[DEBUG] semian_simple_sliding_window_clear\n");
+
+  semian_simple_sliding_window_t *res;
+  TypedData_Get_Struct(self, semian_simple_sliding_window_t, &semian_simple_sliding_window_type, res);
+  semian_simple_sliding_window_shared_t *window = get_window(res->key);
+
+  window->length = 0;
+  window->start = 0;
+  window->end = 0;
+
+  return self;
+}
+
+VALUE semian_simple_sliding_window_reject(VALUE self) {
+  printf("[DEBUG] semian_simple_sliding_window_reject\n");
+
+  rb_need_block();
+
+  semian_simple_sliding_window_t *res;
+  TypedData_Get_Struct(self, semian_simple_sliding_window_t, &semian_simple_sliding_window_type, res);
+  semian_simple_sliding_window_shared_t *window = get_window(res->key);
+
+  // Store these values because we're going to be modifying the buffer.
+  int start = window->start;
+  int length = window->length;
+
+  int cleared = 0;
+  for (int i = 0; i < length; ++i) {
+    int index = (start + i) % length;
+    int value = window->data[index];
+    printf("[DEBUG]   i:%d index: %d value:%d max_size:%d length:%d start:%d end:%d\n", i, index, value, window->max_size, window->length, window->start, window->end);
+    VALUE y = rb_yield(RB_INT2NUM(value));
+    if (RTEST(y)) {
+      if (cleared++ != i) {
+        rb_raise(rb_eArgError, "reject! must delete monotonically");
+      }
+      window->start = (window->start + 1) % window->length;
+      window->length--;
+      printf("[DEBUG]   Removed index:%d (val:%d)\n", i, value);
+    }
+  }
+
+  return self;
+}
+
+VALUE semian_simple_sliding_window_push(VALUE self, VALUE value) {
+  printf("[DEBUG] semian_simple_sliding_window_push\n");
+
+  semian_simple_sliding_window_t *res;
+  TypedData_Get_Struct(self, semian_simple_sliding_window_t, &semian_simple_sliding_window_type, res);
+
+  semian_simple_sliding_window_shared_t *window = get_window(res->key);
+  if (window->length == window->max_size) {
+    window->length--;
+    window->start = (window->start + 1) % window->max_size;
+  }
+
+  const int index = window->end;
+  window->length++;
+  window->data[index] = RB_NUM2INT(value);
+  window->end = (window->end + 1) % window->max_size;
+
+  printf("[DEBUG]   Pushed val:%d index:%d max_size:%d length:%d start:%d end:%d\n", RB_NUM2INT(value), index, window->max_size, window->length, window->start, window->end);
+
+  return self;
 }

--- a/ext/semian/sliding_window.h
+++ b/ext/semian/sliding_window.h
@@ -1,8 +1,19 @@
 #ifndef EXT_SEMIAN_SLIDING_WINDOW_H
 #define EXT_SEMIAN_SLIDING_WINDOW_H
 
+#include <ruby.h>
 #include "types.h"
 
 void Init_SlidingWindow();
+
+VALUE semian_simple_sliding_window_alloc(VALUE klass);
+VALUE semian_simple_sliding_window_initialize(VALUE self, VALUE name, VALUE max_size);
+VALUE semian_simple_sliding_window_size(VALUE self);
+VALUE semian_simple_sliding_window_max_size(VALUE self);
+VALUE semian_simple_sliding_window_push(VALUE self, VALUE value);
+VALUE semian_simple_sliding_window_values(VALUE self);
+VALUE semian_simple_sliding_window_last(VALUE self);
+VALUE semian_simple_sliding_window_clear(VALUE self);
+VALUE semian_simple_sliding_window_reject(VALUE self);
 
 #endif // EXT_SEMIAN_SLIDING_WINDOW_H

--- a/ext/semian/sliding_window.h
+++ b/ext/semian/sliding_window.h
@@ -1,0 +1,8 @@
+#ifndef EXT_SEMIAN_SLIDING_WINDOW_H
+#define EXT_SEMIAN_SLIDING_WINDOW_H
+
+#include "types.h"
+
+void Init_SlidingWindow();
+
+#endif // EXT_SEMIAN_SLIDING_WINDOW_H

--- a/ext/semian/sysv_semaphores.c
+++ b/ext/semian/sysv_semaphores.c
@@ -1,8 +1,7 @@
 #include "sysv_semaphores.h"
-#include <time.h>
 
-static key_t
-generate_key(const char *name);
+#include <time.h>
+#include "util.h"
 
 static void *
 acquire_semaphore(void *p);
@@ -30,7 +29,6 @@ raise_semian_syscall_error(const char *syscall, int error_num)
 void
 initialize_semaphore_set(semian_resource_t* res, const char* id_str, long permissions, int tickets, double quota)
 {
-
   res->key = generate_key(id_str);
   res->strkey = (char*)  malloc((2 /*for 0x*/+ sizeof(uint64_t) /*actual key*/+ 1 /*null*/) * sizeof(char));
   sprintf(res->strkey, "0x%08x", (unsigned int) res->key);
@@ -52,6 +50,10 @@ initialize_semaphore_set(semian_resource_t* res, const char* id_str, long permis
       res->sem_id = wait_for_new_semaphore_set(res->key, permissions);
     }
   }
+
+# if DEBUG
+    printf("[DEBUG] Init semaphore '%s' (key %s) to sem_id %d\n", res->name, res->strkey, res->sem_id);
+# endif
 
   set_semaphore_permissions(res->sem_id, permissions);
 
@@ -177,31 +179,6 @@ acquire_semaphore(void *p)
   }
   return NULL;
 }
-
-static key_t
-generate_key(const char *name)
-{
-  char semset_size_key[20];
-  char *uniq_id_str;
-
-  // It is necessary for the cardinatily of the semaphore set to be part of the key
-  // or else sem_get will complain that we have requested an incorrect number of sems
-  // for the desired key, and have changed the number of semaphores for a given key
-  sprintf(semset_size_key, "_NUM_SEMS_%d", SI_NUM_SEMAPHORES);
-  uniq_id_str = malloc(strlen(name)+strlen(semset_size_key)+1);
-  strcpy(uniq_id_str, name);
-  strcat(uniq_id_str, semset_size_key);
-
-  union {
-    unsigned char str[SHA_DIGEST_LENGTH];
-    key_t key;
-  } digest;
-  SHA1((const unsigned char *) uniq_id_str, strlen(uniq_id_str), digest.str);
-  free(uniq_id_str);
-  /* TODO: compile-time assertion that sizeof(key_t) > SHA_DIGEST_LENGTH */
-  return digest.key;
-}
-
 
 static void
 initialize_new_semaphore_values(int sem_id, long permissions)

--- a/ext/semian/sysv_semaphores.h
+++ b/ext/semian/sysv_semaphores.h
@@ -11,7 +11,6 @@ and functions associated directly weth semops.
 #include <stdio.h>
 #include <string.h>
 
-#include <openssl/sha.h>
 #include <ruby.h>
 #include <ruby/util.h>
 #include <ruby/io.h>
@@ -110,11 +109,12 @@ acquire_semaphore_without_gvl(void *p);
 static inline void
 print_sem_vals(int sem_id)
 {
-  printf("lock %d, tickets: %d configured: %d, registered workers %d\n",
-   get_sem_val(sem_id, SI_SEM_LOCK),
-   get_sem_val(sem_id, SI_SEM_TICKETS),
-   get_sem_val(sem_id, SI_SEM_CONFIGURED_TICKETS),
-   get_sem_val(sem_id, SI_SEM_REGISTERED_WORKERS)
+  printf("[DEBUG] sem_id: %d, lock: %d, tickets: %d configured: %d, registered workers %d\n",
+    sem_id,
+    get_sem_val(sem_id, SI_SEM_LOCK),
+    get_sem_val(sem_id, SI_SEM_TICKETS),
+    get_sem_val(sem_id, SI_SEM_CONFIGURED_TICKETS),
+    get_sem_val(sem_id, SI_SEM_REGISTERED_WORKERS)
   );
 }
 #endif

--- a/ext/semian/types.h
+++ b/ext/semian/types.h
@@ -38,4 +38,23 @@ typedef struct {
   long wait_time;
 } semian_resource_t;
 
+// Internal circuit breaker structure
+typedef struct {
+  int sem_id;
+  uint64_t key;
+  char *strkey;
+  char *name;
+} semian_circuit_breaker_t;
+
+// Shared circuit breaker structure
+typedef struct {
+  int successes;
+} semian_circuit_breaker_shared_t;
+
+// Internal simple integer structure
+typedef struct {
+  uint64_t key;
+  int val;
+} semian_simple_integer_t;
+
 #endif // SEMIAN_TYPES_H

--- a/ext/semian/types.h
+++ b/ext/semian/types.h
@@ -10,6 +10,8 @@ For custom type definitions specific to semian
 #include <sys/sem.h>
 #include <sys/time.h>
 
+#define SLIDING_WINDOW_MAX_SIZE 4096
+
 // For sysV semop syscals
 // see man semop
 union semun {
@@ -54,7 +56,20 @@ typedef struct {
 // Internal simple integer structure
 typedef struct {
   uint64_t key;
-  int val;
 } semian_simple_integer_t;
+
+// Shared simple sliding window structure
+typedef struct {
+  int max_size;
+  int length;
+  int start;
+  int end;
+  int data[SLIDING_WINDOW_MAX_SIZE];
+} semian_simple_sliding_window_shared_t;
+
+// Internal simple sliding window structure
+typedef struct {
+  uint64_t key;
+} semian_simple_sliding_window_t;
 
 #endif // SEMIAN_TYPES_H

--- a/ext/semian/util.c
+++ b/ext/semian/util.c
@@ -1,0 +1,41 @@
+#include "util.h"
+
+const char* check_id_arg(VALUE id)
+{
+  if (TYPE(id) != T_SYMBOL && TYPE(id) != T_STRING) {
+    rb_raise(rb_eTypeError, "id must be a symbol or string");
+  }
+
+  const char *c_id_str = NULL;
+  if (TYPE(id) == T_SYMBOL) {
+    c_id_str = rb_id2name(rb_to_id(id));
+  } else if (TYPE(id) == T_STRING) {
+    c_id_str = RSTRING_PTR(id);
+  }
+
+  return c_id_str;
+}
+
+key_t generate_key(const char *name)
+{
+  char semset_size_key[128];
+  char *uniq_id_str;
+
+  // It is necessary for the cardinatily of the semaphore set to be part of the key
+  // or else sem_get will complain that we have requested an incorrect number of sems
+  // for the desired key, and have changed the number of semaphores for a given key
+  const int NUM_SEMAPHORES = 4;
+  sprintf(semset_size_key, "_NUM_SEMS_%d", NUM_SEMAPHORES);
+  uniq_id_str = malloc(strlen(name) + strlen(semset_size_key) + 1);
+  strcpy(uniq_id_str, name);
+  strcat(uniq_id_str, semset_size_key);
+
+  union {
+    unsigned char str[SHA_DIGEST_LENGTH];
+    key_t key;
+  } digest;
+  SHA1((const unsigned char *) uniq_id_str, strlen(uniq_id_str), digest.str);
+  free(uniq_id_str);
+  /* TODO: compile-time assertion that sizeof(key_t) > SHA_DIGEST_LENGTH */
+  return digest.key;
+}

--- a/ext/semian/util.c
+++ b/ext/semian/util.c
@@ -39,3 +39,14 @@ key_t generate_key(const char *name)
   /* TODO: compile-time assertion that sizeof(key_t) > SHA_DIGEST_LENGTH */
   return digest.key;
 }
+
+const char* to_s(VALUE obj) {
+  if (RB_TYPE_P(obj, T_STRING)) {
+    return RSTRING_PTR(obj);
+  } else if (RB_TYPE_P(obj, T_SYMBOL)) {
+    return rb_id2name(SYM2ID(obj));
+  }
+
+  rb_raise(rb_eArgError, "could not convert object to string");
+  return NULL;
+}

--- a/ext/semian/util.h
+++ b/ext/semian/util.h
@@ -8,4 +8,6 @@ const char* check_id_arg(VALUE id);
 
 key_t generate_key(const char *name);
 
+const char* to_s(VALUE obj);
+
 #endif // EXT_SEMIAN_UTIL_H

--- a/ext/semian/util.h
+++ b/ext/semian/util.h
@@ -1,0 +1,11 @@
+#ifndef EXT_SEMIAN_UTIL_H
+#define EXT_SEMIAN_UTIL_H
+
+#include <openssl/sha.h>
+#include <ruby.h>
+
+const char* check_id_arg(VALUE id);
+
+key_t generate_key(const char *name);
+
+#endif // EXT_SEMIAN_UTIL_H

--- a/lib/semian/circuit_breaker.rb
+++ b/lib/semian/circuit_breaker.rb
@@ -128,7 +128,7 @@ module Semian
     def log_state_transition(new_state)
       return if @state.nil? || new_state == @state.value
 
-      str = "[#{self.class.name}] State transition from #{@state.value} to #{new_state}."
+      str = "[#{self.class.name}] State transition from #{@state} to #{new_state}."
       str << " success_count=#{@successes.value} error_count=#{@errors.size}"
       str << " success_count_threshold=#{@success_count_threshold} error_count_threshold=#{@error_count_threshold}"
       str << " error_timeout=#{@error_timeout} error_last_at=\"#{@errors.last}\""

--- a/lib/semian/circuit_breaker.rb
+++ b/lib/semian/circuit_breaker.rb
@@ -16,13 +16,15 @@ module Semian
       @exceptions = exceptions
       @half_open_resource_timeout = half_open_resource_timeout
 
-      @errors = implementation::SlidingWindow.new(max_size: @error_count_threshold)
+      @errors = implementation::SlidingWindow.new("#{name}_window", max_size: @error_count_threshold)
       @successes = implementation::Integer.new("#{name}_successes")
       state_val = implementation::Integer.new("#{name}_state")
       @state = implementation::State.new(state_val)
     end
 
     def acquire(resource = nil, &block)
+      puts "[DEBUG] #{Time.now} - Acquiring resource '#{resource}'"
+
       return yield if disabled?
       transition_to_half_open if transition_to_half_open?
 
@@ -111,6 +113,7 @@ module Semian
     end
 
     def error_timeout_expired?
+      puts "[DEBUG] Checking error_timeout_expired? #{@errors.last}"
       last_error_time = @errors.last
       return false unless last_error_time
       Time.at(last_error_time) + @error_timeout < Time.now
@@ -121,6 +124,7 @@ module Semian
     end
 
     def push_time(window, time: Time.now)
+      puts "[DEBUG] push_time(#{time.to_i}) - rejecting before #{time.to_i - @error_timeout}"
       window.reject! { |err_time| err_time + @error_timeout < time.to_i }
       window << time.to_i
     end

--- a/lib/semian/circuit_breaker.rb
+++ b/lib/semian/circuit_breaker.rb
@@ -17,8 +17,9 @@ module Semian
       @half_open_resource_timeout = half_open_resource_timeout
 
       @errors = implementation::SlidingWindow.new(max_size: @error_count_threshold)
-      @successes = implementation::Integer.new(name)
-      @state = implementation::State.new
+      @successes = implementation::Integer.new("#{name}_successes")
+      state_val = implementation::Integer.new("#{name}_state")
+      @state = implementation::State.new(state_val)
     end
 
     def acquire(resource = nil, &block)

--- a/lib/semian/circuit_breaker.rb
+++ b/lib/semian/circuit_breaker.rb
@@ -8,6 +8,8 @@ module Semian
 
     def initialize(name, exceptions:, success_threshold:, error_threshold:, error_timeout:, implementation:, half_open_resource_timeout: nil)
       @name = name.to_sym
+      initialize_circuit_breaker(@name)
+
       @success_count_threshold = success_threshold
       @error_count_threshold = error_threshold
       @error_timeout = error_timeout
@@ -15,7 +17,7 @@ module Semian
       @half_open_resource_timeout = half_open_resource_timeout
 
       @errors = implementation::SlidingWindow.new(max_size: @error_count_threshold)
-      @successes = implementation::Integer.new
+      @successes = implementation::Integer.new(name)
       @state = implementation::State.new
     end
 
@@ -59,7 +61,7 @@ module Semian
 
     def mark_success
       return unless half_open?
-      @successes.increment
+      @successes.increment(1)
       transition_to_close if success_threshold_reached?
     end
 

--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -28,6 +28,10 @@ module Semian
       /MySQL client is not connected/i,
     )
 
+    TIMEOUT_ERROR = Regexp.union(
+      /Timeout waiting for a response/i,
+    )
+
     ResourceBusyError = ::Mysql2::ResourceBusyError
     CircuitOpenError = ::Mysql2::CircuitOpenError
     PingFailure = Class.new(::Mysql2::Error)
@@ -118,7 +122,7 @@ module Semian
     def acquire_semian_resource(*)
       super
     rescue ::Mysql2::Error => error
-      if error.message =~ CONNECTION_ERROR || error.is_a?(PingFailure)
+      if error.message =~ CONNECTION_ERROR || error.message =~ TIMEOUT_ERROR || error.is_a?(PingFailure)
         semian_resource.mark_failed(error)
         error.semian_identifier = semian_identifier
       end

--- a/lib/semian/redis.rb
+++ b/lib/semian/redis.rb
@@ -85,7 +85,7 @@ module Semian
         begin
           raw_connect
         rescue SocketError, RuntimeError => e
-          raise ResolveError.new(semian_identifier) if (e.cause || e).to_s =~ /(can't resolve)|(name or service not known)/i
+          raise ResolveError.new(semian_identifier) if (e.cause || e).to_s =~ /(can't resolve)|(name or service not known)|(nodename nor servname provided, or not known)/i
           raise
         end
       end

--- a/lib/semian/simple_integer.rb
+++ b/lib/semian/simple_integer.rb
@@ -5,11 +5,13 @@ module Semian
     class Integer #:nodoc:
       attr_accessor :value
 
-      def initialize
+      def initialize(name)
+        @name = name
+        initialize_simple_integer if respond_to?(:initialize_simple_integer)
         reset
       end
 
-      def increment(val = 1)
+      def increment(val)
         @value += val
       end
 

--- a/lib/semian/simple_sliding_window.rb
+++ b/lib/semian/simple_sliding_window.rb
@@ -3,18 +3,30 @@ require 'thread'
 module Semian
   module Simple
     class SlidingWindow #:nodoc:
-      extend Forwardable
-
-      def_delegators :@window, :size, :last
-      attr_reader :max_size
-
       # A sliding window is a structure that stores the most @max_size recent timestamps
       # like this: if @max_size = 4, current time is 10, @window =[5,7,9,10].
       # Another push of (11) at 11 sec would make @window [7,9,10,11], shifting off 5.
 
-      def initialize(max_size:)
+      def initialize(name, max_size:)
+        initialize_sliding_window(name, max_size)
         @max_size = max_size
         @window = []
+      end
+
+      def size
+        @window.size
+      end
+
+      def max_size
+        @max_size
+      end
+
+      def last
+        @window.last
+      end
+
+      def values
+        @window
       end
 
       def reject!(&block)

--- a/lib/semian/simple_state.rb
+++ b/lib/semian/simple_state.rb
@@ -1,34 +1,43 @@
 module Semian
   module Simple
     class State #:nodoc:
-      def initialize
+      extend Forwardable
+
+      def_delegators :@value, :value
+
+      # State constants. Looks like a flag, but is actually an enum.
+      UNKNOWN   = 0x0
+      OPEN      = 0x1
+      CLOSED    = 0x2
+      HALF_OPEN = 0x4
+
+      def initialize(value)
+        @value = value
         reset
       end
 
-      attr_reader :value
-
       def open?
-        value == :open
+        @value.value == OPEN
       end
 
       def closed?
-        value == :closed
+        @value.value == CLOSED
       end
 
       def half_open?
-        value == :half_open
+        @value.value == HALF_OPEN
       end
 
       def open!
-        @value = :open
+        @value.value = OPEN
       end
 
       def close!
-        @value = :closed
+        @value.value = CLOSED
       end
 
       def half_open!
-        @value = :half_open
+        @value.value = HALF_OPEN
       end
 
       def reset

--- a/lib/semian/simple_state.rb
+++ b/lib/semian/simple_state.rb
@@ -7,8 +7,8 @@ module Semian
 
       # State constants. Looks like a flag, but is actually an enum.
       UNKNOWN   = 0x0
-      OPEN      = 0x1
-      CLOSED    = 0x2
+      CLOSED    = 0x1
+      OPEN      = 0x2
       HALF_OPEN = 0x4
 
       def initialize(value)
@@ -46,6 +46,21 @@ module Semian
 
       def destroy
         reset
+      end
+
+      def to_s
+        case @value.value
+        when UNKNOWN
+          "unknown"
+        when CLOSED
+          "closed"
+        when OPEN
+          "open"
+        when HALF_OPEN
+          "half_open"
+        else
+          "<undefined>"
+        end
       end
     end
   end

--- a/test/adapter_test.rb
+++ b/test/adapter_test.rb
@@ -23,7 +23,7 @@ class TestSemianAdapter < Minitest::Test
   def test_unregister
     client = Semian::AdapterTestClient.new(quota: 0.5)
     assert_nil(Semian.resources[:testing])
-    resource = Semian.register(:testing, tickets: 2, error_threshold: 0, error_timeout: 0, success_threshold: 0)
+    resource = Semian.register(:testing, tickets: 2, error_threshold: 1, error_timeout: 0, success_threshold: 0)
     assert_equal(Semian.resources[:testing], resource)
 
     assert_equal 1, resource.registered_workers

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -11,6 +11,8 @@ class TestCircuitBreaker < Minitest::Test
     rescue
       nil
     end
+
+    puts "[DEBUG] Registering semian :testing at #{Time.now} (#{Time.now.to_i})"
     Semian.register(:testing, tickets: 1, exceptions: [SomeError], error_threshold: 2, error_timeout: 5, success_threshold: 1)
     @resource = Semian[:testing]
   end
@@ -40,8 +42,14 @@ class TestCircuitBreaker < Minitest::Test
   end
 
   def test_until_success_threshold_is_reached_a_single_error_will_reopen_the_circuit
+    puts @strio.string
+    puts "[DEBUG] Half open circuit..."
     half_open_cicuit!
+    puts @strio.string
+    puts "[DEBUG] Trigger error..."
     trigger_error!
+    puts @strio.string
+    puts "[DEBUG] Assert circuit opened..."
     assert_circuit_opened
     assert_match(/State transition from open to half_open/, @strio.string)
   end

--- a/test/redis_test.rb
+++ b/test/redis_test.rb
@@ -272,7 +272,9 @@ class TestRedis < Minitest::Test
       client.get('foo')
     end
 
+    puts "[DEBUG] #1 Time.now = #{Time.now}"
     Timecop.travel(ERROR_TIMEOUT + 1) do
+      puts "[DEBUG] #2 Time.now = #{Time.now}"
       assert_equal '2', client.get('foo')
     end
   end

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -1,5 +1,7 @@
 require 'test_helper'
 
+require 'objspace'
+
 class TestResource < Minitest::Test
   include ResourceHelper
   def setup
@@ -484,6 +486,11 @@ class TestResource < Minitest::Test
 
     assert_equal 5, create_resource(:testing, tickets: 0).count
     assert_equal 0, timeouts
+  end
+
+  def test_memsize
+    r = create_resource :testing, tickets: 1
+    puts "mkipper: Resource size is #{ObjectSpace.memsize_of(r)} byte(s)"
   end
 
   def create_resource(*args)

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -54,7 +54,7 @@ class TestResource < Minitest::Test
 
   def test_unregister_past_0
     workers = 10
-    resource = Semian.register(:testing, tickets: workers * 2, error_threshold: 0, error_timeout: 0, success_threshold: 0)
+    resource = Semian.register(:testing, tickets: workers * 2, error_threshold: 1, error_timeout: 0, success_threshold: 0)
 
     fork_workers(count: workers, tickets: 0, timeout: 0.5, wait_for_timeout: true) do
       Semian.unregister(:testing)
@@ -69,7 +69,7 @@ class TestResource < Minitest::Test
 
   def test_reset_registered_workers
     workers = 10
-    resource = Semian.register(:testing, tickets: 1, error_threshold: 0, error_timeout: 0, success_threshold: 0)
+    resource = Semian.register(:testing, tickets: 1, error_threshold: 1, error_timeout: 0, success_threshold: 0)
 
     fork_workers(count: workers - 1, tickets: 0, timeout: 0.5, wait_for_timeout: true)
 

--- a/test/simple_integer_test.rb
+++ b/test/simple_integer_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class TestSimpleInteger < Minitest::Test
   def setup
-    @integer = ::Semian::ThreadSafe::Integer.new
+    @integer = ::Semian::ThreadSafe::Integer.new(:simple_integer)
   end
 
   def teardown
@@ -26,7 +26,7 @@ class TestSimpleInteger < Minitest::Test
     def test_increment
       @integer.increment(4)
       assert_equal(4, @integer.value)
-      @integer.increment
+      @integer.increment(1)
       assert_equal(5, @integer.value)
       @integer.increment(-2)
       assert_equal(3, @integer.value)

--- a/test/simple_sliding_window_test.rb
+++ b/test/simple_sliding_window_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class TestSimpleSlidingWindow < Minitest::Test
   def setup
-    @sliding_window = ::Semian::ThreadSafe::SlidingWindow.new(max_size: 6)
+    @sliding_window = ::Semian::ThreadSafe::SlidingWindow.new(:sliding_window_test, max_size: 6)
     @sliding_window.clear
   end
 
@@ -24,6 +24,24 @@ class TestSimpleSlidingWindow < Minitest::Test
     assert_sliding_window(@sliding_window, [2, 3, 4, 5, 6, 7], 6)
   end
 
+  def test_sliding_window_reject
+    @sliding_window << 0 << 1 << 2 << 3 << 4 << 5 << 6 << 7;
+    assert_equal(6, @sliding_window.size)
+    assert_sliding_window(@sliding_window, [2, 3, 4, 5, 6, 7], 6)
+    @sliding_window.reject! { |val| val <= 3 }
+    assert_sliding_window(@sliding_window, [4, 5, 6, 7], 6)
+  end
+
+  def test_sliding_window_reject_failure
+    @sliding_window << 0 << 1 << 2 << 3 << 4 << 5 << 6 << 7;
+    assert_equal(6, @sliding_window.size)
+    assert_sliding_window(@sliding_window, [2, 3, 4, 5, 6, 7], 6)
+    assert_raises ArgumentError do
+      # This deletes from the middle of the array
+      @sliding_window.reject! { |val| val == 3 }
+    end
+  end
+
   def resize_to_less_than_1_raises
     assert_raises ArgumentError do
       @sliding_window.resize_to 0
@@ -33,9 +51,7 @@ class TestSimpleSlidingWindow < Minitest::Test
   private
 
   def assert_sliding_window(sliding_window, array, max_size)
-    # Get private member, the sliding_window doesn't expose the entire array
-    data = sliding_window.instance_variable_get("@window")
-    assert_equal(array, data)
+    assert_equal(array, sliding_window.values)
     assert_equal(max_size, sliding_window.max_size)
   end
 end

--- a/test/simple_state_test.rb
+++ b/test/simple_state_test.rb
@@ -2,7 +2,8 @@ require 'test_helper'
 
 class TestSimpleEnum < Minitest::Test
   def setup
-    @state = ::Semian::ThreadSafe::State.new
+    state_val = ::Semian::ThreadSafe::Integer.new(:test_simple_enum)
+    @state = ::Semian::ThreadSafe::State.new(state_val)
   end
 
   def teardown
@@ -17,25 +18,25 @@ class TestSimpleEnum < Minitest::Test
     def test_open
       @state.open!
       assert @state.open?
-      assert_equal @state.value, :open
+      assert_equal ::Semian::Simple::State::OPEN, @state.value
     end
 
     def test_close
       @state.close!
       assert @state.closed?
-      assert_equal @state.value, :closed
+      assert_equal ::Semian::Simple::State::CLOSED, @state.value
     end
 
     def test_half_open
       @state.half_open!
       assert @state.half_open?
-      assert_equal @state.value, :half_open
+      assert_equal ::Semian::Simple::State::HALF_OPEN, @state.value
     end
 
     def test_reset
       @state.reset
       assert @state.closed?
-      assert_equal @state.value, :closed
+      assert_equal ::Semian::Simple::State::CLOSED, @state.value
     end
   end
 


### PR DESCRIPTION
This PR fixes #27.

## What

Moves the implementation of circuit breakers to shared memory so circuit errors can be shared between workers on the same host.

## Why

Currently, for single-threaded workers, we need to see `error_threshold` consecutive failures in order to open a circuit. For applications where timeouts are necessarily high (e.g. 25 seconds for MySQL) that translates into up to 75 seconds of blocking behaviour when a resource is unhealthy.

If all workers on a host experience the outage simultaneously, that information can be shared and the circuit can be tripped in a single timeout iterations, increasing the speed of detecting the unhealthy resource and opening the circuit.

In addition, in the case of a variable latency outage of an upstream resource, the collective hivemind can share information about the increased latency and detect trends earlier and more reliably. This feature is not implemented yet, but becomes possible after this change.

## How

Note: This is **very much** a draft, and needs a lot of refactoring, but it's a start.

The main idea is to move the data for `Simple::Integer` and `Simple::SlidingWindow` to shared memory. The shared memory is accessed via a named key and is protected by a semaphore of the same name.

`Simple::State` simply uses the shared `Simple::Integer` as its backing store to easily share state between workers on the same host.

Feel free to take a look around, but I've still got some refactoring to do.

In particular, this implementation isn't thread-safe yet and requires some _serious_ locking.

cc: @Shopify/servcomm 
cc: @sirupsen, @csfrancis, @byroot 