### PR TITLE
'Temporary failure in name resolution' is a DNS lookup failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ before_install:
   - scripts/install_toxiproxy.sh
 
 rvm:
-  - '2.3.1'
   - '2.4'
   - '2.5'
+  - '2.6'
 
 gemfile:
   - gemfiles/mysql2-0-4-10.gemfile

--- a/lib/semian/redis.rb
+++ b/lib/semian/redis.rb
@@ -85,7 +85,7 @@ module Semian
         begin
           raw_connect
         rescue SocketError, RuntimeError => e
-          raise ResolveError.new(semian_identifier) if (e.cause || e).to_s =~ /(can't resolve)|(name or service not known)|(nodename nor servname provided, or not known)/i
+          raise ResolveError.new(semian_identifier) if dns_resolve_failure?(e.cause || e)
           raise
         end
       end
@@ -110,6 +110,10 @@ module Semian
       return unless reply.is_a?(::Redis::CommandError)
       return unless reply.message =~ /OOM command not allowed when used memory > 'maxmemory'\.\s*\z/
       raise ::Redis::OutOfMemoryError.new(reply.message)
+    end
+
+    def dns_resolve_failure?(e)
+      e.to_s.match?(/(can't resolve)|(name or service not known)|(nodename nor servname provided, or not known)|(failure in name resolution)/i)
     end
   end
 end

--- a/test/redis_test.rb
+++ b/test/redis_test.rb
@@ -193,7 +193,7 @@ class TestRedis < Minitest::Test
   ].each do |message|
     test_suffix = message.gsub(/\W/, '_').downcase
     define_method(:"test_dns_resolution_failure_#{test_suffix}") do
-      ::Socket.expects(:getaddrinfo).with('example.com', any_parameters).raises(message)
+      Redis::Client.any_instance.expects(:raw_connect).raises(message)
 
       assert_raises Redis::ResolveError do
         connect_to_redis!(host: 'example.com')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,8 @@ require 'timecop'
 require 'tempfile'
 require 'fileutils'
 require 'byebug'
+require 'mocha'
+require 'mocha/minitest'
 
 require 'helpers/background_helper'
 require 'helpers/circuit_breaker_helper'


### PR DESCRIPTION
Ran into an issue today where DNS was down, and the message that we got was "Temporary failure in name resolution" (which is EAGAIN on getaddrinfo). This wasn't opening circuits, leading to cascading failure.

cc @inf-rno @stefanmb @daniellaniyo @csfrancis @hkdsun 