### PR TITLE
Flaky test: Wait an extra 100ms to allow Semian to timeout

### DIFF
--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -2,6 +2,10 @@ require 'test_helper'
 
 class TestResource < Minitest::Test
   include ResourceHelper
+
+  # Time epsilon to account for super fast machines
+  EPSILON = 0.1
+
   def setup
     Semian.destroy(:testing)
   rescue
@@ -540,7 +544,7 @@ class TestResource < Minitest::Test
         end
       end
     end
-    sleep((count / 2.0).ceil * timeout) if wait_for_timeout # give time for threads to timeout
+    sleep((count / 2.0).ceil * timeout + EPSILON) if wait_for_timeout # give time for threads to timeout
   end
 
   def count_worker_timeouts


### PR DESCRIPTION
This test was really flaky on my local machine.
It happens when the worker gets the `TERM` signal before Semian has timed out (or acquired the resource). 

I've been watching this for a while and seen no more flakiness.
`watch -n 1 bundle exec ruby -I test --verbose test/resource_test.rb -n /test_acquire_timeout_override$/`

cc: @Shopify/servcomm 