### PR TITLE
Notify on circuit breaker state transitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 /.bundle/
 /lib/**/*.so
 /lib/**/*.bundle
-/tmp/*
+/tmp
+/pkg
 *.gem
 /html/
 Gemfile.lock
@@ -14,3 +15,6 @@ nohup.out
 .vscode-server
 .rubocop-*
 .vscode/ipch
+
+# IntelliJ/RubyMine/CLion project files
+.idea

--- a/test/grpc_test.rb
+++ b/test/grpc_test.rb
@@ -86,8 +86,9 @@ class TestGRPC < Minitest::Test
   def test_instrumentation
     notified = false
     subscriber = Semian.subscribe do |event, resource, scope, adapter|
+      next if event != :success
+
       notified = true
-      assert_equal :success, event
       assert_equal Semian[@host], resource
       assert_equal :request_response, scope
       assert_equal :grpc, adapter

--- a/test/instrumentation_test.rb
+++ b/test/instrumentation_test.rb
@@ -7,7 +7,7 @@ class TestInstrumentation < Minitest::Test
   end
 
   def test_busy_instrumentation
-    assert_notify(:success, :busy) do
+    assert_notify(:success, :busy, :state_change) do
       Semian[:testing].acquire do
         assert_raises Semian::TimeoutError do
           Semian[:testing].acquire {}
@@ -17,7 +17,7 @@ class TestInstrumentation < Minitest::Test
   end
 
   def test_circuit_open_instrumentation
-    assert_notify(:success, :busy) do
+    assert_notify(:success, :busy, :state_change) do
       Semian[:testing].acquire do
         assert_raises Semian::TimeoutError do
           Semian[:testing].acquire {}

--- a/test/mysql2_test.rb
+++ b/test/mysql2_test.rb
@@ -84,8 +84,9 @@ class TestMysql2 < Minitest::Test
   def test_connect_instrumentation
     notified = false
     subscriber = Semian.subscribe do |event, resource, scope, adapter|
+      next unless event == :success
+
       notified = true
-      assert_equal :success, event
       assert_equal Semian[:mysql_testing], resource
       assert_equal :connection, scope
       assert_equal :mysql, adapter

--- a/test/redis_test.rb
+++ b/test/redis_test.rb
@@ -115,8 +115,9 @@ class TestRedis < Minitest::Test
   def test_connect_instrumentation
     notified = false
     subscriber = Semian.subscribe do |event, resource, scope, adapter|
+      next unless event == :success
+
       notified = true
-      assert_equal :success, event
       assert_equal Semian[:redis_testing], resource
       assert_equal :connection, scope
       assert_equal :redis, adapter


### PR DESCRIPTION
Send `:state_change` notifications when circuit breaker state changes.

This is useful to monitor the current Semian state in the simulator we're building.
We monitor state as a Prometheus gauge, with `closed=0` and `open=1`.

**Note**: This further shows the weakness of the notification API as currently written. The `(event, resource, scope, adapter, payload)` signature doesn't apply universally throughout the codebase. In this case, the `resource` is actually the `CircuitBreaker` instance, not the `ProtectedResource` like the other notifications. A better API would simply be `(event, payload)` where the payload is context dependent on the event type.

cc: @Shopify/servcomm 