### PR TITLE
Use `language: minimal ` in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 dist: xenial
+language: minimal
+
+git:
+  depth: 1
 
 before_install:
   - sudo rm /usr/local/bin/docker-compose


### PR DESCRIPTION
## What
Use https://docs.travis-ci.com/user/languages/minimal-and-generic/#minimal for the builds

It speeds up CI by at least double digit seconds by skipping setting up `rbenv` and running `bundle install`. 

Since we are running everything in docker we don't need it