### PR TITLE
Fix a critical bug in MySQL2 adapter causing circuit breaker to almost never re-close

### DIFF
--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -26,9 +26,6 @@ module Semian
       /Too many connections/i,
       /closed MySQL connection/i,
       /MySQL client is not connected/i,
-    )
-
-    TIMEOUT_ERROR = Regexp.union(
       /Timeout waiting for a response/i,
     )
 
@@ -122,7 +119,7 @@ module Semian
     def acquire_semian_resource(*)
       super
     rescue ::Mysql2::Error => error
-      if error.message =~ CONNECTION_ERROR || error.message =~ TIMEOUT_ERROR || error.is_a?(PingFailure)
+      if error.is_a?(PingFailure) || (!error.is_a?(::Mysql2::SemianError) && error.message.match?(CONNECTION_ERROR))
         semian_resource.mark_failed(error)
         error.semian_identifier = semian_identifier
       end


### PR DESCRIPTION
Fix: https://github.com/Shopify/semian/issues/211

@DougEdey and @cjgu just reported two similar nasty production incidents on tow different apps.

Long story short, after a legitimate connection error caused by a SQLProxy being moved around, the app would get unusable for dozens of minutes, and a gigantic amount of `Mysql2::CircuitOpenError` would be reported.

Then I noticed a very weird thing with these exceptions:

![image](https://user-images.githubusercontent.com/19192189/64022209-fc69ad00-cb35-11e9-94c9-fbad1a24921a.png)

`Semian::OpenCircuitError` being cause by another `Semian::OpenCircuitError` makes no sense, because this means every attempt at reconnecting while the circuit is open, would push back the time at which it should close again. So if you enter such state, the only way to have the circuits close again would be to stop connections attempt for long enough.

Since this theory perfectly explained the symptoms that Doug and Carl described I dug a bit in Semian, and as supposed the bug was indeed there.

https://github.com/Shopify/semian/pull/199 introduced a new feature that append the message of the last error recorded by the circuit breaker to the `CircuitOpenError`. The problem is that since MySQL2 raise tons of different errors with the same class, the MySQL2 adapter resort to matching the error message against some regexps. So appending the original message caused the adapter to be confused. 

All versions since `0.8.4` are impacted, and since this bug is quite nasty, we should publish a new release ASAP and make sure we update all our apps.


