### PR TITLE
close block to avoid syntax errors on older versions

### DIFF
--- a/lib/semian/lru_hash.rb
+++ b/lib/semian/lru_hash.rb
@@ -150,11 +150,13 @@ class LRUHash
 
   def try_synchronize
     Thread.handle_interrupt(EXCEPTION_NEVER) do
-      return false unless @lock.try_lock
-      Thread.handle_interrupt(EXCEPTION_IMMEDIATE) { yield }
-      true
-    ensure
-      @lock.unlock if @lock.owned?
+      begin
+        return false unless @lock.try_lock
+        Thread.handle_interrupt(EXCEPTION_IMMEDIATE) { yield }
+        true
+      ensure
+        @lock.unlock if @lock.owned?
+      end
     end
   end
 end


### PR DESCRIPTION
### This PR:
- is related to https://github.com/Shopify/semian/pull/193
- attempts to fix a syntax error when Semian is loaded into older versions of Rails app.

### Background info:
- I'm working on a feature in the [Kit app](https://github.com/Shopify/kit) that requires making graphql calls and thought it would be nice if we could use [Cusco](https://github.com/Shopify/cusco). 
- Kit is running version `2.3.4` of Ruby, and can't upgrade yet as they're still on AWS.
- I added the Cusco gem to Kit, which has a dependency on Semian.
- When I fire up the Kit app with Cusco & Semian installed, the app hits a `SyntaxError` in [lru_hash.rb](https://github.com/Shopify/semian/blob/3fc9810c0f469e13a30cbbd7d3e867132f0e6977/lib/semian/lru_hash.rb#L156):
<img width="1038" alt="trace_at_startup" src="https://user-images.githubusercontent.com/42039957/65434758-571cbe80-dded-11e9-9d0d-6ca03244dc5e.png">


### The Fix:
- Locally I changed the `try_synchronize` method to what's in this PR, mainly ending the initial `Thread.handle_interrupt` block with an `end`, so that the method behaves as if there was a `begin` at the top of the method.
- @casperisfine Looking at #193 I wasn't exactly sure if the `ensure` is there to cover the entire method, or if it was meant for only the block contents, but thought i'd whip this up as a starting point!