### PR TITLE
remove call to match? method not present in < ruby 2.4

### DIFF
--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -119,7 +119,7 @@ module Semian
     def acquire_semian_resource(*)
       super
     rescue ::Mysql2::Error => error
-      if error.is_a?(PingFailure) || (!error.is_a?(::Mysql2::SemianError) && error.message.match?(CONNECTION_ERROR))
+      if error.is_a?(PingFailure) || (!error.is_a?(::Mysql2::SemianError) && error.message =~ CONNECTION_ERROR)
         semian_resource.mark_failed(error)
         error.semian_identifier = semian_identifier
       end


### PR DESCRIPTION
We're running ruby 2.3.4 and just updated to fix the issue with circuit breakers not closing but are now getting `NoMethodError` since `match?` was added in 2.4.  This will keep the fix that was added but restore compatability with 2.3.4