### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.10.0
+
+* Feature: Support half open resource timeout for redis.
+
 # v0.9.1
 
 * Fix: Compatibility with MRI 2.3

--- a/lib/semian/version.rb
+++ b/lib/semian/version.rb
@@ -1,3 +1,3 @@
 module Semian
-  VERSION = '0.9.1'
+  VERSION = '0.10.0'
 end


### PR DESCRIPTION
Includes the half open resource timeout support for Redis added by https://github.com/Shopify/semian/pull/257.
