### PR TITLE
Fix multiple definition errors

### DIFF
--- a/ext/semian/extconf.rb
+++ b/ext/semian/extconf.rb
@@ -30,4 +30,6 @@ else
   $CFLAGS << "-O3"
 end
 
+$LDFLAGS << "-Wl,--allow-multiple-definition"
+
 create_makefile('semian/semian')

--- a/ext/semian/extconf.rb
+++ b/ext/semian/extconf.rb
@@ -30,6 +30,4 @@ else
   $CFLAGS << "-O3"
 end
 
-$LDFLAGS << "-Wl,--allow-multiple-definition"
-
 create_makefile('semian/semian')

--- a/ext/semian/resource.c
+++ b/ext/semian/resource.c
@@ -27,6 +27,10 @@ ms_to_timespec(long ms, struct timespec *ts);
 static const rb_data_type_t
 semian_resource_type;
 
+ID id_wait_time;
+ID id_timeout;
+int system_max_semaphore_count;
+
 VALUE
 semian_resource_acquire(int argc, VALUE *argv, VALUE self)
 {

--- a/ext/semian/resource.h
+++ b/ext/semian/resource.h
@@ -10,9 +10,9 @@ Functions here are associated with rubyland operations.
 #include "sysv_semaphores.h"
 
 // Ruby variables
-ID id_wait_time;
-ID id_timeout;
-int system_max_semaphore_count;
+extern ID id_wait_time;
+extern ID id_timeout;
+extern int system_max_semaphore_count;
 
 /*
  * call-seq:

--- a/ext/semian/sysv_semaphores.c
+++ b/ext/semian/sysv_semaphores.c
@@ -21,6 +21,10 @@ static const char *SEMINDEX_STRING[] = {
     FOREACH_SEMINDEX(GENERATE_STRING)
 };
 
+VALUE eTimeout;
+VALUE eSyscall;
+VALUE eInternal;
+
 void
 raise_semian_syscall_error(const char *syscall, int error_num)
 {

--- a/ext/semian/sysv_semaphores.h
+++ b/ext/semian/sysv_semaphores.h
@@ -63,7 +63,7 @@ enum SEMINDEX_ENUM {
     FOREACH_SEMINDEX(GENERATE_ENUM)
 };
 
-VALUE eSyscall, eTimeout, eInternal;
+extern VALUE eSyscall, eTimeout, eInternal;
 
 // Helper for syscall verbose debugging
 void


### PR DESCRIPTION
### What

This PR addresses failed compilation with GCC 10

which was reported in https://github.com/Shopify/semian/issues/261:

```
$ make
compiling semian.c
compiling tickets.c
linking shared-object semian/semian.so
/usr/bin/ld: semian.o:(.bss+0x60): multiple definition of `eSyscall'; resource.o:(.bss+0x28): first defined here
/usr/bin/ld: semian.o:(.bss+0x58): multiple definition of `eTimeout'; resource.o:(.bss+0x20): first defined here
/usr/bin/ld: semian.o:(.bss+0x50): multiple definition of `eInternal'; resource.o:(.bss+0x18): first defined here
/usr/bin/ld: semian.o:(.bss+0x48): multiple definition of `id_wait_time'; resource.o:(.bss+0x10): first defined here
/usr/bin/ld: semian.o:(.bss+0x40): multiple definition of `id_timeout'; resource.o:(.bss+0x8): first defined here
/usr/bin/ld: semian.o:(.bss+0x38): multiple definition of `system_max_semaphore_count'; resource.o:(.bss+0x0): first defined here
/usr/bin/ld: sysv_semaphores.o:(.bss+0x10): multiple definition of `eSyscall'; resource.o:(.bss+0x28): first defined here
/usr/bin/ld: sysv_semaphores.o:(.bss+0x0): multiple definition of `eInternal'; resource.o:(.bss+0x18): first defined here
/usr/bin/ld: sysv_semaphores.o:(.bss+0x8): multiple definition of `eTimeout'; resource.o:(.bss+0x20): first defined here
/usr/bin/ld: tickets.o:(.bss+0x10): multiple definition of `eSyscall'; resource.o:(.bss+0x28): first defined here
/usr/bin/ld: tickets.o:(.bss+0x8): multiple definition of `eTimeout'; resource.o:(.bss+0x20): first defined here
/usr/bin/ld: tickets.o:(.bss+0x0): multiple definition of `eInternal'; resource.o:(.bss+0x18): first defined here
collect2: error: ld returned 1 exit status
make: *** [Makefile:261: semian.so] Error 1
```

GCC 10 now default `-fno-common`. Many linker errors are now reported.