### PR TITLE
Test ruby 2.7 and fix a thread safety issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,21 @@
 source 'https://rubygems.org'
+
+if RUBY_VERSION >= '2.7'
+  # Hack to get grpc and it's dependencies to install on Ruby 2.7
+  module BundlerHack
+    def __materialize__
+      if name == 'grpc' || name == 'google-protobuf'
+        Bundler.settings.temporary(force_ruby_platform: true) do
+          super
+        end
+      else
+        super
+      end
+    end
+  end
+  Bundler::LazySpecification.prepend(BundlerHack)
+end
+
 gemspec
 
 group :development, :test do

--- a/dockerfiles/semian-ci
+++ b/dockerfiles/semian-ci
@@ -1,4 +1,4 @@
-FROM ruby:2.6.3
+FROM ruby:2.7.0
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/gemfiles/hiredis-0-6.gemfile
+++ b/gemfiles/hiredis-0-6.gemfile
@@ -1,5 +1,21 @@
 source 'https://rubygems.org'
 
+if RUBY_VERSION >= '2.7'
+  # Hack to get grpc and it's dependencies to install on Ruby 2.7
+  module BundlerHack
+    def __materialize__
+      if name == 'grpc' || name == 'google-protobuf'
+        Bundler.settings.temporary(force_ruby_platform: true) do
+          super
+        end
+      else
+        super
+      end
+    end
+  end
+  Bundler::LazySpecification.prepend(BundlerHack)
+end
+
 gemspec path: '..'
 
 gem 'hiredis', '~> 0.6'

--- a/gemfiles/mysql2-0-4-10.gemfile
+++ b/gemfiles/mysql2-0-4-10.gemfile
@@ -1,5 +1,21 @@
 source 'https://rubygems.org'
 
+if RUBY_VERSION >= '2.7'
+  # Hack to get grpc and it's dependencies to install on Ruby 2.7
+  module BundlerHack
+    def __materialize__
+      if name == 'grpc' || name == 'google-protobuf'
+        Bundler.settings.temporary(force_ruby_platform: true) do
+          super
+        end
+      else
+        super
+      end
+    end
+  end
+  Bundler::LazySpecification.prepend(BundlerHack)
+end
+
 gemspec path: '..'
 
 gem 'mysql2', '~> 0.4.10'

--- a/gemfiles/mysql2-0-5-0.gemfile
+++ b/gemfiles/mysql2-0-5-0.gemfile
@@ -1,5 +1,21 @@
 source 'https://rubygems.org'
 
+if RUBY_VERSION >= '2.7'
+  # Hack to get grpc and it's dependencies to install on Ruby 2.7
+  module BundlerHack
+    def __materialize__
+      if name == 'grpc' || name == 'google-protobuf'
+        Bundler.settings.temporary(force_ruby_platform: true) do
+          super
+        end
+      else
+        super
+      end
+    end
+  end
+  Bundler::LazySpecification.prepend(BundlerHack)
+end
+
 gemspec path: '..'
 
 gem 'mysql2', '~> 0.5.0'

--- a/lib/semian/lru_hash.rb
+++ b/lib/semian/lru_hash.rb
@@ -5,8 +5,6 @@ class LRUHash
   # everytime we set a new resource. A default window of
   # 5 minutes will allow empty item to stay in the hash
   # for a maximum of 5 minutes
-  attr_reader :table
-
   class NoopMutex
     def synchronize(*)
       yield

--- a/lib/semian/lru_hash.rb
+++ b/lib/semian/lru_hash.rb
@@ -5,8 +5,6 @@ class LRUHash
   # everytime we set a new resource. A default window of
   # 5 minutes will allow empty item to stay in the hash
   # for a maximum of 5 minutes
-  extend Forwardable
-  def_delegators :@table, :size, :count, :empty?, :values
   attr_reader :table
 
   class NoopMutex
@@ -63,6 +61,22 @@ class LRUHash
       else
         NoopMutex.new
       end
+  end
+
+  def size
+    @lock.synchronize { @table.size }
+  end
+
+  def count(&block)
+    @lock.synchronize { @table.count(&block) }
+  end
+
+  def empty?
+    @lock.synchronize { @table.empty? }
+  end
+
+  def values
+    @lock.synchronize { @table.values }
   end
 
   def set(key, resource)


### PR DESCRIPTION
Since https://github.com/ruby/ruby/commit/36da0b3da1aed77e0dffb3f54038f01ff574972b
Ruby checks more often for interupts in various enumerable methods,
so Hash#count for instance is no longer "atomic".
    
Because of this we need to syncrhonize before calling it on @table,
otherwise if multipel threads use the LRUHash, it migth fail with:
    
`can't add a new key into hash during iteration (RuntimeError)`
    
Credits goes to Alan Wu for figuring the bug.