### PR TITLE
Error rate circuit breaker

### DIFF
--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -264,7 +264,7 @@ module Semian
 
   def create_error_rate_circuit_breaker(name, **options)
     require_keys!([:success_threshold, :error_percent_threshold, :error_timeout,
-                   :minimum_request_volume, :time_window], options)
+                   :minimum_request_volume, :time_window], **options)
 
     exceptions = options[:exceptions] || []
     ErrorRateCircuitBreaker.new(name,
@@ -289,7 +289,7 @@ module Semian
 
     return create_error_rate_circuit_breaker(name, **options) if type == :error_rate
 
-    require_keys!([:success_threshold, :error_threshold, :error_timeout], options)
+    require_keys!([:success_threshold, :error_threshold, :error_timeout], **options)
 
     exceptions = options[:exceptions] || []
     CircuitBreaker.new(

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -161,7 +161,7 @@ module Semian
   # +error_percent_threshold+: The percentage of time spent making calls that ultimately ended in error
   # that will trigger the circuit opening (error_rate circuit breaker required)
   #
-  # +request_volume_threshold+: The number of calls that must happen within the time_window before the circuit
+  # +minimum_request_volume+: The number of calls that must happen within the time_window before the circuit
   # will consider opening based on error_percent_threshold. For example, if the value is 20, then if only 19 requests
   # are received in the rolling window the circuit will not trip open even if all 19 failed.
   # Without this the circuit would open if the first request was an error (100% failure rate).
@@ -264,7 +264,7 @@ module Semian
 
   def create_error_rate_circuit_breaker(name, **options)
     require_keys!([:success_threshold, :error_percent_threshold, :error_timeout,
-                   :request_volume_threshold, :time_window], options)
+                   :minimum_request_volume, :time_window], options)
 
     exceptions = options[:exceptions] || []
     ErrorRateCircuitBreaker.new(name,
@@ -273,7 +273,7 @@ module Semian
                                 error_timeout: options[:error_timeout],
                                 exceptions: Array(exceptions) + [::Semian::BaseError],
                                 half_open_resource_timeout: options[:half_open_resource_timeout],
-                                request_volume_threshold: options[:request_volume_threshold],
+                                minimum_request_volume: options[:minimum_request_volume],
                                 time_window: options[:time_window],
                                 implementation: implementation(**options))
   end

--- a/lib/semian/error_rate_circuit_breaker.rb
+++ b/lib/semian/error_rate_circuit_breaker.rb
@@ -1,0 +1,167 @@
+module Semian
+  class ErrorRateCircuitBreaker #:nodoc:
+    extend Forwardable
+
+    def_delegators :@state, :closed?, :open?, :half_open?
+
+    attr_reader :name, :half_open_resource_timeout, :error_timeout, :state, :last_error, :error_percent_threshold,
+                :request_volume_threshold, :success_count_threshold
+
+    def initialize(name, exceptions:, error_percent_threshold:, error_timeout:, window_size:,
+                   request_volume_threshold:, success_threshold:, implementation:, half_open_resource_timeout: nil)
+
+      raise 'error_threshold_percent should be between 0.0 and 1.0 exclusive' unless (0.0001...1.0).cover?(error_percent_threshold)
+
+      @name = name.to_sym
+      @error_timeout = error_timeout
+      @exceptions = exceptions
+      @half_open_resource_timeout = half_open_resource_timeout
+      @error_percent_threshold = error_percent_threshold
+      @last_error_time = nil
+      @request_volume_threshold = request_volume_threshold
+      @success_count_threshold = success_threshold
+
+      @results = implementation::TimeSlidingWindow.new(window_size)
+      @state = implementation::State.new
+
+      reset
+    end
+
+    def acquire(resource = nil, &block)
+      return yield if disabled?
+      transition_to_half_open if transition_to_half_open?
+
+      raise OpenCircuitError unless request_allowed?
+
+      result = nil
+      begin
+        result = maybe_with_half_open_resource_timeout(resource, &block)
+      rescue *@exceptions => error
+        if !error.respond_to?(:marks_semian_circuits?) || error.marks_semian_circuits?
+          mark_failed(error)
+        end
+        raise error
+      else
+        mark_success
+      end
+      result
+    end
+
+    def transition_to_half_open?
+      open? && error_timeout_expired? && !half_open?
+    end
+
+    def request_allowed?
+      closed? || half_open? || transition_to_half_open?
+    end
+
+    def mark_failed(error)
+      push_error(error)
+      if closed?
+        transition_to_open if error_threshold_reached?
+      elsif half_open?
+        transition_to_open
+      end
+    end
+
+    def mark_success
+      @results << true
+      return unless half_open?
+      transition_to_close if success_threshold_reached?
+    end
+
+    def reset
+      @last_error_time = nil
+      @results.clear
+      transition_to_close
+    end
+
+    def destroy
+      @state.destroy
+    end
+
+    # TODO understand what this is used for inside Semian lib
+    def in_use?
+      return false if error_timeout_expired?
+      @results.count(false) > 0
+    end
+
+    private
+
+    def current_time
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
+    def transition_to_close
+      notify_state_transition(:closed)
+      log_state_transition(:closed)
+      @state.close!
+      @results.clear
+    end
+
+    def transition_to_open
+      notify_state_transition(:open)
+      log_state_transition(:open)
+      @state.open!
+    end
+
+    def transition_to_half_open
+      notify_state_transition(:half_open)
+      log_state_transition(:half_open)
+      @state.half_open!
+      @results.clear
+    end
+
+    def success_threshold_reached?
+      @results.count(true) >= @success_count_threshold
+    end
+
+    def error_threshold_reached?
+      return false if @results.empty? or @results.length < @request_volume_threshold
+      @results.count(false).to_f / @results.length.to_f >= @error_percent_threshold
+    end
+
+    def error_timeout_expired?
+      return false unless @last_error_time
+      current_time - @last_error_time >= @error_timeout
+    end
+
+    def push_error(error)
+      @last_error = error
+      @last_error_time = current_time
+      @results << false
+    end
+
+    def log_state_transition(new_state)
+      return if @state.nil? || new_state == @state.value
+
+      str = "[#{self.class.name}] State transition from #{@state.value} to #{new_state}."
+      str << " success_count=#{@results.count(true)} error_count=#{@results.count(false)}"
+      str << " success_count_threshold=#{@success_count_threshold} error_count_percent=#{@error_percent_threshold}"
+      str << " error_timeout=#{@error_timeout} error_last_at=\"#{@last_error_time}\""
+      str << " name=\"#{@name}\""
+      Semian.logger.info(str)
+    end
+
+    def notify_state_transition(new_state)
+      Semian.notify(:state_change, self, nil, nil, state: new_state)
+    end
+
+    def disabled?
+      ENV['SEMIAN_CIRCUIT_BREAKER_DISABLED'] || ENV['SEMIAN_DISABLED']
+    end
+
+    def maybe_with_half_open_resource_timeout(resource, &block)
+      result =
+          if half_open? && @half_open_resource_timeout && resource.respond_to?(:with_resource_timeout)
+            resource.with_resource_timeout(@half_open_resource_timeout) do
+              block.call
+            end
+          else
+            block.call
+          end
+
+      result
+    end
+  end
+end

--- a/lib/semian/error_rate_circuit_breaker.rb
+++ b/lib/semian/error_rate_circuit_breaker.rb
@@ -5,7 +5,7 @@ module Semian
     def_delegators :@state, :closed?, :open?, :half_open?
 
     attr_reader :name, :half_open_resource_timeout, :error_timeout, :state, :last_error, :error_percent_threshold,
-                :minimum_request_volume, :success_threshold
+                :minimum_request_volume, :success_threshold, :exceptions
 
     def_delegator :@window, :time_window_ms
 

--- a/lib/semian/error_rate_circuit_breaker.rb
+++ b/lib/semian/error_rate_circuit_breaker.rb
@@ -7,21 +7,22 @@ module Semian
     attr_reader :name, :half_open_resource_timeout, :error_timeout, :state, :last_error, :error_percent_threshold,
                 :request_volume_threshold, :success_count_threshold
 
-    def initialize(name, exceptions:, error_percent_threshold:, error_timeout:, window_size:,
-                   request_volume_threshold:, success_threshold:, implementation:, half_open_resource_timeout: nil)
+    def initialize(name, exceptions:, error_percent_threshold:, error_timeout:, time_window:,
+                   request_volume_threshold:, success_threshold:, implementation:,
+                   half_open_resource_timeout: nil, time_source: nil)
 
       raise 'error_threshold_percent should be between 0.0 and 1.0 exclusive' unless (0.0001...1.0).cover?(error_percent_threshold)
 
       @name = name.to_sym
-      @error_timeout = error_timeout
+      @error_timeout = error_timeout * 1000
       @exceptions = exceptions
       @half_open_resource_timeout = half_open_resource_timeout
       @error_percent_threshold = error_percent_threshold
       @last_error_time = nil
       @request_volume_threshold = request_volume_threshold
       @success_count_threshold = success_threshold
-
-      @window = implementation::TimeSlidingWindow.new(window_size)
+      @time_source = time_source ? time_source : -> { Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond) }
+      @window = implementation::TimeSlidingWindow.new(time_window, @time_source)
       @state = implementation::State.new
 
       reset
@@ -33,16 +34,17 @@ module Semian
 
       raise OpenCircuitError unless request_allowed?
 
+      time_start = current_time
       result = nil
       begin
         result = maybe_with_half_open_resource_timeout(resource, &block)
       rescue *@exceptions => error
         if !error.respond_to?(:marks_semian_circuits?) || error.marks_semian_circuits?
-          mark_failed(error)
+          mark_failed(error, current_time - time_start)
         end
         raise error
       else
-        mark_success
+        mark_success(current_time - time_start)
       end
       result
     end
@@ -55,8 +57,8 @@ module Semian
       closed? || half_open? || transition_to_half_open?
     end
 
-    def mark_failed(error)
-      push_error(error)
+    def mark_failed(error, time_spent)
+      push_error(error, time_spent)
       if closed?
         transition_to_open if error_threshold_reached?
       elsif half_open?
@@ -64,8 +66,8 @@ module Semian
       end
     end
 
-    def mark_success
-      @window << true
+    def mark_success(time_spent)
+      @window << [true, time_spent]
       return unless half_open?
       transition_to_close if success_threshold_reached?
     end
@@ -82,26 +84,26 @@ module Semian
 
     def in_use?
       return false if error_timeout_expired?
-      @window.count(false) > 0
+      error_count > 0
     end
 
     private
 
     def current_time
-      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      @time_source.call
     end
 
     def transition_to_close
       notify_state_transition(:closed)
       log_state_transition(:closed)
       @state.close!
-      @window.clear
     end
 
     def transition_to_open
       notify_state_transition(:open)
       log_state_transition(:open)
       @state.open!
+      @window.clear
     end
 
     def transition_to_half_open
@@ -112,12 +114,32 @@ module Semian
     end
 
     def success_threshold_reached?
-      @window.count(true) >= @success_count_threshold
+      success_count >= @success_count_threshold
     end
 
     def error_threshold_reached?
-      return false if @window.empty? or @window.length < @request_volume_threshold
-      @window.count(false).to_f / @window.length.to_f >= @error_percent_threshold
+      return false if @window.empty? || @window.length < @request_volume_threshold
+      success_time_spent, error_time_spent = calculate_time_spent
+      total_time = error_time_spent + success_time_spent
+      error_time_spent / total_time >= @error_percent_threshold
+    end
+
+    def calculate_time_spent
+      @window.each_with_object([0.0, 0.0]) do |entry, sum|
+        if entry[0] == true
+          sum[0] = entry[1] + sum[0]
+        else
+          sum[1] = entry[1] + sum[1]
+        end
+      end
+    end
+
+    def error_count
+      @window.count { |entry| entry[0] == false }.to_f
+    end
+
+    def success_count
+      @window.count { |entry| entry[0] == true }.to_f
     end
 
     def error_timeout_expired?
@@ -125,17 +147,17 @@ module Semian
       current_time - @last_error_time >= @error_timeout
     end
 
-    def push_error(error)
+    def push_error(error, time_spent)
       @last_error = error
       @last_error_time = current_time
-      @window << false
+      @window << [false, time_spent]
     end
 
     def log_state_transition(new_state)
       return if @state.nil? || new_state == @state.value
 
       str = "[#{self.class.name}] State transition from #{@state.value} to #{new_state}."
-      str << " success_count=#{@window.count(true)} error_count=#{@window.count(false)}"
+      str << " success_count=#{success_count} error_count=#{error_count}"
       str << " success_count_threshold=#{@success_count_threshold} error_count_percent=#{@error_percent_threshold}"
       str << " error_timeout=#{@error_timeout} error_last_at=\"#{@last_error_time}\""
       str << " name=\"#{@name}\""
@@ -152,13 +174,13 @@ module Semian
 
     def maybe_with_half_open_resource_timeout(resource, &block)
       result =
-          if half_open? && @half_open_resource_timeout && resource.respond_to?(:with_resource_timeout)
-            resource.with_resource_timeout(@half_open_resource_timeout) do
-              block.call
-            end
-          else
+        if half_open? && @half_open_resource_timeout && resource.respond_to?(:with_resource_timeout)
+          resource.with_resource_timeout(@half_open_resource_timeout) do
             block.call
           end
+        else
+          block.call
+        end
 
       result
     end

--- a/lib/semian/time_sliding_window.rb
+++ b/lib/semian/time_sliding_window.rb
@@ -1,0 +1,88 @@
+require 'thread'
+
+module Semian
+  module Simple
+
+    class TimeSlidingWindow #:nodoc:
+      extend Forwardable
+
+      def_delegators :@window, :size, :empty?, :length
+      attr_reader :time_window_millis
+
+      Pair = Struct.new(:head, :tail)
+
+      # A sliding window is a structure that stores the most recent entries that were pushed within the last slice of time
+      def initialize(time_window)
+        @time_window_millis = time_window * 1000
+        @window = []
+      end
+
+      def count(arg)
+        vals = @window.map { |pair| pair.tail}
+        vals.count(arg)
+      end
+
+      def push(value)
+        remove_old # make room
+        @window << Pair.new(current_time, value)
+        self
+      end
+
+      alias_method :<<, :push
+
+      def clear
+        @window.clear
+        self
+      end
+
+      def last
+        @window.last&.tail
+      end
+
+      def remove_old
+        midtime = current_time - time_window_millis
+        # special case, everything is too old
+        @window.clear if !@window.empty? and @window.last.head < midtime
+        # otherwise we find the index position where the cutoff is
+        idx = (0...@window.size).bsearch { |n| @window[n].head >= midtime }
+        @window.slice!(0, idx) if idx
+      end
+
+      alias_method :destroy, :clear
+
+      private
+
+      def current_time
+        Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond)
+      end
+    end
+  end
+
+  module ThreadSafe
+    class TimeSlidingWindow < Simple::TimeSlidingWindow
+      def initialize(*)
+        super
+        @lock = Mutex.new
+      end
+
+      # #size, #last, and #clear are not wrapped in a mutex. For the first two,
+      # the worst-case is a thread-switch at a timing where they'd receive an
+      # out-of-date value--which could happen with a mutex as well.
+      #
+      # As for clear, it's an all or nothing operation. Doesn't matter if we
+      # have the lock or not.
+
+      def count(*)
+        @lock.synchronize { super }
+      end
+
+      def remove_old
+        @lock.synchronize { super }
+      end
+
+      def push(*)
+        @lock.synchronize { super }
+      end
+    end
+  end
+end

--- a/lib/semian/time_sliding_window.rb
+++ b/lib/semian/time_sliding_window.rb
@@ -2,7 +2,6 @@ require 'thread'
 
 module Semian
   module Simple
-
     class TimeSlidingWindow #:nodoc:
       extend Forwardable
 
@@ -20,13 +19,13 @@ module Semian
 
       def count(&block)
         _remove_old
-        vals = @window.map { |pair| pair.tail}
+        vals = @window.map(&:tail)
         vals.count(&block)
       end
 
       def each_with_object(memo, &block)
         _remove_old
-        vals = @window.map { |pair| pair.tail}
+        vals = @window.map(&:tail)
         vals.each_with_object(memo, &block)
       end
 
@@ -58,7 +57,7 @@ module Semian
       def _remove_old
         midtime = current_time - time_window_millis
         # special case, everything is too old
-        @window.clear if !@window.empty? and @window.last.head < midtime
+        @window.clear if !@window.empty? && @window.last.head < midtime
         # otherwise we find the index position where the cutoff is
         idx = (0...@window.size).bsearch { |n| @window[n].head >= midtime }
         @window.slice!(0, idx) if idx

--- a/lib/semian/time_sliding_window.rb
+++ b/lib/semian/time_sliding_window.rb
@@ -73,12 +73,9 @@ module Semian
         @lock = Mutex.new
       end
 
-      # #size, #last, and #clear are not wrapped in a mutex. For the first two,
-      # the worst-case is a thread-switch at a timing where they'd receive an
+      # #size, #last are not wrapped in a mutex. The worst-case is a
+      # thread-switch at a timing where they'd receive an
       # out-of-date value--which could happen with a mutex as well.
-      #
-      # As for clear, it's an all or nothing operation. Doesn't matter if we
-      # have the lock or not.
 
       def count(*)
         @lock.synchronize { super }
@@ -89,6 +86,10 @@ module Semian
       end
 
       def push(*)
+        @lock.synchronize { super }
+      end
+
+      def clear
         @lock.synchronize { super }
       end
     end

--- a/lib/semian/time_sliding_window.rb
+++ b/lib/semian/time_sliding_window.rb
@@ -18,19 +18,19 @@ module Semian
       end
 
       def count(&block)
-        _remove_old
+        remove_old
         vals = @window.map(&:tail)
         vals.count(&block)
       end
 
       def each_with_object(memo, &block)
-        _remove_old
+        remove_old
         vals = @window.map(&:tail)
         vals.each_with_object(memo, &block)
       end
 
       def push(value)
-        _remove_old # make room
+        remove_old # make room
         @window << Pair.new(current_time, value)
         self
       end
@@ -46,18 +46,15 @@ module Semian
         @window.last&.tail
       end
 
-      def remove_old
-        _remove_old
-      end
-
       alias_method :destroy, :clear
 
       private
 
-      def _remove_old
+      def remove_old
+        return if @window.empty?
         midtime = current_time - time_window_millis
         # special case, everything is too old
-        @window.clear if !@window.empty? && @window.last.head < midtime
+        @window.clear if @window.last.head < midtime
         # otherwise we find the index position where the cutoff is
         idx = (0...@window.size).bsearch { |n| @window[n].head >= midtime }
         @window.slice!(0, idx) if idx
@@ -88,10 +85,6 @@ module Semian
       end
 
       def each_with_object(*)
-        @lock.synchronize { super }
-      end
-
-      def remove_old
         @lock.synchronize { super }
       end
 

--- a/lib/semian/time_sliding_window.rb
+++ b/lib/semian/time_sliding_window.rb
@@ -6,13 +6,13 @@ module Semian
       extend Forwardable
 
       def_delegators :@window, :size, :empty?, :length
-      attr_reader :time_window_millis
+      attr_reader :time_window_ms
 
       Pair = Struct.new(:head, :tail)
 
       # A sliding window is a structure that stores the most recent entries that were pushed within the last slice of time
       def initialize(time_window, time_source = nil)
-        @time_window_millis = time_window * 1000
+        @time_window_ms = time_window * 1000
         @time_source = time_source ? time_source : -> { Process.clock_gettime(Process::CLOCK_MONOTONIC, :float_millisecond) }
         @window = []
       end
@@ -52,7 +52,7 @@ module Semian
 
       def remove_old
         return if @window.empty?
-        midtime = current_time - time_window_millis
+        midtime = current_time - time_window_ms
         # special case, everything is too old
         @window.clear if @window.last.head < midtime
         # otherwise we find the index position where the cutoff is

--- a/test/error_rate_circuit_breaker_test.rb
+++ b/test/error_rate_circuit_breaker_test.rb
@@ -74,6 +74,9 @@ class TestErrorRateCircuitBreaker < Minitest::Test
       @resource.acquire { 1 + 1 }
     end
     assert_match(/State transition from closed to open/, @strio.string)
+    assert_match(/minimum_request_volume=2/, @strio.string)
+    assert_match(/time_window_ms=2000/, @strio.string)
+    assert_match(/error_count_percent=0\.5/, @strio.string)
   end
 
   def test_after_error_threshold_the_circuit_is_open

--- a/test/error_rate_circuit_breaker_test.rb
+++ b/test/error_rate_circuit_breaker_test.rb
@@ -20,8 +20,7 @@ class TestErrorRateCircuitBreaker < Minitest::Test
                                                       implementation: ::Semian::ThreadSafe,
                                                       success_threshold: 1,
                                                       half_open_resource_timeout: nil,
-                                                      time_source: -> { Time.now.to_f * 1000 }
-                                                      )
+                                                      time_source: -> { Time.now.to_f * 1000 })
   end
 
   def half_open_circuit(resource = @resource)
@@ -114,6 +113,7 @@ class TestErrorRateCircuitBreaker < Minitest::Test
   end
 
   def test_not_too_many_errors
+    skip 'Pending decision on if this warrants another threshold'
     resource = ::Semian::ErrorRateCircuitBreaker.new(:testing,
                                                      exceptions: [SomeError],
                                                      error_percent_threshold: 0.90,

--- a/test/error_rate_circuit_breaker_test.rb
+++ b/test/error_rate_circuit_breaker_test.rb
@@ -1,0 +1,342 @@
+require 'test_helper'
+
+class TestErrorRateCircuitBreaker < Minitest::Test
+  include CircuitBreakerHelper
+
+  def setup
+    @strio = StringIO.new
+    Semian.logger = Logger.new @strio
+    begin
+      Semian.destroy(:testing)
+    rescue
+      nil
+    end
+    @resource = ::Semian::ErrorRateCircuitBreaker.new(:testing,
+                                                      exceptions: [Exception],
+                                                      error_percent_threshold: 0.5,
+                                                      error_timeout: 1,
+                                                      window_size: 2,
+                                                      request_volume_threshold: 2,
+                                                      implementation: ::Semian::ThreadSafe,
+                                                      success_threshold: 1,
+                                                      half_open_resource_timeout: nil)
+  end
+
+  # Timecop doesn't work with MONOTONIC_CLOCK
+  def sleep_for_sec(seconds)
+    sleep(seconds)
+  end
+
+  def half_open_circuit(resource = @resource)
+    open_circuit!(resource)
+    assert_circuit_opened(resource)
+    sleep_for_sec(1.1)
+    assert resource.transition_to_half_open?, 'Expect breaker to be half-open'
+  end
+
+  def test_error_threshold_must_be_between_0_and_1
+    assert_raises RuntimeError do
+      ::Semian::ErrorRateCircuitBreaker.new(:testing,
+                                            exceptions: [Exception],
+                                            error_percent_threshold: 1.0,
+                                            error_timeout: 1,
+                                            window_size: 2,
+                                            request_volume_threshold: 2,
+                                            implementation: ::Semian::ThreadSafe,
+                                            success_threshold: 1,
+                                            half_open_resource_timeout: nil)
+    end
+
+    assert_raises RuntimeError do
+      ::Semian::ErrorRateCircuitBreaker.new(:testing,
+                                            exceptions: [Exception],
+                                            error_percent_threshold: 0.0,
+                                            error_timeout: 1,
+                                            window_size: 2,
+                                            request_volume_threshold: 2,
+                                            implementation: ::Semian::ThreadSafe,
+                                            success_threshold: 1,
+                                            half_open_resource_timeout: nil)
+    end
+  end
+
+  def test_acquire_yield_when_the_circuit_is_closed
+    block_called = false
+    @resource.acquire { block_called = true }
+    assert_equal true, block_called
+  end
+
+  def test_acquire_raises_circuit_open_error_when_the_circuit_is_open
+    open_circuit!
+    assert_raises Semian::OpenCircuitError do
+      @resource.acquire { 1 + 1 }
+    end
+    assert_match(/State transition from closed to open/, @strio.string)
+  end
+
+  def test_after_error_threshold_the_circuit_is_open
+    open_circuit!
+    assert_circuit_opened
+  end
+
+  def test_after_error_timeout_is_elapsed_requests_are_attempted_again
+    half_open_circuit
+    assert_circuit_closed
+  end
+
+  def test_until_success_threshold_is_reached_a_single_error_will_reopen_the_circuit
+    half_open_circuit
+    trigger_error!
+    assert_circuit_opened
+  end
+
+  def test_once_success_threshold_is_reached_only_error_threshold_will_open_the_circuit_again
+    half_open_circuit
+    assert_circuit_closed
+    trigger_error!
+    assert_circuit_closed
+    trigger_error!
+    assert_circuit_opened
+  end
+
+  def test_reset_allow_to_close_the_circuit_and_forget_errors
+    open_circuit!
+    @resource.reset
+    assert_match(/State transition from open to closed/, @strio.string)
+    assert_circuit_closed
+  end
+
+  def test_errors_more_than_duration_apart_doesnt_open_circuit
+    trigger_error!
+    sleep_for_sec(2) # allow time for error to slide off time window
+    trigger_error!
+    assert_circuit_closed
+  end
+
+  def test_errors_under_threshold_doesnt_open_circuit
+    # 60% success rate
+    @resource.acquire { 1 + 1}
+    @resource.acquire { 1 + 1}
+    trigger_error!
+    @resource.acquire { 1 + 1}
+    trigger_error!
+    assert_circuit_closed
+  end
+
+  def test_request_allowed_query_doesnt_trigger_transitions
+    open_circuit!
+    refute_predicate @resource, :request_allowed?
+    assert_predicate @resource, :open?
+    sleep_for_sec(1.1)
+    assert_predicate @resource, :request_allowed?
+    assert_predicate @resource, :open?
+  end
+
+  def test_open_close_open_cycle
+    resource = ::Semian::ErrorRateCircuitBreaker.new(:testing,
+                                                     exceptions: [Exception],
+                                                     error_percent_threshold: 0.5,
+                                                     error_timeout: 1,
+                                                     window_size: 2,
+                                                     request_volume_threshold: 2,
+                                                     implementation: ::Semian::ThreadSafe,
+                                                     success_threshold: 2,
+                                                     half_open_resource_timeout: nil)
+    open_circuit!(resource)
+    assert_circuit_opened(resource)
+
+    sleep_for_sec(1.1)
+
+    assert_circuit_closed(resource)
+
+    assert resource.half_open?
+    assert_circuit_closed(resource)
+
+    assert resource.closed?
+
+    open_circuit!(resource)
+    assert_circuit_opened(resource)
+
+    sleep_for_sec(1.1)
+
+
+    assert_circuit_closed(resource)
+
+    assert resource.half_open?
+    assert_circuit_closed(resource)
+
+    assert resource.closed?
+
+
+  end
+
+  def test_env_var_disables_circuit_breaker
+    ENV['SEMIAN_CIRCUIT_BREAKER_DISABLED'] = '1'
+    open_circuit!
+    assert_circuit_closed
+  ensure
+    ENV.delete('SEMIAN_CIRCUIT_BREAKER_DISABLED')
+  end
+
+  def test_semian_wide_env_var_disables_circuit_breaker
+    ENV['SEMIAN_DISABLED'] = '1'
+    open_circuit!
+    assert_circuit_closed
+  ensure
+    ENV.delete('SEMIAN_DISABLED')
+  end
+
+  class RawResource
+    def timeout
+      @timeout || 2
+    end
+
+    def with_resource_timeout(timeout)
+      prev_timeout = @timeout
+      @timeout = timeout
+      yield
+    ensure
+      @timeout = prev_timeout
+    end
+  end
+
+  def test_changes_resource_timeout_when_configured
+    resource = ::Semian::ErrorRateCircuitBreaker.new(:resource_timeout,
+                                                     exceptions: [Exception],
+                                                     error_percent_threshold: 0.5,
+                                                     error_timeout: 1,
+                                                     window_size: 2,
+                                                     request_volume_threshold: 2,
+                                                     implementation: ::Semian::ThreadSafe,
+                                                     success_threshold: 2,
+                                                     half_open_resource_timeout: 0.123)
+
+    half_open_circuit(resource)
+    assert_circuit_closed(resource)
+    assert resource.half_open?
+
+    raw_resource = RawResource.new
+
+    triggered = false
+    resource.acquire(raw_resource) do
+      triggered = true
+      assert_equal 0.123, raw_resource.timeout
+    end
+
+    assert triggered
+    assert_equal 2, raw_resource.timeout
+  end
+
+  def test_doesnt_change_resource_timeout_when_closed
+    resource = ::Semian::ErrorRateCircuitBreaker.new(:resource_timeout,
+                                                     exceptions: [Exception],
+                                                     error_percent_threshold: 0.5,
+                                                     error_timeout: 1,
+                                                     window_size: 2,
+                                                     request_volume_threshold: 2,
+                                                     implementation: ::Semian::ThreadSafe,
+                                                     success_threshold: 2,
+                                                     half_open_resource_timeout: 0.123)
+
+    raw_resource = RawResource.new
+
+    triggered = false
+    resource.acquire(raw_resource) do
+      triggered = true
+      assert_equal 2, raw_resource.timeout
+    end
+
+    assert triggered
+    assert_equal 2, raw_resource.timeout
+  end
+
+  def test_doesnt_blow_up_when_configured_half_open_timeout_but_adapter_doesnt_support
+    resource = ::Semian::ErrorRateCircuitBreaker.new(:resource_timeout,
+                                                     exceptions: [Exception],
+                                                     error_percent_threshold: 0.5,
+                                                     error_timeout: 1,
+                                                     window_size: 2,
+                                                     request_volume_threshold: 2,
+                                                     implementation: ::Semian::ThreadSafe,
+                                                     success_threshold: 2,
+                                                     half_open_resource_timeout: 0.123)
+
+    raw_resource = Object.new
+
+    triggered = false
+    resource.acquire(raw_resource) do
+      triggered = true
+    end
+
+    assert triggered
+  end
+
+  class SomeErrorThatMarksCircuits < SomeError
+    def marks_semian_circuits?
+      true
+    end
+  end
+
+  class SomeSubErrorThatDoesNotMarkCircuits < SomeErrorThatMarksCircuits
+    def marks_semian_circuits?
+      false
+    end
+  end
+
+  def test_opens_circuit_when_error_has_marks_semian_circuits_equal_to_true
+    2.times { trigger_error!(@resource, SomeErrorThatMarksCircuits) }
+    assert_circuit_opened
+  end
+
+  def test_does_not_open_circuit_when_error_has_marks_semian_circuits_equal_to_false
+    2.times { trigger_error!(@resource, SomeSubErrorThatDoesNotMarkCircuits) }
+    assert_circuit_closed
+  end
+
+  def test_notify_state_transition
+    name = :test_notify_state_transition
+
+    events = []
+    Semian.subscribe(:test_notify_state_transition) do |event, resource, _scope, _adapter, payload|
+      if event == :state_change
+        events << {name: resource.name, state: payload[:state]}
+      end
+    end
+
+    # Creating a resource should generate a :closed notification.
+    resource = ::Semian::ErrorRateCircuitBreaker.new(name,
+                                                     exceptions: [Exception],
+                                                     error_percent_threshold: 0.6666,
+                                                     error_timeout: 1,
+                                                     window_size: 2,
+                                                     request_volume_threshold: 2,
+                                                     implementation: ::Semian::ThreadSafe,
+                                                     success_threshold: 1,
+                                                     half_open_resource_timeout: 0.123)
+    assert_equal(1, events.length)
+    assert_equal(name, events[0][:name])
+    assert_equal(:closed, events[0][:state])
+
+    # Acquiring a resource doesn't generate a transition.
+    resource.acquire { nil }
+    assert_equal(1, events.length)
+
+    # error_threshold_percent failures causes a transition to open.
+    2.times { trigger_error!(resource) }
+    assert_equal(2, events.length)
+    assert_equal(name, events[1][:name])
+    assert_equal(:open, events[1][:state])
+
+    sleep_for_sec(1.1)
+
+      # Acquiring the resource successfully generates a transition to half_open, then closed.
+    resource.acquire { nil }
+    assert_equal(4, events.length)
+    assert_equal(name, events[2][:name])
+    assert_equal(:half_open, events[2][:state])
+    assert_equal(name, events[3][:name])
+    assert_equal(:closed, events[3][:state])
+  ensure
+    Semian.unsubscribe(:test_notify_state_transition)
+  end
+end

--- a/test/helpers/circuit_breaker_helper.rb
+++ b/test/helpers/circuit_breaker_helper.rb
@@ -3,8 +3,12 @@ module CircuitBreakerHelper
 
   private
 
-  def open_circuit!(resource = @resource, error_count = 2)
-    error_count.times { trigger_error!(resource) }
+  def open_circuit!(resource = @resource, error_count = 2, elapsed_time = nil)
+    if elapsed_time == nil
+      error_count.times { trigger_error!(resource) }
+    else
+      error_count.times { trigger_error_elapse_time!(resource, elapsed_time) }
+    end
   end
 
   def half_open_cicuit!(resource = @resource, backwards_time_travel = 10)
@@ -16,6 +20,29 @@ module CircuitBreakerHelper
   def trigger_error!(resource = @resource, error = SomeError)
     resource.acquire { raise error }
   rescue error
+  end
+
+  def trigger_error_elapse_time!(resource = @resource, error = SomeError, elapsed_time)
+    Timecop.travel(-1 * elapsed_time) do
+      begin
+        resource.acquire {
+          Timecop.return_to_baseline
+          raise error
+        }
+      rescue error
+      end
+    end
+  end
+
+  def assert_circuit_closed_elapse_time(resource = @resource, elapsed_time)
+    block_called = false
+    Timecop.travel(-1 * elapsed_time) do
+      resource.acquire do
+        Timecop.return_to_baseline
+        block_called = true
+      end
+    end
+    assert block_called, 'Expected the circuit to be closed, but it was open'
   end
 
   def assert_circuit_closed(resource = @resource)

--- a/test/semian_test.rb
+++ b/test/semian_test.rb
@@ -74,7 +74,7 @@ class TestSemian < Minitest::Test
         circuit_breaker_type: :error_rate,
         success_threshold: 1,
         error_percent_threshold: 0.2,
-        request_volume_threshold: 1,
+        minimum_request_volume: 1,
         time_window: 10,
         error_timeout: 5,
         circuit_breaker: true,

--- a/test/semian_test.rb
+++ b/test/semian_test.rb
@@ -68,6 +68,24 @@ class TestSemian < Minitest::Test
     assert_equal exception.message, "Must pass exactly one of ticket or quota"
   end
 
+  def test_register_with_error_rate_circuitbreaker
+    resource = Semian.register(
+        :testing_error_rate,
+        success_threshold: 1,
+        error_percent_threshold: 0.2,
+        request_volume_threshold: 1,
+        window_size: 10,
+        error_timeout: 5,
+        circuit_breaker: true,
+        bulkhead: false,
+        thread_safety_disabled: false,
+        )
+
+    assert resource, Semian[:testing_error_rate]
+    assert resource.circuit_breaker.state.instance_of?(Semian::ThreadSafe::State)
+    assert resource.circuit_breaker.instance_of?(Semian::ErrorRateCircuitBreaker)
+  end
+
   def test_unsuported_constants
     assert defined?(Semian::BaseError)
     assert defined?(Semian::SyscallError)

--- a/test/semian_test.rb
+++ b/test/semian_test.rb
@@ -71,10 +71,11 @@ class TestSemian < Minitest::Test
   def test_register_with_error_rate_circuitbreaker
     resource = Semian.register(
         :testing_error_rate,
+        circuit_breaker_type: :error_rate,
         success_threshold: 1,
         error_percent_threshold: 0.2,
         request_volume_threshold: 1,
-        window_size: 10,
+        time_window: 10,
         error_timeout: 5,
         circuit_breaker: true,
         bulkhead: false,

--- a/test/time_sliding_window_test.rb
+++ b/test/time_sliding_window_test.rb
@@ -44,8 +44,8 @@ class TestTimeSlidingWindow < Minitest::Test
 
   def test_sliding_window_count
     @sliding_window << true << false << true << false << true << true << true
-    assert_equal(5, @sliding_window.count {|e| e == true})
-    assert_equal(2, @sliding_window.count {|e| e == false})
+    assert_equal(5, @sliding_window.count { |e| e == true })
+    assert_equal(2, @sliding_window.count { |e| e == false })
   end
 
   def test_each_with_object
@@ -61,7 +61,6 @@ class TestTimeSlidingWindow < Minitest::Test
 
     assert_equal([4.0, 3.0], result)
   end
-
 
   private
 

--- a/test/time_sliding_window_test.rb
+++ b/test/time_sliding_window_test.rb
@@ -70,6 +70,6 @@ class TestTimeSlidingWindow < Minitest::Test
     # each_with_object will remove old entries first
     data = sliding_window.each_with_object([]) { |v, data| data.append(v) }
     assert_equal(array, data)
-    assert_equal(time_window_millis, sliding_window.time_window_millis)
+    assert_equal(time_window_millis, sliding_window.time_window_ms)
   end
 end

--- a/test/time_sliding_window_test.rb
+++ b/test/time_sliding_window_test.rb
@@ -1,0 +1,64 @@
+require 'test_helper'
+
+class TestTimeSlidingWindow < Minitest::Test
+  def setup
+    @sliding_window = ::Semian::ThreadSafe::TimeSlidingWindow.new(0.5) # Timecop doesn't work with a monotonic clock
+    @sliding_window.clear
+  end
+
+  def teardown
+    @sliding_window.destroy
+  end
+
+  def test_sliding_window_push
+    assert_equal(0, @sliding_window.size)
+    @sliding_window << 1
+    assert_sliding_window(@sliding_window, [1], 500)
+    @sliding_window << 5
+    assert_sliding_window(@sliding_window, [1, 5], 500)
+  end
+
+  def test_special_everything_too_old
+    @sliding_window << 0 << 1
+    sleep(0.501)
+    assert_sliding_window(@sliding_window, [], 500)
+  end
+
+
+  def test_sliding_window_edge_falloff
+    assert_equal(0, @sliding_window.size)
+    @sliding_window << 0 << 1 << 2 << 3 << 4 << 5 << 6 << 7
+    assert_sliding_window(@sliding_window, [0, 1, 2, 3, 4, 5, 6, 7], 500)
+    sleep(0.251)
+    @sliding_window << 8 << 9 << 10
+    sleep(0.251)
+    assert_sliding_window(@sliding_window, [8, 9, 10], 500)
+    @sliding_window << 11
+    sleep(0.251)
+    assert_sliding_window(@sliding_window, [11], 500)
+  end
+
+  def test_sliding_window_count
+    @sliding_window << true << false << true << false << true << true << true
+    assert_equal(5, @sliding_window.count(true))
+    assert_equal(2, @sliding_window.count(false))
+  end
+
+  def test_issue
+    @window = @sliding_window.instance_variable_get("@window")
+    @window << ::Semian::ThreadSafe::TimeSlidingWindow::Pair.new(338019700.707, true)
+    @window << ::Semian::ThreadSafe::TimeSlidingWindow::Pair.new(338019701.707, true)
+    @sliding_window << false
+    puts('break')
+  end
+
+  private
+
+  def assert_sliding_window(sliding_window, array, time_window_millis)
+    # Get private member, the sliding_window doesn't expose the entire array
+    sliding_window.remove_old
+    data = sliding_window.instance_variable_get("@window").map { |pair| pair.tail }
+    assert_equal(array, data)
+    assert_equal(time_window_millis, sliding_window.time_window_millis)
+  end
+end


### PR DESCRIPTION
This PR adds a circuit breaker that opens when the error percentage crosses some threshold (ex, 25% of calls failed in the last 10 seconds), also discussed here: https://github.com/Shopify/semian/issues/245. Ideally trying to solve for the problem mentioned in this comment: https://github.com/Shopify/semian/issues/245#issuecomment-508565807 . We have unpredictable spikes in traffic, which make tuning an absolute # of errors in a time window difficult. 

There are some methods that technically violate the DRY principle, in particular the `acquire` and `maybe_with_half_open_resource_timeout` methods on [lib/semian/error_rate_circuit_breaker.rb](lib/semian/error_rate_circuit_breaker.rb) and [lib/semian/circuit_breaker.rb](lib/semian/circuit_breaker.rb) are the same. I'm open to suggestions on if this should be fixed, and the best way to do so.

This has not been battle-tested in a high volume production environment yet, and I'm still working on documentation. Also working on using Timecop in the new unit tests.