### PR TITLE
Fix positional/keyword arguments deprecation warnings for Ruby 2.7+

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.3
+FROM ruby:2.7.1
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unrealeased
+
+* Fix: Positional/Keyword arguments deprecations warning for Ruby 2.7
+
 # v0.10.1
 
 * Fix: thread safety bug on Ruby 2.7. (#263)

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -287,7 +287,7 @@ module Semian
     Resource.new(name, tickets: options[:tickets], quota: options[:quota], permissions: permissions, timeout: timeout)
   end
 
-  def require_keys!(required = [], **options)
+  def require_keys!(required, options)
     diff = required - options.keys
     unless diff.empty?
       raise ArgumentError, "Missing required arguments for Semian: #{diff}"

--- a/lib/semian/grpc.rb
+++ b/lib/semian/grpc.rb
@@ -79,22 +79,22 @@ module Semian
       raw_semian_options.nil?
     end
 
-    def request_response(*)
+    def request_response(*, **)
       return super if disabled?
       acquire_semian_resource(adapter: :grpc, scope: :request_response) { super }
     end
 
-    def client_streamer(*)
+    def client_streamer(*, **)
       return super if disabled?
       acquire_semian_resource(adapter: :grpc, scope: :client_streamer) { super }
     end
 
-    def server_streamer(*)
+    def server_streamer(*, **)
       return super if disabled?
       acquire_semian_resource(adapter: :grpc, scope: :server_streamer) { super }
     end
 
-    def bidi_streamer(*)
+    def bidi_streamer(*, **)
       return super if disabled?
       acquire_semian_resource(adapter: :grpc, scope: :bidi_streamer) { super }
     end

--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -116,7 +116,7 @@ module Semian
       acquire_semian_resource(adapter: :mysql, scope: :connection) { raw_connect(*args) }
     end
 
-    def acquire_semian_resource(*)
+    def acquire_semian_resource(**)
       super
     rescue ::Mysql2::Error => error
       if error.is_a?(PingFailure) || (!error.is_a?(::Mysql2::SemianError) && error.message.match?(CONNECTION_ERROR))

--- a/lib/semian/resource.rb
+++ b/lib/semian/resource.rb
@@ -4,8 +4,8 @@ module Semian
 
     class << Semian::Resource
       # Ensure that there can only be one resource of a given type
-      def instance(*args)
-        Semian.resources[args.first] ||= ProtectedResource.new(args.first, new(*args), nil)
+      def instance(name, **kwargs)
+        Semian.resources[name] ||= ProtectedResource.new(name, new(name, **kwargs), nil)
       end
     end
 

--- a/lib/semian/simple_sliding_window.rb
+++ b/lib/semian/simple_sliding_window.rb
@@ -44,7 +44,7 @@ module Semian
 
   module ThreadSafe
     class SlidingWindow < Simple::SlidingWindow
-      def initialize(*)
+      def initialize(**)
         super
         @lock = Mutex.new
       end

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -117,7 +117,7 @@ class TestResource < Minitest::Test
 
   def test_register_with_neither_quota_nor_tickets_raises
     assert_raises ArgumentError do
-      create_resource :testing
+      Semian::Resource.new(:testing)
     end
   end
 
@@ -490,9 +490,9 @@ class TestResource < Minitest::Test
     assert_equal 0, timeouts
   end
 
-  def create_resource(*args)
+  def create_resource(name, **kwargs)
     @resources ||= []
-    resource = Semian::Resource.new(*args)
+    resource = Semian::Resource.new(name, **kwargs)
     @resources << resource
     resource
   end


### PR DESCRIPTION
After updating an app to Ruby 2.7, I figured I should contribute to Semian by getting rid of these Deprecation warnings.

You can see these in previous [CI Runs](https://travis-ci.org/github/Shopify/semian/jobs/669129103#L357-L366) for Semian

I avoided doing any autoformatting/linting on these files in order to ensure that I applied the minimal set of changes

In Ruby 3.0, there's a change for Positional & Keyword arguments, you can read all the background [here](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/) as it will do a much better job of explaining it than I will

~I went with the recommended solution of adding the `ruby2_keywords` gem [source](https://github.com/ruby/ruby2_keywords) and [rubygems](https://rubygems.org/gems/ruby2_keywords)~

After discussion with @casperisfine I decided to fix the warnings rather than work around them, there's some warning upstream in grpc still but that'll be an upstream PR by someone:

```
/usr/local/bundle/gems/grpc-1.28.0/src/ruby/lib/grpc/generic/service.rb:175: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/workspace/lib/semian/grpc.rb:87: warning: The called method `client_streamer' is defined here
./usr/local/bundle/gems/grpc-1.28.0/src/ruby/lib/grpc/generic/service.rb:170: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/workspace/lib/semian/grpc.rb:82: warning: The called method `request_response' is defined here
.../usr/local/bundle/gems/grpc-1.28.0/src/ruby/lib/grpc/generic/service.rb:180: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/workspace/lib/semian/grpc.rb:92: warning: The called method `server_streamer' is defined here
..../usr/local/bundle/gems/grpc-1.28.0/src/ruby/lib/grpc/generic/service.rb:185: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/workspace/lib/semian/grpc.rb:97: warning: The called method `bidi_streamer' is defined here
```

