### PR TITLE
Fix Ruby 2.7 warnings in GRPC adapter

### DIFF
--- a/lib/semian/grpc.rb
+++ b/lib/semian/grpc.rb
@@ -79,22 +79,22 @@ module Semian
       raw_semian_options.nil?
     end
 
-    def request_response(*, **)
+    def request_response(*)
       return super if disabled?
       acquire_semian_resource(adapter: :grpc, scope: :request_response) { super }
     end
 
-    def client_streamer(*, **)
+    def client_streamer(*)
       return super if disabled?
       acquire_semian_resource(adapter: :grpc, scope: :client_streamer) { super }
     end
 
-    def server_streamer(*, **)
+    def server_streamer(*)
       return super if disabled?
       acquire_semian_resource(adapter: :grpc, scope: :server_streamer) { super }
     end
 
-    def bidi_streamer(*, **)
+    def bidi_streamer(*)
       return super if disabled?
       acquire_semian_resource(adapter: :grpc, scope: :bidi_streamer) { super }
     end


### PR DESCRIPTION
They are visible in the semian test suite:

```
/usr/local/bundle/gems/grpc-1.28.0/src/ruby/lib/grpc/generic/service.rb:170: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/app/lib/semian/grpc.rb:82: warning: The called method `request_response' is defined here
/usr/local/bundle/gems/grpc-1.28.0/src/ruby/lib/grpc/generic/service.rb:185: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/app/lib/semian/grpc.rb:97: warning: The called method `bidi_streamer' is defined here
/usr/local/bundle/gems/grpc-1.28.0/src/ruby/lib/grpc/generic/service.rb:175: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/app/lib/semian/grpc.rb:87: warning: The called method `client_streamer' is defined here
/usr/local/bundle/gems/grpc-1.28.0/src/ruby/lib/grpc/generic/service.rb:180: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/app/lib/semian/grpc.rb:92: warning: The called method `server_streamer' is defined here
```

These methods pass a hash as last arguments, but they are not keyword args.

BTW, there's something very fishy on CI:

```
semian_1     | TestNetHTTP#test_5xxs_dont_raise_exceptions_unless_fatal_server_flag_enabled:
semian_1     | Net::CircuitOpenError: [nethttp_semian_31050] Semian::OpenCircuitError caused by Internal Server Error
...
semian_1     | 203 runs, 536 assertions, 0 failures, 1 errors, 0 skips
semian_1     | rake aborted!
semian_1     | Command failed with status (1)
...
semian_1     | Running rubocop
semian_1     | Running rubocop failed
semian_semian_1 exited with code 0
Aborting on container exit...
Stopping toxiproxy       ... 
Stopping semian_mysql_1  ... 
Stopping redis           ... 
The command "travis_retry docker-compose -f docker-compose.ci.yml up --force-recreate --exit-code-from semian" exited with 0.
Done. Your build exited with 0.
```

Seems like it's failing but still returning `0`. @epk seems like you introduced that docker & travis_retry. Could you take a look? Here's the build: https://travis-ci.org/github/Shopify/semian/jobs/686209899#L542