### PR TITLE
Revert "Fix Ruby 2.7 warnings in GRPC adapter"

### DIFF
--- a/lib/semian/grpc.rb
+++ b/lib/semian/grpc.rb
@@ -79,22 +79,22 @@ module Semian
       raw_semian_options.nil?
     end
 
-    def request_response(*)
+    def request_response(*, **)
       return super if disabled?
       acquire_semian_resource(adapter: :grpc, scope: :request_response) { super }
     end
 
-    def client_streamer(*)
+    def client_streamer(*, **)
       return super if disabled?
       acquire_semian_resource(adapter: :grpc, scope: :client_streamer) { super }
     end
 
-    def server_streamer(*)
+    def server_streamer(*, **)
       return super if disabled?
       acquire_semian_resource(adapter: :grpc, scope: :server_streamer) { super }
     end
 
-    def bidi_streamer(*)
+    def bidi_streamer(*, **)
       return super if disabled?
       acquire_semian_resource(adapter: :grpc, scope: :bidi_streamer) { super }
     end


### PR DESCRIPTION
Reverts Shopify/semian#269

I made a mistake, the issue wasn't actually in semian, I got confused because we have multiple layers of instrumentation on these methods.

The issue was actually in grpc and was fixed 2 weeks ago: https://github.com/grpc/grpc/commit/3e17411774d81b0371375d729b1166994854212e#diff-37292ab4014737ea90165c478a9a0e50