### PR TITLE
Fix link to 'Release It' book in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -750,7 +750,7 @@ $ cd semian
 
 
 [hystrix]: https://github.com/Netflix/Hystrix
-[release-it]: https://pragprog.com/book/mnee/release-it
+[release-it]: https://pragprog.com/titles/mnee2/release-it-second-edition/
 [shopify]: http://www.shopify.com/
 [mysql-semian-adapter]: lib/semian/mysql2.rb
 [redis-semian-adapter]: lib/semian/redis.rb


### PR DESCRIPTION
The link to the first edition is broken, so we should update it to the second edition.