### PR TITLE
Update README monitoring example

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,11 +648,11 @@ Semian internals. For example to instrument just events with
 # `scope` is `connection` or `query` (others can be instrumented too from the adapter)
 # `adapter` is the name of the adapter (mysql2, redis, ..)
 Semian.subscribe do |event, resource, scope, adapter|
-  StatsD.increment("Shopify.#{adapter}.semian.#{event}", 1, tags: [
-    "resource:#{resource.name}",
-    "total_tickets:#{resource.tickets}",
-    "type:#{scope}",
-  ])
+  StatsD.increment("semian.#{event}", 1, tags: {
+    resource: resource.name,
+    adapter: adapter,
+    type: scope,
+  })
 end
 ```
 


### PR DESCRIPTION
Closes #253 

The old example made an assumption that the resource in question is a bulkhead (referencing tickets), when in some cases the resource will only be protected by a circuit breaker. This feels like a minimal example that will give ALL the event types, with reasonable tags. This is probably too many metrics (for most uses, `circuit_open` and `busy` is probably enough...) but is better than broken?

Tested this locally and it seems to work