### PR TITLE
Fixes for GC.compact

### DIFF
--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -22,12 +22,14 @@ void Init_semian()
    * Represents a Semian error that was caused by an underlying syscall failure.
    */
   eSyscall = rb_const_get(cSemian, rb_intern("SyscallError"));
+  rb_global_variable(&eSyscall);
 
   /* Document-class: Semian::TimeoutError
    *
    * Raised when a Semian operation timed out.
    */
   eTimeout = rb_const_get(cSemian, rb_intern("TimeoutError"));
+  rb_global_variable(&eTimeout);
 
   /* Document-class: Semian::InternalError
    *
@@ -40,6 +42,7 @@ void Init_semian()
    * the semaphore in this case.
    */
   eInternal = rb_const_get(cSemian, rb_intern("InternalError"));
+  rb_global_variable(&eInternal);
 
   rb_define_alloc_func(cResource, semian_resource_alloc);
   rb_define_method(cResource, "initialize_semaphore", semian_resource_initialize, 5);

--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -1,5 +1,7 @@
 #include "semian.h"
 
+VALUE eSyscall, eTimeout, eInternal;
+
 void Init_semian()
 {
   VALUE cSemian, cResource;

--- a/ext/semian/sysv_semaphores.h
+++ b/ext/semian/sysv_semaphores.h
@@ -63,7 +63,7 @@ enum SEMINDEX_ENUM {
     FOREACH_SEMINDEX(GENERATE_ENUM)
 };
 
-VALUE eSyscall, eTimeout, eInternal;
+extern VALUE eSyscall, eTimeout, eInternal;
 
 // Helper for syscall verbose debugging
 void


### PR DESCRIPTION
Without doing this the GC could move the objects returned by
rb_const_get and make Semian's globals point to unexpected objects on
the heap.

No tests here because usually compaction bugs are hard to trigger reliably. I'm trying to trigger them in https://github.com/Shopify/semian/pull/274 though. If it goes well maybe we should include that as a best-effort regression test.