### PR TITLE
Allow MySQL queries through Semian regardless of position

### DIFF
--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -37,12 +37,9 @@ module Semian
     DEFAULT_PORT = 3306
 
     QUERY_WHITELIST = Regexp.union(
-      /\A\s*ROLLBACK/i,
-      /\A\s*COMMIT/i,
-      /\A\s*RELEASE\s+SAVEPOINT/i,
-      /ROLLBACK[\s;]*\z/i,
-      /COMMIT[\s;]*\z/i,
-      /RELEASE\s+SAVEPOINT[\s;]*\z/i,
+      /\A(?:\/\*.*?\*\/)?\s*ROLLBACK/i,
+      /\A(?:\/\*.*?\*\/)?\s*COMMIT/i,
+      /\A(?:\/\*.*?\*\/)?\s*RELEASE\s+SAVEPOINT/i,
     )
 
     # The naked methods are exposed as `raw_query` and `raw_connect` for instrumentation purpose

--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -40,6 +40,9 @@ module Semian
       /\A\s*ROLLBACK/i,
       /\A\s*COMMIT/i,
       /\A\s*RELEASE\s+SAVEPOINT/i,
+      /ROLLBACK[\s;]*\z/i,
+      /COMMIT[\s;]*\z/i,
+      /RELEASE\s+SAVEPOINT[\s;]*\z/i,
     )
 
     # The naked methods are exposed as `raw_query` and `raw_connect` for instrumentation purpose

--- a/test/mysql2_test.rb
+++ b/test/mysql2_test.rb
@@ -200,6 +200,16 @@ class TestMysql2 < Minitest::Test
     end
   end
 
+  def test_semian_allows_rollback_with_marginalia
+    client = connect_to_mysql!
+
+    client.query('START TRANSACTION;')
+
+    Semian[:mysql_testing].acquire do
+      client.query('/*foo:bar*/ ROLLBACK;')
+    end
+  end
+
   def test_semian_allows_commit
     client = connect_to_mysql!
 


### PR DESCRIPTION
The current Semian behaviour will let [certain allow-listed MySQL queries to go through](https://github.com/Shopify/semian/pull/60), even if we don't have tickets -- but the existing matches are incompatible with using the [Marginalia gem set to `prepend_comment`](https://github.com/basecamp/marginalia/blob/7bf7ec89e18cd4849cd43c24ed931d341363665c/lib/marginalia.rb#L52).

This PR adds extra regular expressions to catch this particular case. We still need to anchor on either `\A` or `\z` because otherwise we would match allow-listed words when they appeared in the body of queries.