### PR TITLE
Minor fix: Update url for docker ipc reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,7 +664,7 @@ coordinate access to a resource. The semaphore is only shared within the
 this leaves the bulkheading pattern effectively useless. We recommend sharing
 the IPC namespace between all containers on your host for the best ticket
 economy. If you are using Docker, this can be done with the [--ipc
-flag](https://docs.docker.com/engine/reference/run/#ipc-settings-ipc).
+flag](https://docs.docker.com/engine/reference/run/#ipc-settings---ipc).
 
 **Why isn't resource access shared across the entire cluster?** This implies a
 coordination data store. Semian would have to be resilient to failures of this


### PR DESCRIPTION
Really tiny fix: The old URL was not working, so update with the new.