### PR TITLE
Use global registered_workers count to calculate tickets instead of local per resource lazy loaded count

### DIFF
--- a/ext/semian/resource.c
+++ b/ext/semian/resource.c
@@ -12,6 +12,9 @@ check_quota_arg(VALUE quota);
 static int
 check_tickets_arg(VALUE tickets);
 
+static int
+check_is_global_arg(VALUE is_global);
+
 static long
 check_permissions_arg(VALUE permissions);
 
@@ -200,12 +203,13 @@ semian_resource_key(VALUE self)
 }
 
 VALUE
-semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VALUE permissions, VALUE default_timeout)
+semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VALUE permissions, VALUE default_timeout, VALUE is_global)
 {
   long c_permissions;
   double c_timeout;
   double c_quota;
   int c_tickets;
+  int c_is_global;
   semian_resource_t *res = NULL;
   const char *c_id_str = NULL;
 
@@ -213,6 +217,7 @@ semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VAL
   check_tickets_xor_quota_arg(tickets, quota);
   c_quota = check_quota_arg(quota);
   c_tickets = check_tickets_arg(tickets);
+  c_is_global = check_is_global_arg(is_global);
   c_permissions = check_permissions_arg(permissions);
   c_id_str = check_id_arg(id);
   c_timeout = check_default_timeout_arg(default_timeout);
@@ -227,7 +232,7 @@ semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VAL
   res->wait_time = -1;
 
   // Initialize the semaphore set
-  initialize_semaphore_set(res, c_id_str, c_permissions, c_tickets, c_quota);
+  initialize_semaphore_set(res, c_id_str, c_permissions, c_tickets, c_quota, c_is_global);
 
   return self;
 }
@@ -312,6 +317,12 @@ check_tickets_arg(VALUE tickets)
   }
 
   return c_tickets;
+}
+
+static int
+check_is_global_arg(VALUE is_global)
+{
+  return RTEST(is_global);
 }
 
 static const char*

--- a/ext/semian/resource.h
+++ b/ext/semian/resource.h
@@ -21,7 +21,7 @@ int system_max_semaphore_count;
  * Creates a new Resource. Do not create resources directly. Use Semian.register.
  */
 VALUE
-semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VALUE permissions, VALUE default_timeout);
+semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VALUE permissions, VALUE default_timeout, VALUE is_global);
 
 /*
  * call-seq:

--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -47,7 +47,7 @@ void Init_semian()
   rb_global_variable(&eInternal);
 
   rb_define_alloc_func(cResource, semian_resource_alloc);
-  rb_define_method(cResource, "initialize_semaphore", semian_resource_initialize, 5);
+  rb_define_method(cResource, "initialize_semaphore", semian_resource_initialize, 6);
   rb_define_method(cResource, "acquire", semian_resource_acquire, -1);
   rb_define_method(cResource, "count", semian_resource_count, 0);
   rb_define_method(cResource, "semid", semian_resource_id, 0);

--- a/ext/semian/sysv_semaphores.c
+++ b/ext/semian/sysv_semaphores.c
@@ -28,7 +28,7 @@ raise_semian_syscall_error(const char *syscall, int error_num)
 }
 
 void
-initialize_semaphore_set(semian_resource_t* res, const char* id_str, long permissions, int tickets, double quota)
+initialize_semaphore_set(semian_resource_t* res, const char* id_str, long permissions, int tickets, double quota, int is_global)
 {
 
   res->key = generate_key(id_str);
@@ -70,6 +70,7 @@ initialize_semaphore_set(semian_resource_t* res, const char* id_str, long permis
     .sem_id = res->sem_id,
     .tickets = tickets,
     .quota = quota,
+    .is_global = is_global
   };
   rb_protect(
     configure_tickets,

--- a/ext/semian/sysv_semaphores.h
+++ b/ext/semian/sysv_semaphores.h
@@ -71,7 +71,7 @@ raise_semian_syscall_error(const char *syscall, int error_num);
 
 // Initialize the sysv semaphore structure
 void
-initialize_semaphore_set(semian_resource_t* res, const char* id_str, long permissions, int tickets, double quota);
+initialize_semaphore_set(semian_resource_t* res, const char* id_str, long permissions, int tickets, double quota, int is_global);
 
 // Set semaphore UNIX octal permissions
 void

--- a/ext/semian/types.h
+++ b/ext/semian/types.h
@@ -24,6 +24,7 @@ typedef struct {
   int sem_id;
   int tickets;
   double quota;
+  int is_global;
 } configure_tickets_args_t;
 
 // Internal semaphore structure

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -177,6 +177,15 @@ module Semian
     self[name] || register(name, **args)
   end
 
+  attr_reader :global_resource
+
+  # create new global bulkhead
+  # it's ok to overwrite existing global_bulkhead
+  # as we use this only to track registered_workers count
+  def register_global_worker
+    @global_resource = create_bulkhead(:global, quota: 1)
+  end
+
   # Retrieves a resource by name.
   def [](name)
     resources[name]

--- a/lib/semian/resource.rb
+++ b/lib/semian/resource.rb
@@ -9,9 +9,9 @@ module Semian
       end
     end
 
-    def initialize(name, tickets: nil, quota: nil, permissions: 0660, timeout: 0)
+    def initialize(name, tickets: nil, quota: nil, permissions: 0660, timeout: 0, is_global: false)
       if Semian.semaphores_enabled?
-        initialize_semaphore(name, tickets, quota, permissions, timeout) if respond_to?(:initialize_semaphore)
+        initialize_semaphore(name, tickets, quota, permissions, timeout, is_global) if respond_to?(:initialize_semaphore)
       else
         Semian.issue_disabled_semaphores_warning
       end


### PR DESCRIPTION
In production, we've seen that when using quota and registered_workers count is low, bulkheads are quite frequent.
Specially with an adapter like mysql where we increase registered_workers lazily (only when we connect, ping or query) this is an issue.

With this PR, Semian keeps track of overall number of processes (global registered worker count) in a host once. Then for any Semian resource configuration with `is_global: true`, it uses the global registered worker count to calculate tickets instead of resource specific registered_worker count.

## How to use global workers?

```ruby
# n separate process will call it once each, therefore global worker count = n
10.times { Semian.register_global_worker }

resource = Semian.register(:mysql_shard0, quota: 0.5, is_global: true)
puts resource.tickets
# this will print 5 instead of 1
```

## Approach

Instead of working with a dedicated semaphore to manage global worker count, I decided to use a global worker, which is an singleton instance of general resource. This saves us from complexity and validate the usefulness of this approach quicker.