### PR TITLE
Introduce Semian.default_permissions

### DIFF
--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -90,9 +90,10 @@ module Semian
   InternalError = Class.new(BaseError)
   OpenCircuitError = Class.new(BaseError)
 
-  attr_accessor :maximum_lru_size, :minimum_lru_time
+  attr_accessor :maximum_lru_size, :minimum_lru_time, :default_permissions
   self.maximum_lru_size = 500
   self.minimum_lru_time = 300
+  self.default_permissions = 0660
 
   def issue_disabled_semaphores_warning
     return if defined?(@warning_issued)
@@ -138,7 +139,7 @@ module Semian
   # Mutually exclusive with the 'ticket' argument.
   # but the resource must have been previously registered otherwise an error will be raised. (bulkhead)
   #
-  # +permissions+: Octal permissions of the resource. Default 0660. (bulkhead)
+  # +permissions+: Octal permissions of the resource. Default to +Semian.default_permissions+ (0660). (bulkhead)
   #
   # +timeout+: Default timeout in seconds. Default 0. (bulkhead)
   #
@@ -282,7 +283,7 @@ module Semian
     bulkhead = options.fetch(:bulkhead, true)
     return unless bulkhead
 
-    permissions = options[:permissions] || 0660
+    permissions = options[:permissions] || default_permissions
     timeout = options[:timeout] || 0
     Resource.new(name, tickets: options[:tickets], quota: options[:quota], permissions: permissions, timeout: timeout)
   end

--- a/lib/semian/resource.rb
+++ b/lib/semian/resource.rb
@@ -9,7 +9,7 @@ module Semian
       end
     end
 
-    def initialize(name, tickets: nil, quota: nil, permissions: 0660, timeout: 0)
+    def initialize(name, tickets: nil, quota: nil, permissions: Semian.default_permissions, timeout: 0)
       if Semian.semaphores_enabled?
         initialize_semaphore(name, tickets, quota, permissions, timeout) if respond_to?(:initialize_semaphore)
       else


### PR DESCRIPTION
### Context

I'm trying to rollout a major infrastructure change on an app, and among other things it involve a changed process UID. Because of this, during rollout I get some Semian permission errors:

```
gems/semian-0.10.6/lib/semian/resource.rb:14:in `initialize_semaphore': semget() failed, errno: 13 (Permission denied) (Semian::SyscallError)
```

I could try to change the permissions on every single resource, but I'd feel safer with a global configuration.