### PR TITLE
Add Semian.namespace to flush all resources

### DIFF
--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -90,7 +90,7 @@ module Semian
   InternalError = Class.new(BaseError)
   OpenCircuitError = Class.new(BaseError)
 
-  attr_accessor :maximum_lru_size, :minimum_lru_time, :default_permissions
+  attr_accessor :maximum_lru_size, :minimum_lru_time, :default_permissions, :namespace
   self.maximum_lru_size = 500
   self.minimum_lru_time = 300
   self.default_permissions = 0660

--- a/lib/semian/resource.rb
+++ b/lib/semian/resource.rb
@@ -10,8 +10,14 @@ module Semian
     end
 
     def initialize(name, tickets: nil, quota: nil, permissions: Semian.default_permissions, timeout: 0)
+      unless name.is_a?(String) || name.is_a?(Symbol)
+        raise TypeError, "name must be a string or symbol, got: #{name.class}"
+      end
+
       if Semian.semaphores_enabled?
-        initialize_semaphore(name, tickets, quota, permissions, timeout) if respond_to?(:initialize_semaphore)
+        if respond_to?(:initialize_semaphore)
+          initialize_semaphore("#{Semian.namespace}#{name}", tickets, quota, permissions, timeout)
+        end
       else
         Semian.issue_disabled_semaphores_warning
       end

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -415,6 +415,26 @@ class TestResource < Minitest::Test
     end
   end
 
+  def test_namespace
+    previous_namespace = Semian.namespace
+
+    resource = create_resource :testing, permissions: 0o600, tickets: 1
+    key = resource.key
+    Semian.destroy(:testing)
+
+    resource = create_resource :testing, permissions: 0o600, tickets: 1
+    assert_equal key, resource.key
+    Semian.destroy(:testing)
+
+    Semian.namespace = "testing"
+
+    resource = create_resource :testing, permissions: 0o600, tickets: 1
+    refute_equal key, resource.key
+    Semian.destroy(:testing)
+  ensure
+    Semian.namespace = previous_namespace
+  end
+
   def test_resize_tickets_increase
     resource = create_resource :testing, tickets: 1
 


### PR DESCRIPTION
### Context
I'm trying to rollout a major infrastructure change on an app, and among other things it involve a changed process UID. Because of this, during rollout I get some Semian permission errors:

```
gems/semian-0.10.6/lib/semian/resource.rb:14:in `initialize_semaphore': semget() failed, errno: 13 (Permission denied) (Semian::SyscallError)
```

Because of this I'd like to change the key of all our semaphores. 

### Feature

`Semian.namespace` can be assigned a string that will be prefixed to all semaphores (before the hashing)