### PR TITLE
Remove fast failing MySQL connection error

### DIFF
--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -25,7 +25,6 @@ module Semian
       /MySQL server has gone away/i,
       /Too many connections/i,
       /closed MySQL connection/i,
-      /MySQL client is not connected/i,
       /Timeout waiting for a response/i,
     )
 


### PR DESCRIPTION
The mysql2 gem will only raise a `MySQL client is not connected` exception if [`CONNECTED(wrapper)` evaluates to false](https://github.com/brianmario/mysql2/blob/e2503dc6e8ad02f8c2f4fc71006f9840694e319c/ext/mysql2/client.c#L37-L39). In order to evaluate if the client is still connected, the [`CONNECTED` macro](https://github.com/brianmario/mysql2/blob/e2503dc6e8ad02f8c2f4fc71006f9840694e319c/ext/mysql2/client.c#L29-L33) will check the member contents of the NET struct [defined in libmysqlclient](https://github.com/mysql/mysql-server/blob/ee4455a33b10f1b1886044322e4893f587b319ed/include/mysql_com.h#L859-L866). Since `CONNECTED` only checks the local values stored in a struct, this check should resolve almost instantly.

If the `MySQL client is not connected` error fails fast, then I don't see a reason to track these errors in semian.

### Motivation behind removing this connection error from Semian

During ProxySQL deploys, we're seeing an elevated number of MySQL semian errors across all shards. When a ProxySQL pod is terminated, ProxySQL will close the existing connections after any ongoing queries finish. [On the ActiveRecord side, if the current activerecord thread does not have an associated db connection, it will try to checkout a connection from the connection pool](https://github.com/rails/rails/blob/03d3a1b9945278ee9ff926e726b2584a4c22c542/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L427-L429). If the checked out connection is closed, it will attempt to [establish a new connection](https://github.com/rails/rails/blob/03d3a1b9945278ee9ff926e726b2584a4c22c542/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L532-L534) with one of the new ProxySQL pods.

If there is a db connection associated with the thread, and that connection closes, the query will fail. I think from there, this [retry code](https://github.com/Shopify/shopify/blob/master/lib/patches/active_record/retry.rb) will attempt to establish a new connection with one of the new ProxySQL pods.

These errors are unavoidable because it's how ProxySQL signals to the client that the connection is closed and that it needs to reconnect. Since this error fails fast, we can remove it from Semian, and thus preventing the semian errors from occurring on every ProxySQL deploy.

Addresses: https://github.com/Shopify/shopify-proxysql/issues/129

### Verifying changes after shipping this
* Verify that db query response time and average overall response time for core does not increase
* Verify that when we deploy to ProxySQL, there isn't a spike of semians
* Keep an eye on the dashboards for a while after deploying - there may be other ways to trigger this error