### PR TITLE
Resolve common misconception about error_threshold in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ all workers on a server.
 
 There are four configuration parameters for circuit breakers in Semian:
 
-* **error_threshold**. The amount of errors to encounter for the worker before
+* **error_threshold**. The amount of errors a worker encounters within error_timeout amount of time before
   opening the circuit, that is to start rejecting requests instantly.
 * **error_timeout**. The amount of time in seconds until trying to query the resource
   again.

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -143,7 +143,8 @@ module Semian
   #
   # +timeout+: Default timeout in seconds. Default 0. (bulkhead)
   #
-  # +error_threshold+: The number of errors that will trigger the circuit opening. (circuit breaker required)
+  # +error_threshold+: The amount of errors that must happen within error_timeout amount of time to open
+  # the circuit. (circuit breaker required)
   #
   # +error_timeout+: The duration in seconds since the last error after which the error count is reset to 0.
   # (circuit breaker required)


### PR DESCRIPTION
I've had a few instances of confusion around the interaction between error_timeout and error_threshold.
This simple update to the read-me will help but I can still see how this interaction is unintuitive. 

Perhaps it's time we also update error_threshold to work indefinitely despite the time between errors, and only reset the counter on success.