### PR TITLE
Release v0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.11.2
+
+* Fix: Remove `MySQL client is not connected` error from mysql2 adapter
+
 # v0.11.1
 
 * Feature: Add `Semian.namespace` to globally prefix all the semaphore names. (#280)

--- a/lib/semian/version.rb
+++ b/lib/semian/version.rb
@@ -1,3 +1,3 @@
 module Semian
-  VERSION = '0.11.1'
+  VERSION = '0.11.2'
 end


### PR DESCRIPTION
Only one minor change included in this release https://github.com/Shopify/semian/pull/282

I initially attempted to pin core's semian version to latest master, but had troubles with in-repo gem version consistency. Instead of testing the changes in core before publishing a version to rubygems, I plan to upload a new release to rubygems directly, then run `bundle update` in core and sfr