### PR TITLE
Log last error message on circuit breaker state transition

### DIFF
--- a/lib/semian/circuit_breaker.rb
+++ b/lib/semian/circuit_breaker.rb
@@ -136,6 +136,10 @@ module Semian
       str << " success_count_threshold=#{@success_count_threshold} error_count_threshold=#{@error_count_threshold}"
       str << " error_timeout=#{@error_timeout} error_last_at=\"#{@errors.last}\""
       str << " name=\"#{@name}\""
+      if new_state == :open && @last_error
+        str << " last_error_message=#{@last_error.message.inspect}"
+      end
+
       Semian.logger.info(str)
     end
 

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -29,6 +29,11 @@ class TestCircuitBreaker < Minitest::Test
     assert_match(/State transition from closed to open/, @strio.string)
   end
 
+  def test_last_error_message_is_logged_when_circuit_opens
+    open_circuit!
+    assert_match(/last_error_message="some error message"/, @strio.string)
+  end
+
   def test_after_error_threshold_the_circuit_is_open
     open_circuit!
     assert_circuit_opened

--- a/test/helpers/circuit_breaker_helper.rb
+++ b/test/helpers/circuit_breaker_helper.rb
@@ -14,7 +14,7 @@ module CircuitBreakerHelper
   end
 
   def trigger_error!(resource = @resource, error = SomeError)
-    resource.acquire { raise error }
+    resource.acquire { raise error, "some error message" }
   rescue error
   end
 


### PR DESCRIPTION
This PR will help address: https://github.com/Shopify/shopify-proxysql/issues/129

We are seeing elevated semian errors in core whenever we deploy to ProxySQL. I was unable to find any logs in splunk that noted what caused the circuits to open. This is possibly because the application code that receives the `CircuitOpenError` exception is not choosing to log the error message.

We need to be able to see what errors are causing the circuit to open, so I'm logging the `last_error.message` whenever the state is changed to `open`.