### PR TITLE
feat: add force disable semian

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,4 +20,5 @@ gemspec
 
 group :development, :test do
   gem 'rubocop'
+  gem 'pry-byebug'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -20,5 +20,4 @@ gemspec
 
 group :development, :test do
   gem 'rubocop'
-  gem 'pry-byebug'
 end

--- a/lib/semian/net_http.rb
+++ b/lib/semian/net_http.rb
@@ -61,9 +61,9 @@ module Semian
       end
     end
 
-    def initialize(*args, semian_enabled: true)
+    def initialize(*args, semian: true)
       super(*args)
-      @semian_enabled = semian_enabled
+      @semian_enabled = semian
     end
 
     Semian::NetHTTP.reset_exceptions
@@ -80,7 +80,7 @@ module Semian
     end
 
     def disabled?
-      raw_semian_options.nil? || semian_enabled == false
+      raw_semian_options.nil? || @semian_enabled == false
     end
 
     def connect
@@ -107,8 +107,6 @@ module Semian
         self.open_timeout = prev_open_timeout
       end
     end
-
-    attr_accessor :semian_enabled
 
     private
 

--- a/lib/semian/net_http.rb
+++ b/lib/semian/net_http.rb
@@ -61,6 +61,11 @@ module Semian
       end
     end
 
+    def initialize(*args, semian_enabled: true)
+      super(*args)
+      @semian_enabled = semian_enabled
+    end
+
     Semian::NetHTTP.reset_exceptions
 
     def raw_semian_options
@@ -74,14 +79,8 @@ module Semian
       Semian::NetHTTP.exceptions
     end
 
-    def with_semian_disabled
-      @disable_semian = true
-      yield
-      @disable_semian = false
-    end
-
     def disabled?
-      raw_semian_options.nil? || @disable_semian == true
+      raw_semian_options.nil? || semian_enabled == false
     end
 
     def connect
@@ -109,7 +108,7 @@ module Semian
       end
     end
 
-    attr_accessor :disable_semian
+    attr_accessor :semian_enabled
 
     private
 

--- a/lib/semian/net_http.rb
+++ b/lib/semian/net_http.rb
@@ -44,7 +44,7 @@ module Semian
     ].freeze # Net::HTTP can throw many different errors, this tries to capture most of them
 
     class << self
-      attr_accessor :exceptions, :disable_semian
+      attr_accessor :exceptions
       attr_reader :semian_configuration
 
       def semian_configuration=(configuration)
@@ -54,12 +54,6 @@ module Semian
 
       def retrieve_semian_configuration(host, port)
         @semian_configuration.call(host, port) if @semian_configuration.respond_to?(:call)
-      end
-
-      def force_disable
-        @disable_semian = true
-        yield
-        @disable_semian = false
       end
 
       def reset_exceptions
@@ -78,6 +72,12 @@ module Semian
 
     def resource_exceptions
       Semian::NetHTTP.exceptions
+    end
+
+    def with_semian_disabled
+      @disable_semian = true
+      yield
+      @disable_semian = false
     end
 
     def disabled?
@@ -108,6 +108,8 @@ module Semian
         self.open_timeout = prev_open_timeout
       end
     end
+
+    attr_accessor :disable_semian
 
     private
 

--- a/lib/semian/net_http.rb
+++ b/lib/semian/net_http.rb
@@ -44,7 +44,7 @@ module Semian
     ].freeze # Net::HTTP can throw many different errors, this tries to capture most of them
 
     class << self
-      attr_accessor :exceptions
+      attr_accessor :exceptions, :disable_semian
       attr_reader :semian_configuration
 
       def semian_configuration=(configuration)
@@ -54,6 +54,12 @@ module Semian
 
       def retrieve_semian_configuration(host, port)
         @semian_configuration.call(host, port) if @semian_configuration.respond_to?(:call)
+      end
+
+      def force_disable
+        @disable_semian = true
+        yield
+        @disable_semian = false
       end
 
       def reset_exceptions
@@ -75,7 +81,7 @@ module Semian
     end
 
     def disabled?
-      raw_semian_options.nil?
+      raw_semian_options.nil? || @disable_semian == true
     end
 
     def connect

--- a/test/net_http_test.rb
+++ b/test/net_http_test.rb
@@ -256,19 +256,9 @@ class TestNetHTTP < Minitest::Test
     end
   end
 
-  def test_disable_semian_for_all_http_requests_in_block
-    with_server do
-      http = Net::HTTP.new(SemianConfig['toxiproxy_upstream_host'], SemianConfig['http_toxiproxy_port'])
-      http.with_semian_disabled do
-        assert_equal true, http.disabled?
-      end
-    end
-  end
-
   def test_disable_semian_for_all_http_requests_with_flag
     with_server do
-      http = Net::HTTP.new(SemianConfig['toxiproxy_upstream_host'], SemianConfig['http_toxiproxy_port'])
-      http.disable_semian = true
+      http = Net::HTTP.new(SemianConfig['toxiproxy_upstream_host'], SemianConfig['http_toxiproxy_port'], semian_enabled: false)
       assert_equal true, http.disabled?
     end
   end

--- a/test/net_http_test.rb
+++ b/test/net_http_test.rb
@@ -258,7 +258,7 @@ class TestNetHTTP < Minitest::Test
 
   def test_disable_semian_for_all_http_requests_with_flag
     with_server do
-      http = Net::HTTP.new(SemianConfig['toxiproxy_upstream_host'], SemianConfig['http_toxiproxy_port'], semian_enabled: false)
+      http = Net::HTTP.new(SemianConfig['toxiproxy_upstream_host'], SemianConfig['http_toxiproxy_port'], semian: false)
       assert_equal true, http.disabled?
     end
   end

--- a/test/net_http_test.rb
+++ b/test/net_http_test.rb
@@ -256,6 +256,15 @@ class TestNetHTTP < Minitest::Test
     end
   end
 
+  def test_disable_semian_for_all_http_requests
+    with_server do
+      Semian::NetHTTP.force_disable do
+        http = Net::HTTP.new(SemianConfig['toxiproxy_upstream_host'], SemianConfig['http_toxiproxy_port'])
+        assert_equal true, http.disabled?
+      end
+    end
+  end
+
   def test_use_custom_configuration_to_combine_endpoints_into_one_resource
     semian_config = {}
     semian_config["development"] = {}

--- a/test/net_http_test.rb
+++ b/test/net_http_test.rb
@@ -256,12 +256,20 @@ class TestNetHTTP < Minitest::Test
     end
   end
 
-  def test_disable_semian_for_all_http_requests
+  def test_disable_semian_for_all_http_requests_in_block
     with_server do
-      Semian::NetHTTP.force_disable do
-        http = Net::HTTP.new(SemianConfig['toxiproxy_upstream_host'], SemianConfig['http_toxiproxy_port'])
+      http = Net::HTTP.new(SemianConfig['toxiproxy_upstream_host'], SemianConfig['http_toxiproxy_port'])
+      http.with_semian_disabled do
         assert_equal true, http.disabled?
       end
+    end
+  end
+
+  def test_disable_semian_for_all_http_requests_with_flag
+    with_server do
+      http = Net::HTTP.new(SemianConfig['toxiproxy_upstream_host'], SemianConfig['http_toxiproxy_port'])
+      http.disable_semian = true
+      assert_equal true, http.disabled?
     end
   end
 


### PR DESCRIPTION
In opentelemetry we already implement our own retry mechanism with exponential backoff. Hence we want a way to disable semian temporarily for specific code blocks, to avoid seeing custom errors and overhead of semian.

My intuition is that having ability to disable semian for specific code path has usecases.

