### PR TITLE
Fix disable flag

### DIFF
--- a/lib/semian/net_http.rb
+++ b/lib/semian/net_http.rb
@@ -55,12 +55,6 @@ module Semian
       attr_accessor :exceptions
       attr_reader :semian_configuration
 
-      def prepended(base)
-        class << base
-          prepend ClassMethods
-        end
-      end
-
       def semian_configuration=(configuration)
         raise Semian::NetHTTP::SemianConfigurationChangedError unless @semian_configuration.nil?
         @semian_configuration = configuration
@@ -129,3 +123,4 @@ module Semian
 end
 
 Net::HTTP.prepend(Semian::NetHTTP)
+Net::HTTP.singleton_class.prepend(Semian::NetHTTP::ClassMethods)

--- a/test/net_http_test.rb
+++ b/test/net_http_test.rb
@@ -267,7 +267,7 @@ class TestNetHTTP < Minitest::Test
   def test_disable_semian_for_all_http_requests_with_flag
     with_server do
       with_semian_configuration do
-        http = Net::HTTP.new(SemianConfig['toxiproxy_upstream_host'], SemianConfig['http_toxiproxy_port'], semian: true)
+        http = Net::HTTP.new(SemianConfig['toxiproxy_upstream_host'], SemianConfig['http_toxiproxy_port'], semian: false)
         assert_equal true, http.disabled?
       end
     end

--- a/test/net_http_test.rb
+++ b/test/net_http_test.rb
@@ -255,11 +255,21 @@ class TestNetHTTP < Minitest::Test
       end
     end
   end
+  def test_disable_semian_should_be_false
+    with_server do
+      with_semian_configuration do
+        http = Net::HTTP.new(SemianConfig['toxiproxy_upstream_host'], SemianConfig['http_toxiproxy_port'])
+        assert_equal false, http.disabled?
+      end
+    end
+  end
 
   def test_disable_semian_for_all_http_requests_with_flag
     with_server do
-      http = Net::HTTP.new(SemianConfig['toxiproxy_upstream_host'], SemianConfig['http_toxiproxy_port'], semian: false)
-      assert_equal true, http.disabled?
+      with_semian_configuration do
+        http = Net::HTTP.new(SemianConfig['toxiproxy_upstream_host'], SemianConfig['http_toxiproxy_port'], semian: true)
+        assert_equal true, http.disabled?
+      end
     end
   end
 


### PR DESCRIPTION
I goofed and earlier approach in #301 doesn't work. https://github.com/ruby/ruby/blob/1f4af993835219efa8feaf76a0b36252028691f1/lib/net/http.rb#L654 - http class has its `self.new` definition. This should patch the correct method, but I am a little bit apprehensive to use `instance_variable_set`