### PR TITLE
Don't open the circuit on redis connection reset

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -31,7 +31,7 @@ services:
         sleep infinity
 
   toxiproxy:
-    image: shopify/toxiproxy:latest
+    image: ghcr.io/shopify/toxiproxy:2.3.0
     container_name: toxiproxy-dev
     depends_on: 
     - redis

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       toxiproxy:
-        image: shopify/toxiproxy:latest
+        image: ghcr.io/shopify/toxiproxy:2.3.0
 
     steps:
     - uses: actions/checkout@v1

--- a/lib/semian/redis.rb
+++ b/lib/semian/redis.rb
@@ -16,6 +16,14 @@ class Redis
     include ::Semian::AdapterError
   end
 
+  class ConnectionError < Redis::BaseConnectionError
+    # A Connection Reset is a fast failure and we don't want to track these errors in 
+    # semian
+    def marks_semian_circuits?
+      message != "Connection lost (ECONNRESET)"
+    end
+  end
+
   ResourceBusyError = Class.new(SemianError)
   CircuitOpenError = Class.new(SemianError)
   ResolveError = Class.new(SemianError)

--- a/test/redis_test.rb
+++ b/test/redis_test.rb
@@ -69,6 +69,22 @@ class TestRedis < Minitest::Test
     end
   end
 
+  def test_connection_reset_does_not_open_the_circuit
+    client = connect_to_redis!
+
+    @proxy.downstream(:reset_peer).apply do
+      ERROR_THRESHOLD.times do
+        assert_raises ::Redis::ConnectionError do
+          client.get('foo')
+        end
+      end
+
+      assert_raises ::Redis::ConnectionError do
+        client.get('foo')
+      end
+    end
+  end
+
   def test_command_errors_does_not_open_the_circuit
     client = connect_to_redis!
     client.hset('my_hash', 'foo', 'bar')


### PR DESCRIPTION
Connect Reset by Peer is a fast failing error and should not cause an open circuit, unfortunately the Redis gem bundles `ECONNRESET` along with a few other errors as `Redis::ConnectionError`.  This PR implements the `marks_semian_circuits?` method in the Redis::ConnectionError class and checks the error message to determine if the error is an ECONNRESET.  If it is then we don't mark this as a semian failure. 


This PR also update version of toxiproxy used in tests to 2.3.0 which supports a connect reset toxic.