### PR TITLE
Support new @raw_connection ivar name

### DIFF
--- a/lib/semian/rails.rb
+++ b/lib/semian/rails.rb
@@ -2,6 +2,8 @@ require 'active_record/connection_adapters/abstract_adapter'
 
 class ActiveRecord::ConnectionAdapters::AbstractAdapter
   def semian_resource
-    @connection.semian_resource
+    # support for https://github.com/rails/rails/commit/d86fd6415c0dfce6fadb77e74696cf728e5eb76b
+    connection = instance_variable_defined?(:@raw_connection) ? @raw_connection : @connection
+    connection.semian_resource
   end
 end


### PR DESCRIPTION
Rails change - https://github.com/rails/rails/commit/d86fd6415c0dfce6fadb77e74696cf728e5eb76b

Next version of Rails will use a different name for the `@connection` variable and `semian` needs to support this
Since we can't rely on any version check at this moment so I used `instance_variable_defined` to determine which variable to use

Is there a better way to support both ivars? 