### PR TITLE
Bump toxiproxy to v2.4.0

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - SYS_PTRACE
     security_opt:
       - seccomp:unconfined
-    depends_on: 
+    depends_on:
     - redis
     - mysql
     - toxiproxy
@@ -31,9 +31,9 @@ services:
         sleep infinity
 
   toxiproxy:
-    image: ghcr.io/shopify/toxiproxy:2.3.0
+    image: ghcr.io/shopify/toxiproxy:2.4.0
     container_name: toxiproxy-dev
-    depends_on: 
+    depends_on:
     - redis
     - mysql
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: 
+        ruby:
           # - "3.1" # grpc is causing issues with Ruby 3.1
           - "3.0"
           - "2.7"
@@ -30,11 +30,11 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       toxiproxy:
-        image: ghcr.io/shopify/toxiproxy:2.3.0
+        image: ghcr.io/shopify/toxiproxy:2.4.0
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Build image
-      run: docker build --build-arg RUBY_VERSION=${{ matrix.ruby }} -f dockerfiles/semian-ci -t semian-ci:${GITHUB_SHA::8}-${{ hashFiles(matrix.gemfile) }} .
-    - name: Run tests
-      run: docker run --rm --network=${{ job.container.network }} --network-alias=semian semian-ci:${GITHUB_SHA::8}-${{ hashFiles(matrix.gemfile) }} ./scripts/run_tests.sh
+      - uses: actions/checkout@v1
+      - name: Build image
+        run: docker build --build-arg RUBY_VERSION=${{ matrix.ruby }} -f dockerfiles/semian-ci -t semian-ci:${GITHUB_SHA::8}-${{ hashFiles(matrix.gemfile) }} .
+      - name: Run tests
+        run: docker run --rm --network=${{ job.container.network }} --network-alias=semian semian-ci:${GITHUB_SHA::8}-${{ hashFiles(matrix.gemfile) }} ./scripts/run_tests.sh

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -2,20 +2,20 @@ version: "3.7"
 services:
   semian:
     image: shopify/semian-ci:latest
-    depends_on: 
-    - redis
-    - mysql
-    - toxiproxy
+    depends_on:
+      - redis
+      - mysql
+      - toxiproxy
     command: ./scripts/run_tests.sh
-      
+
   toxiproxy:
-    image: shopify/toxiproxy:latest
+    image: ghcr.io/shopify/toxiproxy:2.4.0
     logging:
       driver: none
     container_name: toxiproxy
-    depends_on: 
-    - redis
-    - mysql
+    depends_on:
+      - redis
+      - mysql
 
   redis:
     image: redis:latest


### PR DESCRIPTION
Update Github actions to use latest version of toxiproxy.