### PR TITLE
Tests are broken for latest redis-client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 /pkg
 *.gem
 /html/
-Gemfile.lock
 vendor/
 *.swp
 *.swo

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,20 @@
 source 'https://rubygems.org'
 
+gem 'benchmark-memory'
+gem 'grpc'
 gem 'hiredis', '~> 0.6'
+gem 'memory_profiler'
+gem 'minitest'
+gem 'mocha'
 gem 'mysql2', '~> 0.5', github: 'brianmario/mysql2'
-gemspec
+gem 'pry-byebug', require: false
+gem 'rake-compiler'
+gem 'rake'
+gem 'redis-client', '0.2.0'
+gem 'redis'
+gem 'timecop'
+gem 'toxiproxy', '~> 1.0.0'
+gem 'webrick'
+gem 'rubocop'
 
-group :development, :test do
-  gem 'rubocop'
-end
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,95 @@
+GIT
+  remote: https://github.com/brianmario/mysql2.git
+  revision: e9c662912dc3bd3707e6c7f0c75e591294cffe12
+  specs:
+    mysql2 (0.5.4)
+
+PATH
+  remote: .
+  specs:
+    semian (0.12.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    benchmark-memory (0.2.0)
+      memory_profiler (~> 1)
+    byebug (11.1.3)
+    coderay (1.1.3)
+    connection_pool (2.2.5)
+    google-protobuf (3.20.1)
+    google-protobuf (3.20.1-x86_64-darwin)
+    googleapis-common-protos-types (1.3.1)
+      google-protobuf (~> 3.14)
+    grpc (1.46.2)
+      google-protobuf (~> 3.19)
+      googleapis-common-protos-types (~> 1.0)
+    grpc (1.46.2-x86_64-darwin)
+      google-protobuf (~> 3.19)
+      googleapis-common-protos-types (~> 1.0)
+    hiredis (0.6.3)
+    memory_profiler (1.0.0)
+    method_source (1.0.0)
+    minitest (5.15.0)
+    mocha (1.14.0)
+    parallel (1.22.1)
+    parser (3.1.2.0)
+      ast (~> 2.4.1)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
+    rainbow (3.1.1)
+    rake (13.0.6)
+    rake-compiler (1.2.0)
+      rake
+    redis (4.6.0)
+    redis-client (0.2.0)
+      connection_pool
+    regexp_parser (2.4.0)
+    rexml (3.2.5)
+    rubocop (1.29.1)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.17.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.18.0)
+      parser (>= 3.1.1.0)
+    ruby-progressbar (1.11.0)
+    timecop (0.9.5)
+    toxiproxy (1.0.3)
+    unicode-display_width (2.1.0)
+    webrick (1.7.0)
+
+PLATFORMS
+  ruby
+  x86_64-darwin-21
+
+DEPENDENCIES
+  benchmark-memory
+  grpc
+  hiredis (~> 0.6)
+  memory_profiler
+  minitest
+  mocha
+  mysql2 (~> 0.5)!
+  pry-byebug
+  rake
+  rake-compiler
+  redis
+  redis-client (= 0.2.0)
+  rubocop
+  semian!
+  timecop
+  toxiproxy (~> 1.0.0)
+  webrick
+
+BUNDLED WITH
+   2.3.14

--- a/semian.gemspec
+++ b/semian.gemspec
@@ -20,18 +20,4 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{lib,ext}/**/**/*.{rb,h,c}']
   s.extensions = ['ext/semian/extconf.rb']
-  s.add_development_dependency 'rake-compiler'
-  s.add_development_dependency 'rake'
-  s.add_development_dependency 'timecop'
-  s.add_development_dependency 'minitest'
-  s.add_development_dependency 'pry-byebug'
-  s.add_development_dependency 'mysql2'
-  s.add_development_dependency 'redis'
-  s.add_development_dependency 'redis-client', '>= 0.2.0'
-  s.add_development_dependency 'webrick'
-  s.add_development_dependency 'toxiproxy', '~> 1.0.0'
-  s.add_development_dependency 'grpc'
-  s.add_development_dependency 'mocha'
-  s.add_development_dependency 'memory_profiler'
-  s.add_development_dependency 'benchmark-memory'
 end


### PR DESCRIPTION
Current broken tests: https://github.com/Shopify/semian/runs/6526541521?check_suite_focus=true

Last success tests: https://github.com/Shopify/semian/runs/6229616802?check_suite_focus=true

The last compatible version was redis-client 0.2.0.

Move development dependencies to Gemfile.

Update gitignore to have Gemfile.lock.
It would allow to test gem against specific versions for dependencies.


Possible solution to check https://github.com/redis-rb/redis-client/blob/78c7932c28023ce8e1b9d64a04bd831cce539543/hiredis-client/lib/hiredis-client.rb