### PR TITLE
Run test in batches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     # https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container
     container: ruby:${{ matrix.ruby }}
-
     strategy:
       fail-fast: false
       matrix:
@@ -58,8 +57,8 @@ jobs:
       #       because upstream to toxiproxy should have access
       #       to the same container
       options: "--hostname semian"
-
     env:
+      TEST_WORKERS: 3
       CI: "1"
     strategy:
       fail-fast: true
@@ -68,6 +67,10 @@ jobs:
           # - "3.1" # grpc is causing issues with Ruby 3.1
           - "3.0"
           - "2.7"
+        worker_num:
+          - 1
+          - 2
+          - 3
     services:
       mysql:
         image: mysql:5.7
@@ -107,8 +110,11 @@ jobs:
         name: Build C extension
         run: bundle exec rake build
       -
-        name: Test
+        name: Parallel tests
+        env:
+          TEST_WORKER_NUM: ${{ matrix.worker_num }}
         run: |
-          bundle exec rake test ||
-          (echo "===== Retry Attempt: 2 ====" && bundle exec rake test) || \
-          (echo "===== Retry Attempt: 3 ====" && bundle exec rake test)
+          bundle exec rake test:parallel ||
+          (echo "===== Retry Attempt: 2 ====" && bundle exec rake test:parallel) || \
+          (echo "===== Retry Attempt: 3 ====" && bundle exec rake test:parallel)
+

--- a/README.md
+++ b/README.md
@@ -809,6 +809,15 @@ $ cd semian
   Running Tests:
   - `$ bundle exec rake` Run with `SKIP_FLAKY_TESTS=true` to skip flaky tests (CI runs all tests)
 
+### Running tests in batches
+
+* *TEST_WORKERS* - Total number of workers or batches.
+  It uses to identify a total number of batches, that would be run in parallel. *Default: 1*
+* *TEST_WORKER_NUM* - Specify which batch to run. The value is between 1 and *TEST_WORKERS*. *Default: 1*
+
+```shell
+$ bundle exec rake test:parallel TEST_WORKERS=5 TEST_WORKER_NUM=1
+```
 
 [hystrix]: https://github.com/Netflix/Hystrix
 [release-it]: https://pragprog.com/titles/mnee2/release-it-second-edition/


### PR DESCRIPTION
Allow to split tests in batches and run.

I could not find a gem for it, so create a new single task base on Rake::TestTask

Currently it does not give huge boost, because I refactored github workflows and those already had improved test performance from 13 mins to 4 mins:

- https://github.com/Shopify/semian/pull/322
- https://github.com/Shopify/semian/pull/327

## Usage

It requires two environment variables:
* *TEST_WORKERS* - Total number of workers or batches. It uses to identify a total number of batches, that would be run in parallel. Default: 1
* *TEST_WORKER_NUM* - Current worker id. The value is between 1 and *TEST_WORKERS*

```shell
$ bundle exec rake test:parallel TEST_WORKERS=5 TEST_WORKER_NUM=1
```


## Alternatives

- [test-queue](https://github.com/tmm1/test-queue)
- [rails_parallel](https://github.com/Shopify/rails_parallel)
- [parallel_tests](https://github.com/grosser/parallel_tests)
- [ci-queue](https://github.com/shopify/ci-queue)