### PR TITLE
Make codespace work

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -10,9 +10,6 @@ services:
       # This is where VS Code should expect to find your project's source code
       # and the value of "workspaceFolder" in .devcontainer/devcontainer.json
       - ..:/workspace
-      - ../.vscode-server:/root/.vscode-server
-      # This lets you avoid setting up Git again in the container
-      - ~/.gitconfig:/root/.gitconfig
     # Required for ptrace-based debuggers like C++, Go, and Rust
     privileged: true
     cap_add:


### PR DESCRIPTION
Make sure there is possobility to spin Codespace[^1].

Remove mount ~/.gitconfig, as it is missing in Codespace.

## Tophat

Device: MacBook Air M1

1. Visit https://github.com/shopify/semian
2. Create a branch: "codespace"
3. Click on Code -> Codespace (tab) -> Create codespace on "codespace"
4. Open in VSCode local
5. Open Terminal and invoke:
   ```shell
   $ bundle install
   $ bundle exec rake build
   $ bundle exec rake test
   ```

![image](https://user-images.githubusercontent.com/21104/169694820-14a0d6c2-4753-4998-9d3a-bd99cbc817ac.png)

## References

[^1]: [Codespace](https://code.visualstudio.com/docs/remote/codespaces)
