### PR TITLE
Handle new Rails connection changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ group :test do
   gem "timecop"
   gem "toxiproxy"
   gem "webrick"
+  gem "activerecord", ">= 7.0.3"
 end
 
 group :lint do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,11 +6,22 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activemodel (7.0.3.1)
+      activesupport (= 7.0.3.1)
+    activerecord (7.0.3.1)
+      activemodel (= 7.0.3.1)
+      activesupport (= 7.0.3.1)
+    activesupport (7.0.3.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
     ast (2.4.2)
     benchmark-memory (0.2.0)
       memory_profiler (~> 1)
     byebug (11.1.3)
     coderay (1.1.3)
+    concurrent-ruby (1.1.10)
     connection_pool (2.2.5)
     google-protobuf (3.21.2)
     google-protobuf (3.21.2-x86_64-darwin)
@@ -25,6 +36,8 @@ GEM
     hiredis (0.6.3)
     hiredis-client (0.5.1)
       redis-client (= 0.5.1)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
     json (2.6.2)
     memory_profiler (1.0.0)
     method_source (1.0.0)
@@ -70,6 +83,8 @@ GEM
     ruby-progressbar (1.11.0)
     timecop (0.9.5)
     toxiproxy (2.0.1)
+    tzinfo (2.0.5)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.2.0)
     webrick (1.7.0)
 
@@ -78,6 +93,7 @@ PLATFORMS
   x86_64-darwin-21
 
 DEPENDENCIES
+  activerecord (>= 7.0.3)
   benchmark-memory
   grpc
   hiredis (~> 0.6)

--- a/lib/semian/rails.rb
+++ b/lib/semian/rails.rb
@@ -2,14 +2,35 @@
 
 require "active_record/connection_adapters/abstract_adapter"
 
-module ActiveRecord
-  module ConnectionAdapters
-    class AbstractAdapter
-      def semian_resource
-        # support for https://github.com/rails/rails/commit/d86fd6415c0dfce6fadb77e74696cf728e5eb76b
-        connection = instance_variable_defined?(:@raw_connection) ? @raw_connection : @connection
-        connection.semian_resource
+module Semian
+  module Rails
+    def semian_resource
+      @semian_resource ||= client_connection.semian_resource
+    end
+
+    def reconnect
+      @semian_resource = nil
+      super
+    end
+
+    private
+
+    # client_connection is an instance of a Mysql2::Client
+    #
+    # The conditionals here support multiple Rails versions.
+    #   - valid_raw_connection is for 7.1.x and above
+    #   - @raw_connection is for 7.0.x
+    #   - @connection is for versions below 6.1.x and below
+    def client_connection
+      if respond_to?(:valid_raw_connection)
+        valid_raw_connection
+      elsif instance_variable_defined?(:@raw_connection)
+        @raw_connection
+      else
+        @connection
       end
     end
   end
 end
+
+ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend(Semian::Rails)

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestRails < Minitest::Test
+  SUCCESS_THRESHOLD = 2
+  ERROR_THRESHOLD = 1
+  ERROR_TIMEOUT = 5
+  SEMIAN_OPTIONS = {
+    name: :testing,
+    tickets: 1,
+    timeout: 0,
+    error_threshold: ERROR_THRESHOLD,
+    success_threshold: SUCCESS_THRESHOLD,
+    error_timeout: ERROR_TIMEOUT,
+  }
+
+  def setup
+    @config = {
+      adapter: "mysql2",
+      connect_timeout: 2,
+      read_timeout: 2,
+      write_timeout: 2,
+      reconnect: true,
+      prepared_statements: false,
+      host: SemianConfig["toxiproxy_upstream_host"],
+      port: SemianConfig["mysql_toxiproxy_port"],
+      semian: SEMIAN_OPTIONS,
+    }
+
+    ActiveRecord::Base.establish_connection(@config)
+
+    @connection = ActiveRecord::Base.connection
+    @resource = @connection.semian_resource
+    @circuit_breaker = @resource.circuit_breaker
+  end
+
+  def test_connection_has_a_semian_resource
+    assert_semian_resource
+  end
+
+  def test_semian_resource_is_available_after_disconnect
+    assert_semian_resource_reconnects do
+      @connection.disconnect!
+    end
+  end
+
+  def test_semian_resource_is_available_after_reset
+    assert_semian_resource_reconnects do
+      @connection.reset!
+    end
+  end
+
+  def test_semian_resource_is_available_after_reconnect
+    assert_semian_resource_reconnects do
+      @connection.reconnect!
+    end
+  end
+
+  private
+
+  def assert_semian_resource_reconnects(&block)
+    assert_semian_resource
+
+    yield
+
+    assert_semian_resource
+  end
+
+  def assert_semian_resource
+    assert_equal(SEMIAN_OPTIONS, @connection.instance_variable_get(:@config)[:semian])
+    assert(@resource, "expected semian_resource to be available on @connection")
+    assert_equal(:mysql_testing, @resource.name)
+    assert_equal(SUCCESS_THRESHOLD, @circuit_breaker.instance_variable_get(:@success_count_threshold))
+    assert_equal(ERROR_THRESHOLD, @circuit_breaker.instance_variable_get(:@error_count_threshold))
+    assert_equal(ERROR_TIMEOUT, @circuit_breaker.instance_variable_get(:@error_timeout))
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ require "rubygems"
 require "bundler/setup"
 
 require "minitest/autorun"
+require "active_record"
 require "mysql2"
 require "semian"
 require "semian/mysql2"


### PR DESCRIPTION
The refactoring in https://github.com/rails/rails/pull/44591 we started
seeing errors like `NoMethodError: undefined method 'semian_resource'
for nil:NilClass` coming from Semian. While this is called from
shopify/shopify, the `connection` that's `nil` is the one in the
`rails.rb` monkey patch.

After debugging with matthewd we found that Semian is relying on the
previous connection being available, whereas the new AR behavior means
it might not be.

To fix this we can memoize the `semian_resource` on `connection` in the
adapter, and then when the connection is reset or disconencted, set
`semian_resource` to `nil` and grab the new connection instance next
time we need it.

In addition to these changes I decided to add `activerecord` as a
development dependency to the gemspec so that we are able to test these
changes. Previously you would need to bundle open the gem in
shopify/shopify to test changes before sending a PR. It's important that
we're able to test what Semian is relying on so it makes sense to have a
depenedency on Active Record here.

Related: https://github.com/Shopify/shopify/pull/367400