### PR TITLE
Freeze grpc version 1.46.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 group :test do
   gem "benchmark-memory"
-  gem "grpc"
+  gem "grpc", "1.46.3"
   gem "hiredis", "~> 0.6"
   gem "memory_profiler"
   gem "minitest"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,14 +12,14 @@ GEM
     byebug (11.1.3)
     coderay (1.1.3)
     connection_pool (2.2.5)
-    google-protobuf (3.21.2)
-    google-protobuf (3.21.2-x86_64-darwin)
+    google-protobuf (3.21.5)
+    google-protobuf (3.21.5-x86_64-darwin)
     googleapis-common-protos-types (1.3.2)
       google-protobuf (~> 3.14)
-    grpc (1.47.0)
+    grpc (1.46.3)
       google-protobuf (~> 3.19)
       googleapis-common-protos-types (~> 1.0)
-    grpc (1.47.0-x86_64-darwin)
+    grpc (1.46.3-x86_64-darwin)
       google-protobuf (~> 3.19)
       googleapis-common-protos-types (~> 1.0)
     hiredis (0.6.3)
@@ -79,7 +79,7 @@ PLATFORMS
 
 DEPENDENCIES
   benchmark-memory
-  grpc
+  grpc (= 1.46.3)
   hiredis (~> 0.6)
   hiredis-client
   memory_profiler


### PR DESCRIPTION
Shipit could not install grpc 1.47.
Reverting for stable version.

Recently I found that tests in CI/CD are failing related to GRPC. 
This PR should fix them all.