### PR TITLE
Detect Redis 5

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,8 @@ FROM ruby:${RUBY_VERSION} as base
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install --no-install-recommends -y \
+RUN apt-get -o Acquire::Max-FutureTime=86400 update \
+ && apt-get install --no-install-recommends -y \
       apt-utils \
       build-essential \
       clang \

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem "rake-compiler"
   gem "rake"
   gem "hiredis-client"
-  gem "redis"
+  gem "redis", "~> 4.8"
   gem "timecop"
   gem "toxiproxy"
   gem "webrick"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GEM
     connection_pool (2.2.5)
     google-protobuf (3.21.5)
     google-protobuf (3.21.5-x86_64-darwin)
-    googleapis-common-protos-types (1.3.2)
+    googleapis-common-protos-types (1.4.0)
       google-protobuf (~> 3.14)
     grpc (1.46.3)
       google-protobuf (~> 3.19)
@@ -105,7 +105,7 @@ DEPENDENCIES
   pry-byebug
   rake
   rake-compiler
-  redis
+  redis (~> 4.8)
   rubocop
   rubocop-minitest
   rubocop-rake

--- a/lib/semian/redis.rb
+++ b/lib/semian/redis.rb
@@ -3,6 +3,11 @@
 require "semian/adapter"
 require "redis"
 
+if Redis::VERSION >= "5.0.0"
+  Semian.logger.warn("NOTE: Semian is not compatible with Redis 5.x")
+  return
+end
+
 class Redis
   Redis::BaseConnectionError.include(::Semian::AdapterError)
   ::Errno::EINVAL.include(::Semian::AdapterError)

--- a/semian.gemspec
+++ b/semian.gemspec
@@ -28,4 +28,17 @@ Gem::Specification.new do |s|
   s.files = ::Dir["{lib,ext}/**/**/*.{rb,h,c}"] +
     ::Dir.glob("*.md")
   s.extensions = ["ext/semian/extconf.rb"]
+
+  s.post_install_message = <<~MSG
+
+    ==============================================================================
+
+    semians is not compatible with redis 5.x.
+    Update Gemfile to use older redis version:
+
+        gem "redis", "~> 4.8"
+
+    ==============================================================================
+
+  MSG
 end


### PR DESCRIPTION
Print warning message redis 5.x during load time.

```
# gem install pkg/semian-0.13.2.gem
Building native extensions. This could take a while...

==============================================================================

semians is not compatible with redis 5.x.".
Update Gemfile to use older redis version:

    gem "redis", "~> 4.8"

==============================================================================

Successfully installed semian-0.13.2
1 gem installed
````

Ignore Semian settings for redis 5.

```irb
> require "redis"

> Redis::VERSION
=> "5.0.2"

> require "semian/redis"
W, [2022-09-02T16:33:00.722716 #194]  WARN -- : NOTE: Semian is not compatible with Redis 5.x
```

I would like to have this hack.
Mean time work on proper solution in https://github.com/Shopify/semian/issues/385.