### PR TITLE
Redis 5.0 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,8 @@ group :test do
   gem "mysql2", "~> 0.5"
   gem "pry-byebug", require: false
   gem "rake-compiler"
-  gem "hiredis-client"
-  gem "redis", "~> 4.8"
+  gem "hiredis-client", github: "redis-rb/redis-client"
+  gem "redis", github: "redis/redis-rb"
   gem "timecop"
   gem "toxiproxy"
   gem "webrick"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,19 @@
+GIT
+  remote: https://github.com/redis-rb/redis-client.git
+  revision: 5dc39f533f96fb94ebd6ef6cf7776b43f6243791
+  specs:
+    hiredis-client (0.7.3)
+      redis-client (= 0.7.3)
+    redis-client (0.7.3)
+      connection_pool
+
+GIT
+  remote: https://github.com/redis/redis-rb.git
+  revision: a06bed18e8beb5099b655fb792b93d66309ed39c
+  specs:
+    redis (5.0.2)
+      redis-client (~> 0.7)
+
 PATH
   remote: .
   specs:
@@ -34,8 +50,6 @@ GEM
       google-protobuf (~> 3.19)
       googleapis-common-protos-types (~> 1.0)
     hiredis (0.6.3)
-    hiredis-client (0.7.1)
-      redis-client (= 0.7.1)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json (2.6.2)
@@ -57,9 +71,6 @@ GEM
     rake (13.0.6)
     rake-compiler (1.2.0)
       rake
-    redis (4.8.0)
-    redis-client (0.7.1)
-      connection_pool
     regexp_parser (2.5.0)
     rexml (3.2.5)
     rubocop (1.36.0)
@@ -97,7 +108,7 @@ DEPENDENCIES
   benchmark-memory
   grpc (= 1.46.3)
   hiredis (~> 0.6)
-  hiredis-client
+  hiredis-client!
   memory_profiler
   minitest
   mocha
@@ -105,7 +116,7 @@ DEPENDENCIES
   pry-byebug
   rake
   rake-compiler
-  redis (~> 4.8)
+  redis!
   rubocop
   rubocop-minitest
   rubocop-rake

--- a/lib/semian/redis.rb
+++ b/lib/semian/redis.rb
@@ -3,8 +3,8 @@
 require "semian/adapter"
 require "redis"
 
-if Redis::VERSION >= "5.0.0"
-  Semian.logger.warn("NOTE: Semian is not compatible with Redis 5.x")
+if Redis::VERSION >= "5"
+  require "semian/redis/v5"
   return
 end
 
@@ -63,7 +63,7 @@ class Redis
 end
 
 module Semian
-  module Redis
+  module RedisV4
     include Semian::Adapter
 
     ResourceBusyError = ::Redis::ResourceBusyError
@@ -157,4 +157,4 @@ module Semian
   end
 end
 
-::Redis::Client.include(Semian::Redis)
+::Redis::Client.include(Semian::RedisV4)

--- a/lib/semian/redis/v5.rb
+++ b/lib/semian/redis/v5.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "semian/redis_client"
+
+class Redis
+  Redis::BaseConnectionError.include(::Semian::AdapterError)
+  class OutOfMemoryError < Redis::CommandError
+    include ::Semian::AdapterError
+  end
+
+  class SemianError < Redis::BaseConnectionError
+    def initialize(semian_identifier, *args)
+      super(*args)
+      @semian_identifier = semian_identifier
+    end
+  end
+
+  ResourceBusyError = Class.new(SemianError)
+  CircuitOpenError = Class.new(SemianError)
+
+  Client::ERROR_MAPPING.merge!(
+    RedisClient::CircuitOpenError => Redis::CircuitOpenError,
+    RedisClient::ResourceBusyError => Redis::ResourceBusyError,
+  )
+end
+
+module Semian
+  module RedisV5
+    def semian_resource
+      _client.semian_resource
+    end
+
+    def semian_identifier
+      _client.semian_identifier
+    end
+  end
+
+  module RedisV5Client
+    private
+
+    def translate_error!(error)
+      redis_error = translate_error_class(error.class)
+      if redis_error < ::Semian::AdapterError
+        redis_error = redis_error.new(error.message)
+        redis_error.semian_identifier = semian_identifier
+      end
+      raise redis_error, error.message, error.backtrace
+    end
+  end
+end
+
+::Redis.prepend(Semian::RedisV5)
+::Redis::Client.prepend(Semian::RedisV5Client)


### PR DESCRIPTION
Since 5.0 use redis-client under the hood, for the most part we only need to translate errors and delegate a few methods.

Closes #385