### PR TITLE
Cleanup redis 5.0 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,8 @@ group :test do
   gem "mysql2", "~> 0.5"
   gem "pry-byebug", require: false
   gem "rake-compiler"
-  gem "hiredis-client", github: "redis-rb/redis-client"
-  gem "redis", github: "redis/redis-rb"
+  gem "hiredis-client"
+  gem "redis"
   gem "timecop"
   gem "toxiproxy"
   gem "webrick"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,3 @@
-GIT
-  remote: https://github.com/redis-rb/redis-client.git
-  revision: 5dc39f533f96fb94ebd6ef6cf7776b43f6243791
-  specs:
-    hiredis-client (0.7.3)
-      redis-client (= 0.7.3)
-    redis-client (0.7.3)
-      connection_pool
-
-GIT
-  remote: https://github.com/redis/redis-rb.git
-  revision: a06bed18e8beb5099b655fb792b93d66309ed39c
-  specs:
-    redis (5.0.2)
-      redis-client (~> 0.7)
-
 PATH
   remote: .
   specs:
@@ -50,6 +34,8 @@ GEM
       google-protobuf (~> 3.19)
       googleapis-common-protos-types (~> 1.0)
     hiredis (0.6.3)
+    hiredis-client (0.7.4)
+      redis-client (= 0.7.4)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json (2.6.2)
@@ -71,6 +57,10 @@ GEM
     rake (13.0.6)
     rake-compiler (1.2.0)
       rake
+    redis (5.0.3)
+      redis-client (>= 0.7.4)
+    redis-client (0.7.4)
+      connection_pool
     regexp_parser (2.5.0)
     rexml (3.2.5)
     rubocop (1.36.0)
@@ -108,7 +98,7 @@ DEPENDENCIES
   benchmark-memory
   grpc (= 1.46.3)
   hiredis (~> 0.6)
-  hiredis-client!
+  hiredis-client
   memory_profiler
   minitest
   mocha
@@ -116,7 +106,7 @@ DEPENDENCIES
   pry-byebug
   rake
   rake-compiler
-  redis!
+  redis
   rubocop
   rubocop-minitest
   rubocop-rake

--- a/lib/semian/redis.rb
+++ b/lib/semian/redis.rb
@@ -4,6 +4,7 @@ require "semian/adapter"
 require "redis"
 
 if Redis::VERSION >= "5"
+  gem "redis", ">= 5.0.3"
   require "semian/redis/v5"
   return
 end

--- a/lib/semian/redis/v5.rb
+++ b/lib/semian/redis/v5.rb
@@ -3,12 +3,10 @@
 require "semian/redis_client"
 
 class Redis
-  Redis::BaseConnectionError.include(::Semian::AdapterError)
-  class OutOfMemoryError < Redis::CommandError
-    include ::Semian::AdapterError
-  end
+  BaseConnectionError.include(::Semian::AdapterError)
+  OutOfMemoryError.include(::Semian::AdapterError)
 
-  class SemianError < Redis::BaseConnectionError
+  class SemianError < BaseConnectionError
     def initialize(semian_identifier, *args)
       super(*args)
       @semian_identifier = semian_identifier


### PR DESCRIPTION
I released new `redis` and `redis-client` version with native support for `OutOfMemoryError`. So we can cleanup the gemfile and adapter a bit.