### PR TITLE
Translate open circuit error if we have one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix: Patch `new_client` for Rails apps so that the OpenCircuitError makes it through.
+
 # v0.14.0
 
 * Compatible with Redis 5 (#388, #392)


### PR DESCRIPTION
Prior to the connection management changes to Rails when we had an OpenCircuitError it wasn't translated to another error.

After these changes the OpenCircuitError gets translated to ConnectionNotEstablished by the adapter, and therefore is handled differently. This would cause issues for services that don't expect a ConnectionNotEstablsihed error.

Here we're patching `new_client` so that it will raise the right error cause for this failure case.