### PR TITLE
Pinging a closed connection shouldn't be considered a failure

### DIFF
--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -70,6 +70,8 @@ module Semian
     end
 
     def ping
+      return false if closed?
+
       result = nil
       acquire_semian_resource(adapter: :mysql, scope: :ping) do
         result = raw_ping

--- a/test/adapters/mysql2_test.rb
+++ b/test/adapters/mysql2_test.rb
@@ -305,6 +305,15 @@ class TestMysql2 < Minitest::Test
     assert_equal(2, client.query("SELECT 1 + 1 as sum;").to_a.first["sum"])
   end
 
+  def test_ping_on_closed_connection_dont_break_the_circuit
+    client = connect_to_mysql!
+    client.close
+
+    (ERROR_THRESHOLD * 2).times do
+      refute(client.ping)
+    end
+  end
+
   def test_pings_are_circuit_broken
     client = connect_to_mysql!
 


### PR DESCRIPTION
When reconnecting, Active Record's `MySQL2Adapter` closes the old connection, but keep the old connection around:


```ruby
      def active?
        !!@raw_connection&.ping
      end
# ....
        def connect
          @raw_connection = self.class.new_client(@connection_parameters)
        end

        def reconnect
          @raw_connection&.close
          connect
        end
```

So if that reconnection attempts fail, we are left with a closed connection in `@raw_connection`.

The problem is that if the circuit breaker was open, before closing again we move to `half-open` state, meaning we open again on the first failure.

Since before reconnecting `Mysql2Adapter` does try to ping the existing connection, we end up reopening the CB immediately because we called `ping` on a closed connection. 

Either way it makes no sense to report a failure in such case, as a closed connection is no indication of a resource having a  problem.

@bmansoob @eileencodes @miry 