### PR TITLE
Enrich to_s for Resources classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+* Provide more informaion for string represintation of `Semian:ProtectedResource`,
+  `Semian:Resource`, and `Semian:CircuitBreaker` instances. (#411)
+
 # v0.15.0
 
 * Pinging a closed connection shouldn't be considered a failure. (#396)

--- a/lib/semian/circuit_breaker.rb
+++ b/lib/semian/circuit_breaker.rb
@@ -89,6 +89,17 @@ module Semian
       !error_timeout_expired? && !@errors.empty?
     end
 
+    def to_s
+      "\#<#{self.class} name: #{@name}, " \
+        "half_open_resource_timeout: #{@half_open_resource_timeout}, " \
+        "error_timeout: #{@error_timeout}, " \
+        "closed?: #{@state.closed?}, " \
+        "open?: #{@state.open?}, " \
+        "half_open?: #{@state.half_open?}, " \
+        "implementation: #{@state.class.to_s.split("::")[-2]}, " \
+        "last_error: #{@last_error}>"
+    end
+
     private
 
     def transition_to_close

--- a/lib/semian/protected_resource.rb
+++ b/lib/semian/protected_resource.rb
@@ -36,6 +36,11 @@ module Semian
       circuit_breaker&.in_use? || bulkhead&.in_use?
     end
 
+    def to_s
+      bulkhead_str = @bulkhead.nil? ? "" : ", bulkhead: #{@bulkhead}"
+      "\#<#{self.class} name: #{@name}, circuit_breaker: #{@circuit_breaker}#{bulkhead_str}>"
+    end
+
     private
 
     def acquire_circuit_breaker(scope, adapter, resource)

--- a/lib/semian/resource.rb
+++ b/lib/semian/resource.rb
@@ -63,5 +63,9 @@ module Semian
     def in_use?
       false
     end
+
+    def to_s
+      "#<#{self.class} name: #{@name}>"
+    end
   end
 end

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -13,9 +13,34 @@ class TestCircuitBreaker < Minitest::Test
     rescue
       nil
     end
-    Semian.register(:testing, tickets: 1, exceptions: [SomeError], error_threshold: 2, error_timeout: 5,
+    Semian.register(:testing,
+      tickets: 1,
+      exceptions: [SomeError],
+      error_threshold: 2,
+      error_timeout: 5,
       success_threshold: 1)
     @resource = Semian[:testing]
+  end
+
+  def test_to_s
+    expected = "#<Semian::CircuitBreaker name: testing, half_open_resource_timeout: , " \
+      "error_timeout: 5, closed?: true, open?: false, half_open?: false, " \
+      "implementation: ThreadSafe, last_error: >"
+    assert_equal(expected, @resource.circuit_breaker.to_s)
+  end
+
+  def test_to_s_with_disabled_thread_safe
+    subject = Semian.register(:foo,
+      tickets: 1,
+      exceptions: [SomeError],
+      thread_safety_disabled: true,
+      error_threshold: 2,
+      error_timeout: 5,
+      success_threshold: 1)
+    expected = "#<Semian::CircuitBreaker name: foo, half_open_resource_timeout: , " \
+      "error_timeout: 5, closed?: true, open?: false, half_open?: false, " \
+      "implementation: Simple, last_error: >"
+    assert_equal(expected, subject.circuit_breaker.to_s)
   end
 
   def test_acquire_yield_when_the_circuit_is_closed

--- a/test/protected_resource_test.rb
+++ b/test/protected_resource_test.rb
@@ -154,4 +154,37 @@ class TestProtectedResource < Minitest::Test
       Process.kill("INT", pid)
     end
   end
+
+  def test_to_s
+    subject = Semian.register(
+      :expected_inspect_test_name,
+      error_threshold: 1,
+      error_timeout: 1,
+      success_threshold: 1,
+      bulkhead: true,
+      tickets: 1,
+    )
+
+    expected =
+      "#<Semian::ProtectedResource name: expected_inspect_test_name, " \
+        "circuit_breaker: .*, bulkhead: .*>"
+    assert_match(
+      Regexp.new(expected),
+      subject.to_s,
+    )
+  end
+
+  def test_to_s_without_bulkhead
+    subject = Semian.register(
+      :expected_inspect_test_name,
+      error_threshold: 1,
+      error_timeout: 1,
+      success_threshold: 1,
+      bulkhead: false,
+    )
+    assert_match(
+      /#<Semian::ProtectedResource name: expected_inspect_test_name, circuit_breaker: .*>/,
+      subject.to_s,
+    )
+  end
 end

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -20,6 +20,11 @@ class TestResource < Minitest::Test
     Process.waitall
   end
 
+  def test_to_s
+    subject = Semian::Resource.new(:testing, tickets: 1)
+    assert_equal("#<Semian::Resource name: testing>", subject.to_s)
+  end
+
   def test_initialize_invalid_args
     assert_raises(TypeError) do
       create_resource(123, tickets: 2)


### PR DESCRIPTION
When working with Semian, found to be usefull have light version of Resource.

Provide more informaion for string represintation of `Semian:ProtectedResource`,
  `Semian:Resource`, and `Semian:CircuitBreaker` instances.

Change the return value of `to_s` from class name with address to
class name with some fields.

Example:

* `"#<Semian::ProtectedResource:0x0000ffffa6f38558>"` -> `#<Semian::ProtectedResource name: testing, circuit_breaker: #<Semian::CircuitBreaker name: testing, half_open_resource_timeout: , error_timeout: 5, closed?: true, open?: false, half_open?: false, last_error: >, bulkhead: #<Semian::Resource name: testing>>`
* `"#<Semian::CircuitBreaker:0x0000ffffa6f3a830>"` -> `#<Semian::CircuitBreaker name: testing, half_open_resource_timeout: , error_timeout: 5, closed?: true, open?: false, half_open?: false, last_error: >`
* `"#<Semian::Resource:0x0000ffffa6f38d00>"` -> `#<Semian::Resource name: testing>`