### PR TITLE
Typo in error message in bulkhead settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Typo in error message for missing option `:tickets`. (#412)
+
 # v0.15.0
 
 * Pinging a closed connection shouldn't be considered a failure. (#396)

--- a/ext/semian/resource.c
+++ b/ext/semian/resource.c
@@ -273,10 +273,10 @@ static void
 check_tickets_xor_quota_arg(VALUE tickets, VALUE quota)
 {
   if (tickets == Qnil && quota == Qnil) {
-    rb_raise(rb_eArgError, "Semian configuration require either the :ticket or :quota parameter, you provided neither");
+    rb_raise(rb_eArgError, "Semian configuration require either the :tickets or :quota parameter, you provided neither");
   }
   if (tickets != Qnil && quota != Qnil) {
-    rb_raise(rb_eArgError, "Semian configuration require either the :ticket or :quota parameter, you provided both");
+    rb_raise(rb_eArgError, "Semian configuration require either the :tickets or :quota parameter, you provided both");
   }
 }
 

--- a/test/semian_test.rb
+++ b/test/semian_test.rb
@@ -65,7 +65,7 @@ class TestSemian < Minitest::Test
         circuit_breaker: false,
       )
     end
-    assert_equal("Semian configuration require either the :ticket or :quota parameter, you provided neither",
+    assert_equal("Semian configuration require either the :tickets or :quota parameter, you provided neither",
       exception.message)
   end
 
@@ -78,7 +78,7 @@ class TestSemian < Minitest::Test
         circuit_breaker: false,
       )
     end
-    assert_equal("Semian configuration require either the :ticket or :quota parameter, you provided both",
+    assert_equal("Semian configuration require either the :tickets or :quota parameter, you provided both",
       exception.message)
   end
 


### PR DESCRIPTION
Bulkhead require settings `:tickets` or `:quota`.
Error message suggested to add `:ticket`,
and it is not valid option.
There are examples to use `:tickets` [^1]


New message:

```
Semian configuration require either the :tickets or :quota parameter, you provided ...
```

[^1]: [Configuration](https://github.com/Shopify/semian#configuration)