### PR TITLE
Update debug message for resource (bulkheading)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Typo in error message for missing option `:tickets`. (#412)
+* Add process id in DEBUG message for bulkheading/resource. (#416)
 
 # v0.15.0
 

--- a/ext/semian/sysv_semaphores.h
+++ b/ext/semian/sysv_semaphores.h
@@ -10,6 +10,9 @@ and functions associated directly weth semops.
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
+#ifdef DEBUG
+#include <unistd.h>
+#endif
 
 #include <openssl/sha.h>
 #include <ruby.h>
@@ -110,7 +113,8 @@ acquire_semaphore_without_gvl(void *p);
 static inline void
 print_sem_vals(int sem_id)
 {
-  printf("lock %d, tickets: %d configured: %d, registered workers %d\n",
+  printf("[pid=%d][semian] semaphore values lock: %d, tickets: %d configured: %d, registered workers: %d\n",
+   getpid(),
    get_sem_val(sem_id, SI_SEM_LOCK),
    get_sem_val(sem_id, SI_SEM_TICKETS),
    get_sem_val(sem_id, SI_SEM_CONFIGURED_TICKETS),


### PR DESCRIPTION
Bulkheading could be used in forks.
Add process id in the log message.

Old message: `lock 1, tickets: 1 configured: 2, registered workers 1`
New message: `[pid=123][semian] semaphore values lock 1, tickets: 1 configured: 2, registered workers 1`