### PR TITLE
Avoid chaining duplicated semian identifiers in error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+* Avoid prepending the same prefix twice to errors messages. (#423)
+  This mostly happens with the `redis-rb 5+` gem as it translate `redis-client` errors.
+
 # v0.16.0
 
 * Typo in error message for missing option `:tickets`. (#412)

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -122,11 +122,16 @@ module Semian
     attr_accessor :semian_identifier
 
     def to_s
+      message = super
       if @semian_identifier
-        "[#{@semian_identifier}] #{super}"
-      else
-        super
+        prefix = "[#{@semian_identifier}] "
+        # When an error is created from another error's message it might
+        # already have a semian identifier in their message
+        unless message.start_with?(prefix)
+          message = "#{prefix}#{message}"
+        end
       end
+      message
     end
   end
 

--- a/test/adapter_test.rb
+++ b/test/adapter_test.rb
@@ -89,6 +89,20 @@ class TestSemianAdapter < Minitest::Test
     end
   end
 
+  class MyAdapterError < StandardError
+    include Semian::AdapterError
+  end
+
+  def test_adapter_error_message
+    error = MyAdapterError.new("[ServiceClass] Different prefixes")
+    error.semian_identifier = :my_service
+    assert_equal("[my_service] [ServiceClass] Different prefixes", error.message)
+
+    error = MyAdapterError.new("[my_service] Same Prefix")
+    error.semian_identifier = :my_service
+    assert_equal("[my_service] Same Prefix", error.message)
+  end
+
   def without_gc
     GC.disable
     yield


### PR DESCRIPTION
When errors are created from other errors messages they might already have a semian identifier in their message