### PR TITLE
WIP: Update tests to remove setup method

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,7 @@ Lint/SuppressedException:
   Exclude:
     - examples/**/*.rb
     - test/adapters/net_http_test.rb
+    - test/circuit_breaker_test.rb
     - test/helpers/circuit_breaker_helper.rb
     - test/helpers/resource_helper.rb
     - test/protected_resource_test.rb

--- a/test/helpers/circuit_breaker_helper.rb
+++ b/test/helpers/circuit_breaker_helper.rb
@@ -3,28 +3,26 @@
 module CircuitBreakerHelper
   SomeError = Class.new(StandardError)
 
-  private
-
-  def open_circuit!(resource = @resource, error_count = 2)
+  def open_circuit!(resource = @resource, error_count: 2)
     error_count.times { trigger_error!(resource) }
   end
 
-  def half_open_cicuit!(resource = @resource, backwards_time_travel = 10)
+  def half_open_cicuit!(resource = @resource, error_count: 2, backwards_time_travel: 10)
     time_travel(-backwards_time_travel) do
-      open_circuit!(resource)
+      open_circuit!(resource, error_count: error_count)
     end
   end
 
-  def trigger_error!(resource = @resource, error = SomeError)
+  def trigger_error!(resource = @resource, error: SomeError)
     resource.acquire { raise error, "some error message" }
   rescue error
   end
 
   def assert_circuit_closed(resource = @resource)
-    block_called = false
-    resource.acquire { block_called = true }
+    acquired = false
+    resource.acquire { acquired = true }
 
-    assert(block_called, "Expected the circuit to be closed, but it was open")
+    assert(acquired, "Expected the circuit to be closed, but it was open")
   end
 
   def assert_circuit_opened(resource = @resource)
@@ -36,5 +34,16 @@ module CircuitBreakerHelper
     end
 
     assert(open, "Expected the circuit to be open, but it was closed")
+  end
+
+  def assert_log_message_match(pattern, level: :debug, &block)
+    old = Semian.logger
+    subject = StringIO.new
+    Semian.logger = Logger.new(subject, level)
+    yield
+
+    assert_match(pattern, subject.string)
+  ensure
+    Semian.logger = old
   end
 end


### PR DESCRIPTION
Remove global resource object,
to make sure every tests has an example of Semian resource and 
configuration.

Intorduce assert helper to check logs.