### PR TITLE
DEBUG mode broke tests

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -4,8 +4,6 @@ version: "3.7"
 services:
   semian: &base
     container_name: semian
-    environment:
-      DEBUG: "1"
     build:
       dockerfile: .devcontainer/Dockerfile
       context: ..

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Avoid prepending the same prefix twice to errors messages. (#423)
   This mostly happens with the `redis-rb 5+` gem as it translate `redis-client` errors.
+* Fix running tests in DEBUG mode to test missing semaphores resources. (#430)
 
 # v0.16.0
 

--- a/ext/semian/sysv_semaphores.c
+++ b/ext/semian/sysv_semaphores.c
@@ -269,3 +269,19 @@ diff_timespec_ms(struct timespec *end, struct timespec *begin)
   long begin_ms = (begin->tv_sec * 1e3) + (begin->tv_nsec / 1e6);
   return end_ms - begin_ms;
 }
+
+#ifdef DEBUG
+VALUE
+print_sem_vals_without_rescue(VALUE v_sem_id)
+{
+  int sem_id = rb_to_int(v_sem_id);
+  printf("[pid=%d][semian] semaphore values lock: %d, tickets: %d configured: %d, registered workers: %d\n",
+   getpid(),
+   get_sem_val(sem_id, SI_SEM_LOCK),
+   get_sem_val(sem_id, SI_SEM_TICKETS),
+   get_sem_val(sem_id, SI_SEM_CONFIGURED_TICKETS),
+   get_sem_val(sem_id, SI_SEM_REGISTERED_WORKERS)
+  );
+  return (VALUE)0;
+}
+#endif

--- a/ext/semian/sysv_semaphores.h
+++ b/ext/semian/sysv_semaphores.h
@@ -110,16 +110,14 @@ void *
 acquire_semaphore_without_gvl(void *p);
 
 #ifdef DEBUG
+VALUE
+print_sem_vals_without_rescue(VALUE v_sem_id);
+
 static inline void
 print_sem_vals(int sem_id)
 {
-  printf("[pid=%d][semian] semaphore values lock: %d, tickets: %d configured: %d, registered workers: %d\n",
-   getpid(),
-   get_sem_val(sem_id, SI_SEM_LOCK),
-   get_sem_val(sem_id, SI_SEM_TICKETS),
-   get_sem_val(sem_id, SI_SEM_CONFIGURED_TICKETS),
-   get_sem_val(sem_id, SI_SEM_REGISTERED_WORKERS)
-  );
+  int state;
+  rb_protect(print_sem_vals_without_rescue, INT2NUM(sem_id), &state);
 }
 #endif
 

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -390,9 +390,10 @@ class TestResource < Minitest::Test
   def test_destroy
     resource = create_resource(:testing, tickets: 1)
     resource.destroy
-    assert_raises(Semian::SyscallError) do
+    exception = assert_raises(Semian::SyscallError) do
       resource.acquire {}
     end
+    assert_equal("semop() failed, errno: 22 (Invalid argument)", exception.message)
   end
 
   def test_destroy_already_destroyed


### PR DESCRIPTION
In debug mode there is an unexpected exception for tests.
THe function to print semaphores could not access to the resource and raise exception.
The observability should not produces exceptions and ignore errors.

```shell
$ DEBUG=1 bundle exec rake clean build
$ DEBUG=1 bundle exec ruby -Itest test/resource_test.rb -n test_destroy

# Running:

[pid=1345][semian] semaphore values lock: 1, tickets: 0 configured: 0, registered workers: 0
[pid=1345][semian] semaphore values lock: 0, tickets: 0 configured: 0, registered workers: 1
F

Finished in 0.001262s, 792.3403 runs/s, 792.3403 assertions/s.

  1) Failure:
TestResource#test_destroy [test/resource_test.rb:393]:
[Semian::SyscallError] exception expected, not
Class: <Semian::InternalError>
Message: <"error getting value of SI_SEM_LOCK for sem 131097, errno: 22 (Invalid argument)">
---Backtrace---
test/resource_test.rb:394:in `acquire'
test/resource_test.rb:394:in `block in test_destroy'
---------------
```

## Solution

Disable DEBUG mode for containers, as it is produced unreliable tests.
In debug function handle exceptions, to not produces errors.