### PR TITLE
Replace Time.now with monotonic in lru cache and resource update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   variable `SEMIAN_DISABLED` is set. (#427)
   Introduces environment variables `SEMIAN_CIRCUIT_BREAKER_DISABLED` to disable only
   `circuit_breaker` and `SEMIAN_BULKHEAD_DISABLED` only `bulkhead`.
+* Refactor: Replace `Time.now` with `CLOCK_MONOTONIC` in Resource `updated_at` field. (#443)
+  Replace `Timecop.travel` for tests with custom mock solution to support monotonic clocks.
 
 # v0.16.0
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ There are some global configuration options that can be set for Semian:
 # Note: Setting this to 0 enables aggressive garbage collection.
 Semian.maximum_lru_size = 0
 
-# Minimum time a resource should be resident in the LRU cache (default: 300s)
+# Minimum time in seconds a resource should be resident in the LRU cache (default: 300s)
 Semian.minimum_lru_time = 60
 ```
 

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -104,7 +104,7 @@ module Semian
   attr_accessor :maximum_lru_size, :minimum_lru_time, :default_permissions, :namespace
 
   self.maximum_lru_size = 500
-  self.minimum_lru_time = 300
+  self.minimum_lru_time = 300 # 300 seconds / 5 minutes
   self.default_permissions = 0660
 
   def issue_disabled_semaphores_warning

--- a/lib/semian/protected_resource.rb
+++ b/lib/semian/protected_resource.rb
@@ -15,7 +15,7 @@ module Semian
       @name = name
       @bulkhead = bulkhead
       @circuit_breaker = circuit_breaker
-      @updated_at = Time.now
+      @updated_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
 
     def destroy

--- a/lib/semian/unprotected_resource.rb
+++ b/lib/semian/unprotected_resource.rb
@@ -9,7 +9,7 @@ module Semian
 
     def initialize(name)
       @name = name
-      @updated_at = Time.now
+      @updated_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
 
     def registered_workers

--- a/test/helpers/time_helper.rb
+++ b/test/helpers/time_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module TimeHelper
+  def time_travel(val)
+    now_monotonic = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    now_timestamp = Time.now
+
+    new_monotonic = now_monotonic + val
+    Process.stubs(:clock_gettime).with(Process::CLOCK_MONOTONIC).returns(new_monotonic)
+
+    new_timestamp = now_timestamp + val
+    Time.stubs(:now).returns(new_timestamp)
+
+    yield
+  ensure
+    Time.unstub(:now)
+    Process.unstub(:clock_gettime)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,11 +12,12 @@ require "fileutils"
 require "mocha"
 require "mocha/minitest"
 
+require "helpers/adapter_helper"
 require "helpers/background_helper"
 require "helpers/circuit_breaker_helper"
-require "helpers/resource_helper"
-require "helpers/adapter_helper"
 require "helpers/mock_server.rb"
+require "helpers/resource_helper"
+require "helpers/time_helper.rb"
 
 require "config/semian_config"
 

--- a/test/time_helper_test.rb
+++ b/test/time_helper_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestTimeHelper < Minitest::Test
+  include TimeHelper
+
+  def test_time_monotonic_travel_past
+    now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    current = now + 1
+    time_travel(-6) do
+      current = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
+    assert(now > current, "now #{now} should be bigger than current #{current}")
+  end
+
+  def test_time_monotonic_travel_future
+    now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    current = now - 1
+    time_travel(6) do
+      current = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
+    assert(now + 5 < current, "now #{now} should be less than current #{current} at least by 5 secs")
+  end
+
+  def test_time_travel_past
+    now = Time.now
+    current = now + 1
+    time_travel(-6) do
+      current = Time.now
+    end
+
+    assert(now > current, "now #{now} should be bigger than current #{current}")
+  end
+
+  def test_time_travel_future
+    now = Time.now
+    current = now - 1
+    time_travel(6) do
+      current = Time.now
+    end
+
+    assert(now + 5 < current, "now #{now} should be less than current #{current} at least by 5 secs")
+  end
+end


### PR DESCRIPTION
Resource updated_at used only for LRU cache to clean unused resources.
There is no need in keeping timestamp.


Sidecar:
Implement basic travel time helper to cover Monotonic clocks.