### PR TITLE
Replace timecop with custom Time helper

### DIFF
--- a/test/adapters/mysql2_test.rb
+++ b/test/adapters/mysql2_test.rb
@@ -80,7 +80,7 @@ class TestMysql2 < Minitest::Test
     # After Mysql2::CircuitOpenError check regular queries are working fine.
     query_string = "1 + 1"
     result = nil
-    Timecop.travel(ERROR_TIMEOUT + 1) do
+    time_travel(ERROR_TIMEOUT + 1) do
       result = client.query("SELECT #{query_string};")
     end
 
@@ -166,7 +166,7 @@ class TestMysql2 < Minitest::Test
       connect_to_mysql!
     end
 
-    Timecop.travel(ERROR_TIMEOUT + 1) do
+    time_travel(ERROR_TIMEOUT + 1) do
       connect_to_mysql!
     end
   end
@@ -297,7 +297,7 @@ class TestMysql2 < Minitest::Test
       client.query("SELECT 1 + 1;")
     end
 
-    Timecop.travel(ERROR_TIMEOUT + 1) do
+    time_travel(ERROR_TIMEOUT + 1) do
       assert_equal(2, client.query("SELECT 1 + 1 as sum;").to_a.first["sum"])
     end
   end
@@ -355,7 +355,7 @@ class TestMysql2 < Minitest::Test
       client.query("SELECT 1 + 1;")
     end
 
-    Timecop.travel(ERROR_TIMEOUT + 1) do
+    time_travel(ERROR_TIMEOUT + 1) do
       @proxy.downstream(:latency, latency: 1500).apply do
         assert_raises(Mysql2::Error) do
           client.query("SELECT 1 + 1;")
@@ -363,7 +363,7 @@ class TestMysql2 < Minitest::Test
       end
     end
 
-    Timecop.travel(ERROR_TIMEOUT * 2 + 1) do
+    time_travel(ERROR_TIMEOUT * 2 + 1) do
       client.query("SELECT 1 + 1;")
       client.query("SELECT 1 + 1;")
 

--- a/test/adapters/net_http_test.rb
+++ b/test/adapters/net_http_test.rb
@@ -474,7 +474,7 @@ class TestNetHTTP < Minitest::Test
   private
 
   def half_open_cicuit!(backwards_time_travel = 10)
-    Timecop.travel(Time.now - backwards_time_travel) do
+    time_travel(-backwards_time_travel) do
       open_circuit!
     end
   end
@@ -541,12 +541,13 @@ class TestNetHTTP < Minitest::Test
 
   def close_circuit!(hostname: SemianConfig["toxiproxy_upstream_host"], toxic_port: SemianConfig["http_toxiproxy_port"])
     http = Net::HTTP.new(hostname, toxic_port)
-    Timecop.travel(http.raw_semian_options[:error_timeout])
-    # Cause successes success_threshold times so circuit closes
-    http.raw_semian_options[:success_threshold].times do
-      response = http.get("/200")
+    time_travel(http.raw_semian_options[:error_timeout]) do
+      # Cause successes success_threshold times so circuit closes
+      http.raw_semian_options[:success_threshold].times do
+        response = http.get("/200")
 
-      assert_equal(200, response.code.to_i)
+        assert_equal(200, response.code.to_i)
+      end
     end
   end
 

--- a/test/adapters/redis_client_test.rb
+++ b/test/adapters/redis_client_test.rb
@@ -170,7 +170,7 @@ module RedisClientTests
       connect_to_redis!(host: "thisdoesnotresolve")
     end
 
-    Timecop.travel(ERROR_TIMEOUT + 1) do
+    time_travel(ERROR_TIMEOUT + 1) do
       connect_to_redis!
     end
   end
@@ -199,7 +199,7 @@ module RedisClientTests
     half_open_resource_timeout = 0.1
     client = connect_to_redis!(half_open_resource_timeout: half_open_resource_timeout)
 
-    Timecop.freeze(0) do
+    time_travel(0) do
       @proxy.downstream(:latency, latency: redis_timeout_ms + 200).apply do
         ERROR_THRESHOLD.times do
           assert_raises(RedisClient::TimeoutError) do
@@ -214,13 +214,14 @@ module RedisClientTests
     end
 
     time_circuit_half_open = ERROR_TIMEOUT + 1
-    Timecop.travel(time_circuit_half_open) do
+    time_travel(time_circuit_half_open) do
       assert_redis_timeout_in_delta(expected_timeout: half_open_resource_timeout) do
         client.call("get", "foo")
       end
     end
 
     time_circuit_closed = time_circuit_half_open + ERROR_TIMEOUT + 1
+    # TODO: Returns failure `Expected |0.0 - 0.5| (0.5) to be <= 0.1.`
     Timecop.travel(time_circuit_closed) do
       SUCCESS_THRESHOLD.times { client.call("get", "foo") }
 
@@ -239,7 +240,7 @@ module RedisClientTests
     half_open_resource_timeout = 0.1
     client = connect_to_redis!(half_open_resource_timeout: half_open_resource_timeout)
 
-    Timecop.freeze(0) do
+    time_travel(0) do
       @proxy.downstream(:latency, latency: redis_timeout_ms + 200).apply do
         ERROR_THRESHOLD.times do
           assert_raises(RedisClient::TimeoutError) do
@@ -256,7 +257,7 @@ module RedisClientTests
     client.close
 
     time_circuit_half_open = ERROR_TIMEOUT + 1
-    Timecop.travel(time_circuit_half_open) do
+    time_travel(time_circuit_half_open) do
       assert_redis_timeout_in_delta(expected_timeout: half_open_resource_timeout) do
         client.call("set", "foo", 1)
       end
@@ -265,6 +266,7 @@ module RedisClientTests
     client.close
 
     time_circuit_closed = time_circuit_half_open + ERROR_TIMEOUT + 1
+    # TODO: Returns failure `Expected |0.0 - 0.5| (0.5) to be <= 0.1.`
     Timecop.travel(time_circuit_closed) do
       SUCCESS_THRESHOLD.times { client.call("set", "foo", 1) }
 
@@ -281,7 +283,7 @@ module RedisClientTests
   def test_timeout_doesnt_change_when_half_open_but_not_configured
     client = connect_to_redis!
 
-    Timecop.freeze(0) do
+    time_travel(0) do
       @proxy.downstream(:latency, latency: redis_timeout_ms + 200).apply do
         ERROR_THRESHOLD.times do
           assert_raises(RedisClient::TimeoutError) do
@@ -296,6 +298,7 @@ module RedisClientTests
     end
 
     time_circuit_half_open = ERROR_TIMEOUT + 1
+    # TODO: Returns failure `Expected |0.0 - 0.5| (0.5) to be <= 0.1.`
     Timecop.travel(time_circuit_half_open) do
       assert_redis_timeout_in_delta(expected_timeout: REDIS_TIMEOUT) do
         client.call("get", "foo")
@@ -348,7 +351,7 @@ module RedisClientTests
       client.call("get", "foo")
     end
 
-    Timecop.travel(ERROR_TIMEOUT + 1) do
+    time_travel(ERROR_TIMEOUT + 1) do
       assert_equal("2", client.call("get", "foo"))
     end
   end

--- a/test/adapters/redis_test.rb
+++ b/test/adapters/redis_test.rb
@@ -212,7 +212,7 @@ module RedisTests
       connect_to_redis!(host: "thisdoesnotresolve")
     end
 
-    Timecop.travel(ERROR_TIMEOUT + 1) do
+    time_travel(ERROR_TIMEOUT + 1) do
       connect_to_redis!
     end
   end
@@ -255,7 +255,7 @@ module RedisTests
       connect_to_redis!
     end
 
-    Timecop.travel(ERROR_TIMEOUT + 1) do
+    time_travel(ERROR_TIMEOUT + 1) do
       connect_to_redis!
     end
   end
@@ -288,7 +288,7 @@ module RedisTests
     half_open_resource_timeout = 0.1
     client = connect_to_redis!(semian: { half_open_resource_timeout: half_open_resource_timeout })
 
-    Timecop.freeze(0) do
+    time_travel(0) do
       @proxy.downstream(:latency, latency: redis_timeout_ms + 200).apply do
         ERROR_THRESHOLD.times do
           assert_raises(::Redis::TimeoutError) do
@@ -303,13 +303,14 @@ module RedisTests
     end
 
     time_circuit_half_open = ERROR_TIMEOUT + 1
-    Timecop.travel(time_circuit_half_open) do
+    time_travel(time_circuit_half_open) do
       assert_redis_timeout_in_delta(expected_timeout: half_open_resource_timeout) do
         client.get("foo")
       end
     end
 
     time_circuit_closed = time_circuit_half_open + ERROR_TIMEOUT + 1
+    # TODO: Returns failure `Expected |0.0 - 0.5| (0.5) to be <= 0.1.`
     Timecop.travel(time_circuit_closed) do
       SUCCESS_THRESHOLD.times { client.get("foo") }
 
@@ -326,7 +327,7 @@ module RedisTests
     half_open_resource_timeout = 0.1
     client = connect_to_redis!(semian: { half_open_resource_timeout: half_open_resource_timeout })
 
-    Timecop.freeze(0) do
+    time_travel(0) do
       @proxy.downstream(:latency, latency: redis_timeout_ms + 200).apply do
         ERROR_THRESHOLD.times do
           assert_raises(::Redis::TimeoutError) do
@@ -343,7 +344,7 @@ module RedisTests
     client.close
 
     time_circuit_half_open = ERROR_TIMEOUT + 1
-    Timecop.travel(time_circuit_half_open) do
+    time_travel(time_circuit_half_open) do
       assert_redis_timeout_in_delta(expected_timeout: half_open_resource_timeout) do
         client.set("foo", 1)
       end
@@ -352,6 +353,7 @@ module RedisTests
     client.close
 
     time_circuit_closed = time_circuit_half_open + ERROR_TIMEOUT + 1
+    # TODO: Returns failure `Expected |0.0 - 0.5| (0.5) to be <= 0.1.`
     Timecop.travel(time_circuit_closed) do
       SUCCESS_THRESHOLD.times { client.set("foo", 1) }
 
@@ -366,7 +368,7 @@ module RedisTests
   def test_timeout_doesnt_change_when_half_open_but_not_configured
     client = connect_to_redis!
 
-    Timecop.freeze(0) do
+    time_travel(0) do
       @proxy.downstream(:latency, latency: redis_timeout_ms + 200).apply do
         ERROR_THRESHOLD.times do
           assert_raises(::Redis::TimeoutError) do
@@ -381,6 +383,7 @@ module RedisTests
     end
 
     time_circuit_half_open = ERROR_TIMEOUT + 1
+    # TODO: Returns failure `Expected |0.0 - 0.5| (0.5) to be <= 0.1.`
     Timecop.travel(time_circuit_half_open) do
       assert_redis_timeout_in_delta(expected_timeout: REDIS_TIMEOUT) do
         client.get("foo")
@@ -433,7 +436,7 @@ module RedisTests
       client.get("foo")
     end
 
-    Timecop.travel(ERROR_TIMEOUT + 1) do
+    time_travel(ERROR_TIMEOUT + 1) do
       assert_equal("2", client.get("foo"))
     end
   end

--- a/test/helpers/circuit_breaker_helper.rb
+++ b/test/helpers/circuit_breaker_helper.rb
@@ -10,7 +10,7 @@ module CircuitBreakerHelper
   end
 
   def half_open_cicuit!(resource = @resource, backwards_time_travel = 10)
-    Timecop.travel(Time.now - backwards_time_travel) do
+    time_travel(-backwards_time_travel) do
       open_circuit!(resource)
     end
   end

--- a/test/protected_resource_test.rb
+++ b/test/protected_resource_test.rb
@@ -7,6 +7,7 @@ class TestProtectedResource < Minitest::Test
   include CircuitBreakerHelper
   include ResourceHelper
   include BackgroundHelper
+  include TimeHelper
 
   def setup
     Semian.destroy(:testing)

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -9,9 +9,7 @@ class TestResource < Minitest::Test
   EPSILON = 0.1
 
   def setup
-    Semian.destroy(:testing)
-  rescue
-    nil
+    Semian.destroy_all_resources
   end
 
   def teardown

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -71,5 +71,6 @@ module Minitest
   class Test
     include CleanupHelper
     include BackgroundHelper
+    include TimeHelper
   end
 end


### PR DESCRIPTION
It is next step to replace Time.now with Monotonic clock.
Update first tests, to make sure it works.