### PR TITLE
Tune examples to cover some cases

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,3 +36,6 @@ Style/GlobalVars:
 
 Style/SingleLineMethods:
   Enabled: false
+
+Style/SpecialGlobalVars:
+  Enabled: false

--- a/examples/net_http/06_circuit_in_fork.rb
+++ b/examples/net_http/06_circuit_in_fork.rb
@@ -88,19 +88,19 @@ worker_bar = fork do
     Net::HTTP.start("example.com", 81, open_timeout: 3) do |http|
       http.request_get(bad_host)
     end
-  rescue => e
+  rescue Net::OpenTimeout => e
     puts "[pid=#{pid}]   >> Could not connect: #{e.message}".brown
   end
   puts
 
-  sleep(2)
+  sleep(1.5)
 
   puts "[pid=#{pid}] >> 4. Request to http://example.com:81/index.html - fail".magenta
   begin
     Net::HTTP.start("example.com", 81, open_timeout: 3) do |http|
       http.request_get(bad_host)
     end
-  rescue => e
+  rescue Net::OpenTimeout => e
     puts "[pid=#{pid}]   >> Could not connect: #{e.message}".brown
   end
   puts "[pid=#{pid}]   !!! Semian changed state from `closed` to `open` and record last error exception !!!".red.bold
@@ -125,6 +125,9 @@ worker_bar = fork do
 end
 
 Process.waitpid(worker_bar)
+exit($?.exitstatus) if $?.exitstatus != 0
+
 Process.waitpid(worker_foo)
+exit($?.exitstatus) if $?.exitstatus != 0
 
 puts "> That's all Folks!".green

--- a/examples/net_http/11_bulkhead_in_forks.rb
+++ b/examples/net_http/11_bulkhead_in_forks.rb
@@ -47,8 +47,8 @@ workers << fork do
   Net::HTTP.start("example.com", 81, open_timeout: 5) do |http|
     http.request_get(bad_host)
   end
-rescue Errno::EADDRNOTAVAIL => e
-  puts "[pid=#{pid}] Expected networking problem that blocked the last ticket: #{e.class}: #{e.message}".blue
+rescue Errno::EADDRNOTAVAIL, Net::OpenTimeout => e
+  puts "[pid=#{pid}] EXPECTED networking problem that blocked the last ticket: #{e.class}: #{e.message}".blue
 end
 
 2.times do
@@ -58,7 +58,7 @@ end
     Net::HTTP.get_response(uri)
     raise "Should not get to this line."
   rescue Net::ResourceBusyError => e
-    puts "[pid=#{pid}] Out of tickets: #{e.class}: #{e.message}\n    #{e.backtrace.join("\n    ")}".brown
+    puts "[pid=#{pid}] EXPECTED: Out of tickets: #{e.class}: #{e.message}".brown
   end
 end
 

--- a/examples/net_http/12_bulkhead_quotes_in_forks.rb
+++ b/examples/net_http/12_bulkhead_quotes_in_forks.rb
@@ -70,8 +70,9 @@ workers << fork do
   Net::HTTP.start("example.com", 81, open_timeout: 5) do |http|
     http.request_get(bad_host)
   end
-rescue Errno::EADDRNOTAVAIL => e
-  puts "[pid=#{pid}] Expected networking problem that blocked the last ticket: #{e.class}: #{e.message}".blue
+  raise "Should not get to this line."
+rescue Errno::EADDRNOTAVAIL, Net::OpenTimeout => e
+  puts "[pid=#{pid}] EXPECTED networking problem that blocked the last ticket: #{e.class}: #{e.message}".blue
 end
 
 5.times do |_i|


### PR DESCRIPTION
Update examples to limit expected expectations and mark lines that should not be reached.
Replaced some rescue to single errors, to not cover to many problems.
Add lines to bulkhead examples to make sure script finished with unsuccess,
if thread or fork got exception.

Extract changes from https://github.com/Shopify/semian/pull/441/