### PR TITLE
Standardize cleans up

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,10 +19,11 @@ Layout/LineLength:
 
 Lint/SuppressedException:
   Exclude:
-    - test/helpers/circuit_breaker_helper.rb
-    - test/adapters/net_http_test.rb
-    - test/protected_resource_test.rb
     - examples/**/*.rb
+    - test/adapters/net_http_test.rb
+    - test/helpers/circuit_breaker_helper.rb
+    - test/helpers/resource_helper.rb
+    - test/protected_resource_test.rb
 
 Minitest/RefuteFalse:
   Enabled: false

--- a/test/adapter_test.rb
+++ b/test/adapter_test.rb
@@ -4,13 +4,7 @@ require "test_helper"
 
 class TestSemianAdapter < Minitest::Test
   def setup
-    Semian.unregister_all_resources
-    # Consumers registered in other test files must be cleared
-    Semian.reset!
-  end
-
-  def teardown
-    Semian.unregister_all_resources
+    destroy_all_semian_resources
   end
 
   def test_adapter_registers_consumer

--- a/test/circuit_breaker_test.rb
+++ b/test/circuit_breaker_test.rb
@@ -9,7 +9,7 @@ class TestCircuitBreaker < Minitest::Test
   def setup
     @strio = StringIO.new
     Semian.logger = Logger.new(@strio)
-    Semian.destroy_all_resources
+    destroy_all_semian_resources
     Semian.register(
       :testing,
       tickets: 1,

--- a/test/helpers/resource_helper.rb
+++ b/test/helpers/resource_helper.rb
@@ -20,4 +20,14 @@ module ResourceHelper
     end
     @resources = []
   end
+
+  def destroy_all_semian_resources
+    Semian.resources.values.each do |resource|
+      resource.bulkhead&.unregister_worker
+    rescue ::Semian::SyscallError
+    end
+    Semian.destroy_all_resources
+    destroy_resources
+    Semian.reset!
+  end
 end

--- a/test/instrumentation_test.rb
+++ b/test/instrumentation_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class TestInstrumentation < Minitest::Test
   def setup
-    Semian.destroy(:testing) if Semian[:testing]
+    destroy_all_semian_resources
     Semian.register(:testing, tickets: 1, error_threshold: 1, error_timeout: 5, success_threshold: 1)
   end
 

--- a/test/protected_resource_test.rb
+++ b/test/protected_resource_test.rb
@@ -6,18 +6,9 @@ require "securerandom"
 class TestProtectedResource < Minitest::Test
   include CircuitBreakerHelper
   include ResourceHelper
-  include BackgroundHelper
-  include TimeHelper
 
   def setup
-    Semian.destroy(:testing)
-  rescue
-    nil
-  end
-
-  def teardown
-    destroy_resources
-    super
+    destroy_all_semian_resources
   end
 
   def test_acquire_without_bulkhead

--- a/test/semian_test.rb
+++ b/test/semian_test.rb
@@ -3,6 +3,10 @@
 require "test_helper"
 
 class TestSemian < Minitest::Test
+  def setup
+    destroy_all_semian_resources
+  end
+
   def test_unsupported_acquire_yields
     acquired = false
     Semian.register(:testing, tickets: 1, error_threshold: 1, error_timeout: 2, success_threshold: 1)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -61,16 +61,10 @@ Minitest.after_run do
   servers.each(&:stop)
 end
 
-module CleanupHelper
-  def setup
-    Semian.destroy_all_resources
-  end
-end
-
 module Minitest
   class Test
-    include CleanupHelper
     include BackgroundHelper
     include TimeHelper
+    include ResourceHelper
   end
 end

--- a/test/time_helper_test.rb
+++ b/test/time_helper_test.rb
@@ -3,8 +3,6 @@
 require "test_helper"
 
 class TestTimeHelper < Minitest::Test
-  include TimeHelper
-
   def test_time_monotonic_travel_past
     now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     current = now + 1


### PR DESCRIPTION
Introduce semian resources clean up in ResourceHelper.
Update test `test_permissions` to make sure there is at least single line in semaphors.

Extract from https://github.com/Shopify/semian/pull/441