### PR TITLE
Update tests to have less collisions of resources and remove Timecop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,9 @@ Lint/SuppressedException:
     - test/helpers/resource_helper.rb
     - test/protected_resource_test.rb
 
+Minitest/AssertPredicate:
+  Enabled: false
+
 Minitest/RefuteFalse:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ group :test do
   gem "minitest"
   gem "mocha"
   gem "pry-byebug", require: false
-  gem "timecop"
   gem "toxiproxy"
   gem "webrick"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,6 @@ GEM
       rubocop (~> 1.35)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
-    timecop (0.9.5)
     toxiproxy (2.0.2)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
@@ -121,7 +120,6 @@ DEPENDENCIES
   rubocop-rake
   rubocop-shopify
   semian!
-  timecop
   toxiproxy
   webrick
 

--- a/gemfiles/grpc.gemfile
+++ b/gemfiles/grpc.gemfile
@@ -6,7 +6,6 @@ gem "rake"
 gem "rake-compiler"
 gem "minitest"
 gem "mocha"
-gem "timecop"
 gem "toxiproxy"
 gem "webrick"
 

--- a/gemfiles/grpc.gemfile.lock
+++ b/gemfiles/grpc.gemfile.lock
@@ -27,7 +27,6 @@ GEM
     rake-compiler (1.2.0)
       rake
     ruby2_keywords (0.0.5)
-    timecop (0.9.5)
     toxiproxy (2.0.2)
     webrick (1.7.0)
 
@@ -45,7 +44,6 @@ DEPENDENCIES
   rake
   rake-compiler
   semian!
-  timecop
   toxiproxy
   webrick
 

--- a/gemfiles/mysql2.gemfile
+++ b/gemfiles/mysql2.gemfile
@@ -6,7 +6,6 @@ gem "rake"
 gem "rake-compiler"
 gem "minitest"
 gem "mocha"
-gem "timecop"
 gem "toxiproxy"
 gem "webrick"
 

--- a/gemfiles/mysql2.gemfile.lock
+++ b/gemfiles/mysql2.gemfile.lock
@@ -14,7 +14,6 @@ GEM
     rake-compiler (1.2.0)
       rake
     ruby2_keywords (0.0.5)
-    timecop (0.9.5)
     toxiproxy (2.0.2)
     webrick (1.7.0)
 
@@ -32,7 +31,6 @@ DEPENDENCIES
   rake
   rake-compiler
   semian!
-  timecop
   toxiproxy
   webrick
 

--- a/gemfiles/net_http.gemfile
+++ b/gemfiles/net_http.gemfile
@@ -7,7 +7,6 @@ gem "rake-compiler"
 
 gem "minitest"
 gem "mocha"
-gem "timecop"
 gem "toxiproxy"
 gem "webrick"
 

--- a/gemfiles/net_http.gemfile.lock
+++ b/gemfiles/net_http.gemfile.lock
@@ -13,7 +13,6 @@ GEM
     rake-compiler (1.2.0)
       rake
     ruby2_keywords (0.0.5)
-    timecop (0.9.5)
     toxiproxy (2.0.2)
     webrick (1.7.0)
 
@@ -30,7 +29,6 @@ DEPENDENCIES
   rake
   rake-compiler
   semian!
-  timecop
   toxiproxy
   webrick
 

--- a/gemfiles/rails.gemfile
+++ b/gemfiles/rails.gemfile
@@ -6,7 +6,6 @@ gem "rake"
 gem "rake-compiler"
 gem "minitest"
 gem "mocha"
-gem "timecop"
 gem "toxiproxy"
 gem "webrick"
 

--- a/gemfiles/rails.gemfile.lock
+++ b/gemfiles/rails.gemfile.lock
@@ -27,7 +27,6 @@ GEM
     rake-compiler (1.2.0)
       rake
     ruby2_keywords (0.0.5)
-    timecop (0.9.5)
     toxiproxy (2.0.2)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
@@ -48,7 +47,6 @@ DEPENDENCIES
   rake
   rake-compiler
   semian!
-  timecop
   toxiproxy
   webrick
 

--- a/gemfiles/redis_5.gemfile
+++ b/gemfiles/redis_5.gemfile
@@ -6,7 +6,6 @@ gem "rake"
 gem "rake-compiler"
 gem "minitest"
 gem "mocha"
-gem "timecop"
 gem "toxiproxy"
 gem "webrick"
 

--- a/gemfiles/redis_5.gemfile.lock
+++ b/gemfiles/redis_5.gemfile.lock
@@ -21,7 +21,6 @@ GEM
     redis-client (0.11.2)
       connection_pool
     ruby2_keywords (0.0.5)
-    timecop (0.9.5)
     toxiproxy (2.0.2)
     webrick (1.7.0)
 
@@ -41,7 +40,6 @@ DEPENDENCIES
   rake-compiler
   redis
   semian!
-  timecop
   toxiproxy
   webrick
 

--- a/gemfiles/redis_client.gemfile
+++ b/gemfiles/redis_client.gemfile
@@ -6,7 +6,6 @@ gem "rake"
 gem "rake-compiler"
 gem "minitest"
 gem "mocha"
-gem "timecop"
 gem "toxiproxy"
 gem "webrick"
 

--- a/gemfiles/redis_client.gemfile.lock
+++ b/gemfiles/redis_client.gemfile.lock
@@ -31,7 +31,6 @@ GEM
     rake-compiler (1.2.0)
       rake
     ruby2_keywords (0.0.5)
-    timecop (0.9.5)
     toxiproxy (2.0.2)
     webrick (1.7.0)
 
@@ -51,7 +50,6 @@ DEPENDENCIES
   rake-compiler
   redis!
   semian!
-  timecop
   toxiproxy
   webrick
 

--- a/test/adapters/net_http_test.rb
+++ b/test/adapters/net_http_test.rb
@@ -19,6 +19,10 @@ class TestNetHTTP < Minitest::Test
     DEFAULT_SEMIAN_OPTIONS.merge(name: "#{host}_#{port}")
   end
 
+  def setup
+    destroy_all_semian_resources
+  end
+
   def test_semian_identifier
     with_server do
       with_semian_configuration do

--- a/test/adapters/redis_test.rb
+++ b/test/adapters/redis_test.rb
@@ -303,21 +303,20 @@ module RedisTests
     end
 
     time_circuit_half_open = ERROR_TIMEOUT + 1
-    time_travel(time_circuit_half_open) do
-      assert_redis_timeout_in_delta(expected_timeout: half_open_resource_timeout) do
+    assert_redis_timeout_in_delta(expected_timeout: half_open_resource_timeout) do
+      time_travel(time_circuit_half_open) do
         client.get("foo")
       end
     end
 
     time_circuit_closed = time_circuit_half_open + ERROR_TIMEOUT + 1
-    # TODO: Returns failure `Expected |0.0 - 0.5| (0.5) to be <= 0.1.`
-    Timecop.travel(time_circuit_closed) do
+    time_travel(time_circuit_closed) do
       SUCCESS_THRESHOLD.times { client.get("foo") }
+    end
 
-      # Timeout has reset now that the Circuit is closed
-      assert_redis_timeout_in_delta(expected_timeout: REDIS_TIMEOUT) do
-        client.get("foo")
-      end
+    # Timeout has reset now that the Circuit is closed
+    assert_redis_timeout_in_delta(expected_timeout: REDIS_TIMEOUT) do
+      client.get("foo")
     end
 
     assert_default_timeouts(client)
@@ -344,8 +343,8 @@ module RedisTests
     client.close
 
     time_circuit_half_open = ERROR_TIMEOUT + 1
-    time_travel(time_circuit_half_open) do
-      assert_redis_timeout_in_delta(expected_timeout: half_open_resource_timeout) do
+    assert_redis_timeout_in_delta(expected_timeout: half_open_resource_timeout) do
+      time_travel(time_circuit_half_open) do
         client.set("foo", 1)
       end
     end
@@ -353,13 +352,12 @@ module RedisTests
     client.close
 
     time_circuit_closed = time_circuit_half_open + ERROR_TIMEOUT + 1
-    # TODO: Returns failure `Expected |0.0 - 0.5| (0.5) to be <= 0.1.`
-    Timecop.travel(time_circuit_closed) do
+    time_travel(time_circuit_closed) do
       SUCCESS_THRESHOLD.times { client.set("foo", 1) }
+    end
 
-      assert_redis_timeout_in_delta(expected_timeout: REDIS_TIMEOUT) do
-        client.set("foo", 1)
-      end
+    assert_redis_timeout_in_delta(expected_timeout: REDIS_TIMEOUT) do
+      client.set("foo", 1)
     end
 
     assert_default_timeouts(client)
@@ -383,9 +381,8 @@ module RedisTests
     end
 
     time_circuit_half_open = ERROR_TIMEOUT + 1
-    # TODO: Returns failure `Expected |0.0 - 0.5| (0.5) to be <= 0.1.`
-    Timecop.travel(time_circuit_half_open) do
-      assert_redis_timeout_in_delta(expected_timeout: REDIS_TIMEOUT) do
+    assert_redis_timeout_in_delta(expected_timeout: REDIS_TIMEOUT) do
+      time_travel(time_circuit_half_open) do
         client.get("foo")
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,6 @@ require "bundler/setup"
 require "minitest/autorun"
 require "semian"
 require "toxiproxy"
-require "timecop"
 require "tempfile"
 require "fileutils"
 require "mocha"
@@ -52,6 +51,8 @@ Toxiproxy.populate([
     listen: "#{SemianConfig["toxiproxy_upstream_host"]}:#{SemianConfig["grpc_toxiproxy_port"]}",
   },
 ])
+
+Toxiproxy.reset
 
 servers = []
 servers << MockServer.start(hostname: BIND_ADDRESS, port: SemianConfig["http_port_service_a"])


### PR DESCRIPTION
NetHTTP setup method to clean all resources.
Remove usage of Timecop in redis adapaters.
Update circuite breaker tests to have initialization of resource in multiple lines.