### PR TITLE
Support Ruby 3.2

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUBY_VERSION=3.1.3
+ARG RUBY_VERSION=3.2.0
 FROM ruby:${RUBY_VERSION} as base
 
 # Avoid warnings by switching to noninteractive

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -28,7 +28,7 @@ jobs:
       -
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
           bundler-cache: true
       -
         name: Ruby Linting

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -15,7 +15,7 @@ jobs:
     name: Update gems for all Gemfiles
     runs-on: ubuntu-latest
     container:
-      image: ruby:3.1
+      image: ruby:3.2
     steps:
       -
         name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
       fail-fast: true
       matrix:
         ruby:
+          - "3.2"
           - "3.1"
           - "3.0"
           - "2.7"
@@ -106,6 +107,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - "3.2"
           - "3.1"
           - "3.0"
           - "2.7"
@@ -170,11 +172,8 @@ jobs:
           bundle install
       -
         name: Build C extension
-        env:
-          BUNDLE_GEMFILE: Gemfile
         run: |
           bundle config path vendor/bundle
-          bundle install --without test,lint
           bundle exec rake build
       -
         name: Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Refactor: Replace `Time.now` with `CLOCK_MONOTONIC` in Resource `updated_at` field. (#443)
   Replace `Timecop.travel` for tests with custom mock solution to support monotonic clocks.
 * Refactor: Replace `Time.now` with `CLOCK_MONOTONIC` in `CircuitBreaker`. (#441)
+* Support Ruby 3.2.0. (#463)
 
 # v0.16.0
 

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,8 @@ group :test do
   gem "mysql2", "~> 0.5"
   gem "activerecord", ">= 7.0.3"
   gem "hiredis", "~> 0.6"
-  gem "hiredis-client"
+  # NOTE: v0.12.0 required for ruby 3.2.0. https://github.com/redis-rb/redis-client/issues/58
+  gem "hiredis-client", ">= 0.12.0"
   gem "redis"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,22 +24,14 @@ GEM
     concurrent-ruby (1.1.10)
     connection_pool (2.3.0)
     google-protobuf (3.21.12)
-    google-protobuf (3.21.12-x86_64-darwin)
-    google-protobuf (3.21.12-x86_64-linux)
     googleapis-common-protos-types (1.5.0)
       google-protobuf (~> 3.14)
     grpc (1.47.0)
       google-protobuf (~> 3.19)
       googleapis-common-protos-types (~> 1.0)
-    grpc (1.47.0-x86_64-darwin)
-      google-protobuf (~> 3.19)
-      googleapis-common-protos-types (~> 1.0)
-    grpc (1.47.0-x86_64-linux)
-      google-protobuf (~> 3.19)
-      googleapis-common-protos-types (~> 1.0)
     hiredis (0.6.3)
-    hiredis-client (0.11.2)
-      redis-client (= 0.11.2)
+    hiredis-client (0.12.0)
+      redis-client (= 0.12.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
@@ -64,7 +56,7 @@ GEM
       rake
     redis (5.0.5)
       redis-client (>= 0.9.0)
-    redis-client (0.11.2)
+    redis-client (0.12.0)
       connection_pool
     regexp_parser (2.6.1)
     rexml (3.2.5)
@@ -106,7 +98,7 @@ DEPENDENCIES
   benchmark-memory
   grpc (= 1.47.0)
   hiredis (~> 0.6)
-  hiredis-client
+  hiredis-client (>= 0.12.0)
   memory_profiler
   minitest
   mocha
@@ -124,4 +116,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.3.26
+   2.4.3

--- a/dockerfiles/semian-ci
+++ b/dockerfiles/semian-ci
@@ -1,4 +1,4 @@
-ARG RUBY_VERSION=3.1.3
+ARG RUBY_VERSION=3.2.0
 FROM ruby:${RUBY_VERSION} as base
 
 # Avoid warnings by switching to noninteractive

--- a/gemfiles/grpc.gemfile.lock
+++ b/gemfiles/grpc.gemfile.lock
@@ -7,17 +7,9 @@ GEM
   remote: https://rubygems.org/
   specs:
     google-protobuf (3.21.12)
-    google-protobuf (3.21.12-x86_64-darwin)
-    google-protobuf (3.21.12-x86_64-linux)
     googleapis-common-protos-types (1.5.0)
       google-protobuf (~> 3.14)
     grpc (1.47.0)
-      google-protobuf (~> 3.19)
-      googleapis-common-protos-types (~> 1.0)
-    grpc (1.47.0-x86_64-darwin)
-      google-protobuf (~> 3.19)
-      googleapis-common-protos-types (~> 1.0)
-    grpc (1.47.0-x86_64-linux)
       google-protobuf (~> 3.19)
       googleapis-common-protos-types (~> 1.0)
     minitest (5.17.0)
@@ -48,4 +40,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.3.26
+   2.4.3

--- a/gemfiles/mysql2.gemfile.lock
+++ b/gemfiles/mysql2.gemfile.lock
@@ -35,4 +35,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.3.26
+   2.4.3

--- a/gemfiles/net_http.gemfile.lock
+++ b/gemfiles/net_http.gemfile.lock
@@ -33,4 +33,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.3.26
+   2.4.3

--- a/gemfiles/rails.gemfile.lock
+++ b/gemfiles/rails.gemfile.lock
@@ -51,4 +51,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.3.26
+   2.4.3

--- a/gemfiles/redis_4.gemfile.lock
+++ b/gemfiles/redis_4.gemfile.lock
@@ -8,8 +8,8 @@ GEM
   specs:
     connection_pool (2.3.0)
     hiredis (0.6.3)
-    hiredis-client (0.11.2)
-      redis-client (= 0.11.2)
+    hiredis-client (0.12.0)
+      redis-client (= 0.12.0)
     minitest (5.17.0)
     mocha (2.0.2)
       ruby2_keywords (>= 0.0.5)
@@ -17,7 +17,7 @@ GEM
     rake-compiler (1.2.1)
       rake
     redis (4.8.0)
-    redis-client (0.11.2)
+    redis-client (0.12.0)
       connection_pool
     ruby2_keywords (0.0.5)
     toxiproxy (2.0.2)
@@ -43,4 +43,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.3.26
+   2.4.3

--- a/gemfiles/redis_5.gemfile
+++ b/gemfiles/redis_5.gemfile
@@ -10,7 +10,7 @@ gem "toxiproxy"
 gem "webrick"
 
 gem "hiredis", "~> 0.6"
-gem "hiredis-client"
+gem "hiredis-client", ">= 0.12.0"
 gem "redis"
 
 gemspec path: "../"

--- a/gemfiles/redis_5.gemfile.lock
+++ b/gemfiles/redis_5.gemfile.lock
@@ -8,8 +8,8 @@ GEM
   specs:
     connection_pool (2.3.0)
     hiredis (0.6.3)
-    hiredis-client (0.11.2)
-      redis-client (= 0.11.2)
+    hiredis-client (0.12.0)
+      redis-client (= 0.12.0)
     minitest (5.17.0)
     mocha (2.0.2)
       ruby2_keywords (>= 0.0.5)
@@ -18,7 +18,7 @@ GEM
       rake
     redis (5.0.5)
       redis-client (>= 0.9.0)
-    redis-client (0.11.2)
+    redis-client (0.12.0)
       connection_pool
     ruby2_keywords (0.0.5)
     toxiproxy (2.0.2)
@@ -33,7 +33,7 @@ PLATFORMS
 
 DEPENDENCIES
   hiredis (~> 0.6)
-  hiredis-client
+  hiredis-client (>= 0.12.0)
   minitest
   mocha
   rake
@@ -44,4 +44,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.3.26
+   2.4.3

--- a/gemfiles/redis_client.gemfile.lock
+++ b/gemfiles/redis_client.gemfile.lock
@@ -1,10 +1,10 @@
 GIT
   remote: https://github.com/redis-rb/redis-client.git
-  revision: 809bbab767f8e514ccd0d6008116c360435f3026
+  revision: ac1f3bffd9c1cef1e2d46a0dee6dc12b333da229
   specs:
-    hiredis-client (0.11.2)
-      redis-client (= 0.11.2)
-    redis-client (0.11.2)
+    hiredis-client (0.12.0)
+      redis-client (= 0.12.0)
+    redis-client (0.12.0)
       connection_pool
 
 GIT
@@ -54,4 +54,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.3.26
+   2.4.3


### PR DESCRIPTION
Add ruby 3.2 to the list of ruby versions to check tests against.
Upgrade hiredis-client to support ruby 3.2