### PR TITLE
Remove unsupported way to run callbacks on signal

### DIFF
--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -63,9 +63,7 @@ class TestResource < Minitest::Test
       success_threshold: 0,
     )
 
-    fork_workers(count: workers, tickets: 0, timeout: 0.5, wait_for_timeout: true) do
-      Semian.unregister(:testing)
-    end
+    fork_workers(count: workers, tickets: 0, timeout: 0.5, wait_for_timeout: true)
 
     Semian.unregister(:testing)
     signal_workers("TERM")


### PR DESCRIPTION
In tests used lru clean table with Mutex in fork process on exit.
It is not supported anymore and could be removed https://bugs.ruby-lang.org/issues/14222.

Sample exception:

```
Class: ThreadError
Message: can't be called from trap context
---Backtrace---
lib/semian/lru_hash.rb:110:in `synchronize'
lib/semian/lru_hash.rb:110:in `delete'
lib/semian.rb:231:in `unregister'
test/resource_test.rb:67:in `block in test_unregister_past_0'
```

Could not run https://github.com/Shopify/semian/blob/e1252f57da51e0c0c44fb4cae24063da4ae0b3b9/lib/semian/lru_hash.rb#L110 inside `Signal.trap`.