### PR TITLE
Benchmark and performance review between versions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,12 +12,17 @@ RUN apt-get -o Acquire::Max-FutureTime=86400 update \
       git \
       less \
       libssl-dev \
+      linux-perf \
       lldb \
       lsb-release \
       netcat \
       procps \
       xz-utils \
  && gem install bundler rcodetools rubocop ruby-debug-ide fastri
+
+WORKDIR /opt
+RUN git clone --depth 1 https://github.com/brendangregg/FlameGraph
+ENV PATH /opt/FlameGraph:$PATH
 
 # Switch back to dialog for any ad-hoc use of apt-get
 ENV DEBIAN_FRONTEND=dialog

--- a/Rakefile
+++ b/Rakefile
@@ -144,3 +144,23 @@ task examples: ["examples:net_http", "examples:activerecord_trilogy_adapter"]
 
 task default: :build
 task default: :test # rubocop:disable Rake/DuplicateTask
+
+desc "Generate flamegrpahs for different versions"
+task :flamegraph do
+  script = "scripts/benchmarks/flamegraph.rb"
+  flamegraph_parse_command = "flamegraph.pl --countname=ms --width=1400"
+
+  %x(ruby #{script} | #{flamegraph_parse_command} > without_semian.svg)
+  ["v0.15.0", "v0.16.0", "v0.17.0", "master"].each do |ver|
+    %x(WITH_CIRCUIT_BREAKER_ENABLED=1 SEMIAN_VERSION=#{ver} ruby #{script} \
+        | #{flamegraph_parse_command} > semian_#{ver}_enabled.svg)
+  end
+end
+
+desc "Run benchmarks for specific versions"
+task :benchmark do
+  ["v0.15.0", "v0.16.0", "v0.17.0", "master"].each do |ver|
+    ruby "scripts/benchmarks/net_http_acquire_benchmarker.rb SEMIAN_VERSION=#{ver}"
+    ruby "scripts/benchmarks/lru_benchmarker.rb SEMIAN_VERSION=#{ver}"
+  end
+end

--- a/scripts/benchmarks/flamegraph.rb
+++ b/scripts/benchmarks/flamegraph.rb
@@ -1,0 +1,120 @@
+#!/usr/bin/env ruby
+
+# frozen_string_literal: true
+
+# Envronment variable SEMIAN_VERSION have values v0.16.0, HEAD, master, custom-branch-name.
+target_version = ENV.fetch("SEMIAN_VERSION", nil)
+
+require "bundler/inline"
+
+gemfile do
+  source "https://rubygems.org"
+  gem "ruby-prof-flamegraph", require: "ruby-prof-flamegraph"
+  if target_version
+    gem "semian", git: "https://github.com/shopify/semian.git", ref: target_version
+  end
+end
+
+require "socket"
+require "net/http"
+require "ruby-prof"
+require "ruby-prof-flamegraph"
+
+def server(server_port)
+  fork do
+    trap("TERM") do
+      $stderr.puts "Server: kill signal received...shutting down"
+      exit
+    end
+    # We need to include the Content-Type and Content-Length headers
+    # to let the client know the size and type of data
+    # contained in the response. Note that HTTP is whitespace
+    # sensitive, and expects each header line to end with CRLF (i.e. "\r\n")
+    response = "success!"
+    response_headers_basis =
+      "HTTP/1.1 200 OK\r\n" \
+        "Content-Type: text/plain\r\n" \
+        "Content-Length: #{response.bytesize}\r\n" \
+        "Connection: close\r\n\r\n#{response}"
+
+    server = TCPServer.new("127.0.0.1", server_port)
+    $stderr.puts "Server: started on #{server_port}..."
+    loop do
+      Thread.start(server.accept) do |socket|
+        # NOTICE: Ignore for now the request!
+        # request = socket.gets
+        socket.print(response_headers_basis)
+        socket.close
+      end
+    end
+  end
+end
+
+def bench(target_version, server_port)
+  host = "127.0.0.1"
+
+  if target_version
+    require "semian"
+    require "semian/version"
+    require "semian/net_http"
+    $stderr.puts "Load Semian #{Semian::VERSION}"
+
+    if ENV.key?("WITH_CIRCUIT_BREAKER_ENABLED")
+      $stderr.puts "Enable Circuit breaker for HTTP requests"
+      Semian::NetHTTP.semian_configuration = proc do
+        {
+          name: "mock_server",
+          circuit_breaker: true,
+          success_threshold: 3,
+          error_threshold: 2,
+          error_timeout: 5,
+          bulkhead: true,
+          tickets: 1,
+        }
+      end
+
+      # Semian.subscribe do |event, resource, scope, adapter|
+      #   $stderr.puts "[semian] adapter=#{adapter} scope=#{scope} event=#{event} " \
+      #     "resource_name=#{resource.name} resource=#{resource}"
+      # end
+    end
+  end
+
+  # http = Net::HTTP.new(host, server_port)
+  # warmup
+  100.times do
+    http = Net::HTTP.new(host, server_port)
+    http.open_timeout = 1
+    begin
+      http.get("/")
+    rescue
+      nil
+    end
+  end
+
+  # Profile the code
+  result = RubyProf.profile do
+    1000.times do
+      http = Net::HTTP.new(host, server_port)
+      http.open_timeout = 1
+      begin
+        http.get("/")
+      rescue
+        nil
+      end
+    end
+  end
+
+  # Print a graph profile to text
+  printer = RubyProf::FlameGraphPrinter.new(result)
+  printer.print($stdout, {})
+end
+
+begin
+  server_port = 2345
+  server_pid = server(server_port)
+  sleep(1)
+  bench(target_version, server_port)
+ensure
+  Process.kill(:TERM, server_pid)
+end

--- a/scripts/benchmarks/lru_benchmarker.rb
+++ b/scripts/benchmarks/lru_benchmarker.rb
@@ -3,18 +3,27 @@
 # Benchmarks the usage of an LRUHash during the set operation.
 # To make sure we are cleaning resources, MINIMUM_TIME_IN_LRU needs
 # to be set to 0
-$LOAD_PATH.unshift(File.expand_path("../../../lib", __FILE__))
-$LOAD_PATH.unshift(File.expand_path("../../../test", __FILE__))
-require "thin"
+
+# Envronment variable SEMIAN_VERSION have values v0.16.0, HEAD, master, custom-branch-name.
+target_version = ENV.fetch("SEMIAN_VERSION", nil)
+if target_version.nil? && !ARGV.empty?
+  target_version = ARGV.first.sub("SEMIAN_VERSION=", "")
+end
+
+require "bundler/inline"
+
+gemfile do
+  source "https://rubygems.org"
+  gem "benchmark-ips", require: "benchmark/ips"
+  gem "benchmark-memory", require: "benchmark/memory"
+  gem "semian", git: "https://github.com/shopify/semian.git", ref: target_version
+end
+
 require "benchmark"
 require "benchmark/ips"
 require "benchmark/memory"
 require "semian"
 require "semian/net_http"
-require "toxiproxy"
-require "yaml"
-require "byebug"
-require "minitest"
 
 class LRUBenchmarker
   def run_ips_benchmark

--- a/scripts/benchmarks/net_http_acquire_benchmarker.rb
+++ b/scripts/benchmarks/net_http_acquire_benchmarker.rb
@@ -1,0 +1,136 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Envronment variable SEMIAN_VERSION have values v0.16.0, HEAD, master, custom-branch-name.
+target_version = ENV.fetch("SEMIAN_VERSION", nil)
+if target_version.nil? && !ARGV.empty?
+  target_version = ARGV.first.sub("SEMIAN_VERSION=", "")
+end
+
+require "bundler/inline"
+
+gemfile do
+  source "https://rubygems.org"
+  gem "benchmark-ips", require: "benchmark/ips"
+  gem "benchmark-memory", require: "benchmark/memory"
+  if target_version
+    gem "semian", git: "https://github.com/shopify/semian.git", ref: target_version
+  end
+end
+
+require "socket"
+require "net/http"
+require "benchmark/ips"
+
+def server(server_port)
+  fork do
+    trap("TERM") do
+      puts "Server: kill signal received...shutting down"
+      exit
+    end
+    # We need to include the Content-Type and Content-Length headers
+    # to let the client know the size and type of data
+    # contained in the response. Note that HTTP is whitespace
+    # sensitive, and expects each header line to end with CRLF (i.e. "\r\n")
+    response = "success!"
+    response_headers_basis =
+      "HTTP/1.1 200 OK\r\n" \
+        "Content-Type: text/plain\r\n" \
+        "Content-Length: #{response.bytesize}\r\n" \
+        "Connection: close\r\n\r\n#{response}"
+
+    server = TCPServer.new("127.0.0.1", server_port)
+    puts "Server: started on #{server_port}..."
+    loop do
+      Thread.start(server.accept) do |socket|
+        # NOTICE: Ignore for now the request!
+        # request = socket.gets
+        socket.print(response_headers_basis)
+        socket.close
+      end
+    end
+  end
+end
+
+# Benchmarking
+class GCSuite
+  def warming(*)
+    run_gc
+  end
+
+  def running(*)
+    run_gc
+  end
+
+  def warmup_stats(*)
+  end
+
+  def add_report(*)
+  end
+
+  private
+
+  def run_gc
+    GC.enable
+    GC.start
+    GC.disable
+  end
+end
+
+def bench(target_version, server_port)
+  host = "127.0.0.1"
+  suite = GCSuite.new
+  report_name = "without HEAD"
+
+  if target_version
+    require "semian"
+    require "semian/version"
+    require "semian/net_http"
+    puts "Load Semian #{Semian::VERSION}"
+    report_name = "with #{target_version}"
+
+    if ENV.key?("WITH_CIRCUIT_BREAKER_ENABLED")
+      puts "Enable Circuit breaker for HTTP requests"
+      report_name += "/circuit breaker"
+      Semian::NetHTTP.semian_configuration = {
+        name: "mock_server",
+        circuit_breaker: true,
+        success_threshold: 3,
+        error_threshold: 2,
+        error_timeout: 5,
+        bulkhead: true,
+        tickets: 1,
+      }
+    end
+  end
+
+  Benchmark.ips do |x|
+    x.config(time: 30, warmup: 10, suite: suite)
+
+    x.report(report_name) do
+      Net::HTTP.get_response(host, "/", server_port)
+    end
+
+    x.save!("benchmarks_latency.json")
+    x.compare!
+  end
+
+  # NOTICE: The gem is not working properly with 3.2 - it shows the same numbers!
+  Benchmark.memory do |x|
+    x.report(report_name) do
+      Net::HTTP.get_response(host, "/", server_port)
+    end
+    x.compare!
+    x.hold!("benchmarks_memory.json")
+  end
+end
+
+# Exit
+begin
+  server_port = 2345
+  server_pid = server(server_port)
+  sleep(1)
+  bench(target_version, server_port)
+ensure
+  Process.kill(:TERM, server_pid)
+end


### PR DESCRIPTION
Add function to run benchmark against HTTP requests
for different Semian gem versions and git commits.

Add possibility to generate flamegrpahs:
```
rake flamegraph
```

Run different benchmarks: 

```
rake benchmark
```

Sample charts generated in https://github.com/Shopify/semian/issues/458#issuecomment-1405049992