### PR TITLE
Enable write barrier protection on Resource

### DIFF
--- a/ext/semian/resource.c
+++ b/ext/semian/resource.c
@@ -359,13 +359,13 @@ ms_to_timespec(long ms, struct timespec *ts)
   ts->tv_nsec = (ms % 1000) * 1000000;
 }
 
-static inline void
+static void
 semian_resource_mark(void *ptr)
 {
   /* noop */
 }
 
-static inline void
+static void
 semian_resource_free(void *ptr)
 {
   semian_resource_t *res = (semian_resource_t *) ptr;
@@ -376,7 +376,7 @@ semian_resource_free(void *ptr)
   xfree(res);
 }
 
-static inline size_t
+static size_t
 semian_resource_memsize(const void *ptr)
 {
   return sizeof(semian_resource_t);
@@ -390,5 +390,5 @@ semian_resource_type = {
     semian_resource_free,
     semian_resource_memsize
   },
-  NULL, NULL, RUBY_TYPED_FREE_IMMEDIATELY
+  NULL, NULL, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
 };


### PR DESCRIPTION
Resources are not holding any references to Ruby objects as such they can be marked as WB protected without any change.

This mean the Ruby garbage collect won't have to mark them on minor GC runs if the resource was promoted to oldgen.