### PR TITLE
Make sure AR Trilogy adpater does not modify input

### DIFF
--- a/lib/semian/activerecord_trilogy_adapter.rb
+++ b/lib/semian/activerecord_trilogy_adapter.rb
@@ -33,6 +33,7 @@ module Semian
 
     def initialize(*options)
       *, config = options
+      config = config.dup
       @raw_semian_options = config.delete(:semian)
       @semian_identifier = begin
         name = semian_options && semian_options[:name]

--- a/test/adapters/activerecord_trilogy_adapter_test.rb
+++ b/test/adapters/activerecord_trilogy_adapter_test.rb
@@ -59,6 +59,15 @@ module ActiveRecord
         assert_instance_of(Semian::UnprotectedResource, resource)
       end
 
+      def test_adapter_does_not_modify_config
+        config = @configuration.merge(config_overrides)
+
+        assert(config.key?(:semian))
+        TrilogyAdapter.new(config)
+
+        assert(config.key?(:semian))
+      end
+
       def test_unconfigured
         adapter = trilogy_adapter(
           host: SemianConfig["toxiproxy_upstream_host"],


### PR DESCRIPTION
During working with Trilogy adapter,
found that `semian` key removed from the original Hash. 

Update adapter to use copy of input structure, instead of modify the object it self.

Example how to reproduce the problem:

```ruby
SEMIAN_PARAMETERS = {
  circuit_breaker: true,
  success_threshold: 1,
  error_threshold: 3,
  error_timeout: 3,
  bulkhead: false,
}

configuration = {
  adapter: "trilogy",
  username: "root",
  host: ENV.fetch("MYSQL_HOST", "localhost"),
  port: Integer(ENV.fetch("MYSQL_PORT", 3306)),
  database: "mysql",
  semian: SEMIAN_PARAMETERS,
}

adapter = ActiveRecord::ConnectionAdapters::TrilogyAdapter.new(configuration)
adapter.execute("SELECT 1;")

adapter = ActiveRecord::ConnectionAdapters::TrilogyAdapter.new(configuration)
adapter.execute("SELECT 1;")
# Print in logs that Semian is not configured
```