### PR TITLE
POC for per-request HTTP resource naming

### DIFF
--- a/lib/semian/adapter.rb
+++ b/lib/semian/adapter.rb
@@ -12,7 +12,7 @@ module Semian
       return @semian_resource if @semian_resource
 
       options ||= semian_options
-      name = semian_identifier(options: options)
+      name = semian_identifier
 
       case options
       when false

--- a/lib/semian/net_http.rb
+++ b/lib/semian/net_http.rb
@@ -90,7 +90,8 @@ module Semian
       # $call_count += 1
       # puts "$call_count: #{$call_count}"
       # puts caller[0]
-      raw_semian_options = time("call config block") { Semian::NetHTTP.retrieve_semian_configuration(address, port) }
+      # raw_semian_options = time("call config block") { Semian::NetHTTP.retrieve_semian_configuration(address, port) }
+      raw_semian_options = Semian::NetHTTP.retrieve_semian_configuration(address, port)
       if raw_semian_options
         raw_semian_options = raw_semian_options.dup
 

--- a/lib/semian/net_http.rb
+++ b/lib/semian/net_http.rb
@@ -30,8 +30,8 @@ module Semian
       end
     end
 
-    def semian_identifier(options: raw_semian_options)
-      "nethttp_#{options[:name]}"
+    def semian_identifier
+      "nethttp_#{raw_semian_options[:name]}"
     end
 
     DEFAULT_ERRORS = [

--- a/test/adapters/net_http_test.rb
+++ b/test/adapters/net_http_test.rb
@@ -498,7 +498,7 @@ class TestNetHTTP < Minitest::Test
     mutated_objects = {}
     Semian::NetHTTP.send(:alias_method, :orig_semian_resource, :semian_resource)
     Semian::NetHTTP.send(:alias_method, :orig_raw_semian_options, :raw_semian_options)
-    Semian::NetHTTP.send(:define_method, :semian_resource) do
+    Semian::NetHTTP.send(:define_method, :semian_resource) do |_options = nil|
       mutated_objects[self] = [@semian_resource, @raw_semian_options] unless mutated_objects.key?(self)
       orig_semian_resource
     end


### PR DESCRIPTION
POC for #480

---

A few notes about the POC, in no particular order:

- One of the big issues with the way the code works right now is that in the context of a single request (or a single connection opening), we execute the configuration block multiple times, which is unnecessary. Memoization was given us that "for free", now we'd have to move things around to reach what I'd consider the ideal goal: "a single request/connection => a single execution of the configuration block".
- The whole `deterministic: false` is how I ended up with it, but this is in no way trying to be prescriptive
- I used the `time` method to get a sense of the performance difference of memoization vs no memoization when running the acquire resource method. For my use case where I'm making an API call that will be in the best case scenario in the 50-100ms range, and often slower than 1s, the performance cost of calling a block per request seems to be marginal (~1us vs ~10us on my local machine)

---

TODO list:

- [x] Add tests to show the desired behavior