### PR TITLE
Use 3.2.1 for dev base image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUBY_VERSION=3.2.0
+ARG RUBY_VERSION=3.2.1
 FROM ruby:${RUBY_VERSION} as base
 
 # Avoid warnings by switching to noninteractive

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,6 @@ jobs:
           - "3.2"
           - "3.1"
           - "3.0"
-          - "2.7"
     services:
       mysql:
         image: mysql:5.7
@@ -112,7 +111,6 @@ jobs:
           - "3.2"
           - "3.1"
           - "3.0"
-          - "2.7"
         gemfile:
           - grpc
           - mysql2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,8 +10,10 @@ inherit_gem:
   rubocop-shopify: rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   NewCops: enable
+  UseCache: true
+  CacheRootDirectory: tmp/rubocop
 
 Layout/LineLength:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Drop support of Ruby 2.7. (#???)
+
 # v0.18.0
 
 * Support Active Record Trilogy adapter. (#468)

--- a/dockerfiles/semian-ci
+++ b/dockerfiles/semian-ci
@@ -1,4 +1,4 @@
-ARG RUBY_VERSION=3.2.0
+ARG RUBY_VERSION=3.2.1
 FROM ruby:${RUBY_VERSION} as base
 
 # Avoid warnings by switching to noninteractive


### PR DESCRIPTION
Ruby 2.7 is comming to the end of life on 2023-03-31.
https://www.ruby-lang.org/en/downloads/branches/