### PR TITLE
Fix for Dockerfile smell DL3009

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,7 +18,9 @@ RUN apt-get -o Acquire::Max-FutureTime=86400 update \
       netcat \
       procps \
       xz-utils \
- && gem install bundler rcodetools rubocop ruby-debug-ide fastri
+ && gem install bundler rcodetools rubocop ruby-debug-ide fastri \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt
 RUN git clone --depth 1 https://github.com/brendangregg/FlameGraph


### PR DESCRIPTION
Hi!
The Dockerfile placed at ".devcontainer/Dockerfile" contains the best practice violation [DL3009](https://github.com/hadolint/hadolint/wiki/DL3009) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3009 occurs when the apt tool is used to install packages without wiping the cache and source lists.
This pull request proposes a fix for that smell generated by my fixing tool. The generated patch has been manually verified before opening the pull request.
To fix this smell, specifically, the instructions to clean up the apt cache and remove the /var/lib/apt/lists have been added. This helps keep the image size down.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance