### PR TITLE
Do not require "activerecord-trilogy-adapter"

### DIFF
--- a/lib/semian/activerecord_trilogy_adapter.rb
+++ b/lib/semian/activerecord_trilogy_adapter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "semian/adapter"
-require "activerecord-trilogy-adapter"
+require "active_record"
 require "active_record/connection_adapters/trilogy_adapter"
 
 module ActiveRecord


### PR DESCRIPTION
The gem has been upstreamed to Rails edge, so
"active_record/connection_adapters/trilogy_adapter" might be defined by Rails itself.