### PR TITLE
Also test trilogy adapter through activerecord

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,8 @@ jobs:
           - grpc
           - mysql2
           - net_http
-          - rails
+          - rails_mysql2
+          - rails_trilogy
           - redis_4
           - redis_5
           - redis_client
@@ -129,8 +130,10 @@ jobs:
             adapter: mysql2
           - gemfile: net_http
             adapter: net_http
-          - gemfile: rails
-            adapter: rails
+          - gemfile: rails_mysql2
+            adapter: rails_mysql2
+          - gemfile: rails_trilogy
+            adapter: rails_trilogy
           - gemfile: redis_4
             adapter: redis
           - gemfile: redis_5

--- a/gemfiles/rails_mysql2.gemfile
+++ b/gemfiles/rails_mysql2.gemfile
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "rake"
+gem "rake-compiler"
+gem "minitest"
+gem "mocha"
+gem "toxiproxy"
+gem "webrick"
+
+gem "mysql2", "~> 0.5"
+gem "activerecord", ">= 7.0.3"
+
+gemspec path: "../"

--- a/gemfiles/rails_mysql2.gemfile.lock
+++ b/gemfiles/rails_mysql2.gemfile.lock
@@ -1,0 +1,63 @@
+PATH
+  remote: ..
+  specs:
+    semian (0.18.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (7.0.4.1)
+      activesupport (= 7.0.4.1)
+    activerecord (7.0.4.1)
+      activemodel (= 7.0.4.1)
+      activesupport (= 7.0.4.1)
+    activesupport (7.0.4.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    concurrent-ruby (1.1.10)
+    debug (1.7.2)
+      irb (>= 1.5.0)
+      reline (>= 0.3.1)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
+    io-console (0.6.0)
+    irb (1.6.4)
+      reline (>= 0.3.0)
+    minitest (5.17.0)
+    mocha (2.0.2)
+      ruby2_keywords (>= 0.0.5)
+    mysql2 (0.5.4)
+    rake (13.0.6)
+    rake-compiler (1.2.1)
+      rake
+    reline (0.3.3)
+      io-console (~> 0.5)
+    ruby2_keywords (0.0.5)
+    toxiproxy (2.0.2)
+    tzinfo (2.0.5)
+      concurrent-ruby (~> 1.0)
+    webrick (1.7.0)
+
+PLATFORMS
+  aarch64-linux
+  arm64-darwin-21
+  ruby
+  x86_64-darwin-21
+  x86_64-linux
+
+DEPENDENCIES
+  activerecord (>= 7.0.3)
+  debug
+  minitest
+  mocha
+  mysql2 (~> 0.5)
+  rake
+  rake-compiler
+  semian!
+  toxiproxy
+  webrick
+
+BUNDLED WITH
+   2.4.3

--- a/gemfiles/rails_trilogy.gemfile
+++ b/gemfiles/rails_trilogy.gemfile
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "rake"
+gem "rake-compiler"
+gem "minitest"
+gem "mocha"
+gem "toxiproxy"
+gem "webrick"
+
+gem "trilogy", github: "github/trilogy", branch: "main", glob: "contrib/ruby/*.gemspec"
+# we can share the Gemfile with rails mysql2 once activerecord is released with the trilogy adapter
+gem "activerecord", github: "rails/rails", branch: "main"
+
+gemspec path: "../"

--- a/gemfiles/rails_trilogy.gemfile.lock
+++ b/gemfiles/rails_trilogy.gemfile.lock
@@ -1,23 +1,15 @@
 GIT
-  remote: https://github.com/github/activerecord-trilogy-adapter.git
-  revision: 516c234352388c8b423f9bb50ca4d54bef8f04fa
-  branch: main
-  specs:
-    activerecord-trilogy-adapter (2.1.0)
-      activerecord (~> 7.1.a)
-      trilogy (>= 2.1.1)
-
-GIT
   remote: https://github.com/github/trilogy.git
-  revision: 2dd91e5d1974b29473ad646e5dba0a50562fe37a
+  revision: 6dd14cca18dade150d6573d55496ce7f8b8b45dc
   branch: main
   glob: contrib/ruby/*.gemspec
   specs:
-    trilogy (2.2.0)
+    trilogy (2.4.0)
 
 GIT
   remote: https://github.com/rails/rails.git
-  revision: 6017df6a8e1468eef6432065e7a679f7f203827f
+  revision: eac3208b809c45ace005d1a3e5039c69216ca02f
+  branch: main
   specs:
     activemodel (7.1.0.alpha)
       activesupport (= 7.1.0.alpha)
@@ -39,11 +31,11 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    concurrent-ruby (1.2.0)
-    connection_pool (2.3.0)
-    i18n (1.12.0)
+    concurrent-ruby (1.2.2)
+    connection_pool (2.4.0)
+    i18n (1.13.0)
       concurrent-ruby (~> 1.0)
-    minitest (5.17.0)
+    minitest (5.18.0)
     mocha (2.0.2)
       ruby2_keywords (>= 0.0.5)
     rake (13.0.6)
@@ -56,12 +48,10 @@ GEM
     webrick (1.8.1)
 
 PLATFORMS
-  arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
   activerecord!
-  activerecord-trilogy-adapter!
   minitest
   mocha
   rake
@@ -72,4 +62,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.4.3
+   2.4.12

--- a/test/adapters/rails_mysql2_test.rb
+++ b/test/adapters/rails_mysql2_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "rails_tests"
+require "semian/mysql2"
+
+class TestRailsMysql2 < Minitest::Test
+  include RailsTests
+
+  def setup
+    @adapter = "mysql2"
+    super
+  end
+end

--- a/test/adapters/rails_tests.rb
+++ b/test/adapters/rails_tests.rb
@@ -2,10 +2,9 @@
 
 require "test_helper"
 require "active_record"
-require "semian/mysql2"
 require "semian/rails"
 
-class TestRails < Minitest::Test
+module RailsTests
   SUCCESS_THRESHOLD = 2
   ERROR_THRESHOLD = 1
   ERROR_TIMEOUT = 5
@@ -20,7 +19,7 @@ class TestRails < Minitest::Test
 
   def setup
     @config = {
-      adapter: "mysql2",
+      adapter: @adapter,
       connect_timeout: 2,
       read_timeout: 2,
       write_timeout: 2,

--- a/test/adapters/rails_trilogy_test.rb
+++ b/test/adapters/rails_trilogy_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "rails_tests"
+require "semian/activerecord_trilogy_adapter"
+
+class TestRailsTrilogy < Minitest::Test
+  include RailsTests
+
+  def setup
+    @adapter = "trilogy"
+    super
+  end
+end


### PR DESCRIPTION
Follow-up to #486 

Since the adapter is in Active Record now, we can test Trilogy through Active Record too. So I just extracted the rails tests and used them both for the mysql2 and trilogy adapter.

Actually at first, I thought maybe the `semian/rails` code isn't too related to the specific adapter, so maybe there's no need to test it for each adapter/client semian supports, but then I saw the code from https://github.com/Shopify/semian/pull/395 which is specific to mysql2.

By adding a share test we could see the special case made for Mysql2 and reproduce it for Trilogy, but looking more into it, I don't think it's ever used:

```
>> ActiveRecord::ConnectionAdapters::Mysql2Adapter.method(:new_client)
=> #<Method: ActiveRecord::ConnectionAdapters::Mysql2Adapter.new_client(config) /Users/etienne/.gem/ruby/3.2.2/gems/activerecord-7.0.4.3/lib/active_record/connection_adapters/mysql2_adapter.rb:43>
>> ActiveRecord::ConnectionAdapters::Mysql2Adapter.method(:new_client).super_method
=> #<Method: Semian::Rails::ClassMethods#new_client(config) /Users/etienne/.gem/ruby/3.2.2/gems/semian-0.18.0/lib/semian/rails.rb:13>
```

and `ActiveRecord::ConnectionAdapters::Mysql2Adapter.new_client` doesn't call `super` so those exceptions are never rescued/re-raised.

Anyway, I can look into this later but this may still be worth it. Let me know what you think.