### PR TITLE
Remove Trilogy adapter's async keyword parameter in execute

### DIFF
--- a/lib/semian/activerecord_trilogy_adapter.rb
+++ b/lib/semian/activerecord_trilogy_adapter.rb
@@ -47,15 +47,16 @@ module Semian
       super
     end
 
-    def execute(sql, name = nil, async: false, allow_retry: false)
+    def execute(sql, *)
       if query_allowlisted?(sql)
-        super(sql, name, async: async, allow_retry: allow_retry)
+        super
       else
         acquire_semian_resource(adapter: :trilogy_adapter, scope: :execute) do
-          super(sql, name, async: async, allow_retry: allow_retry)
+          super
         end
       end
     end
+    ruby2_keywords :execute
 
     def active?
       acquire_semian_resource(adapter: :trilogy_adapter, scope: :ping) do


### PR DESCRIPTION
Followup from https://github.com/Shopify/semian/pull/486

From https://github.com/rails/rails/pull/48054, `#execute` removes the support the `async` keyword parameter.