### PR TITLE
Release v0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# v0.19.1
 
 * Active Record Trilogy adapter needs to patch `#raw_execute` instead of `#execute` for queries. (#494)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: .
   specs:
-    semian (0.19.0)
+    semian (0.19.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/semian/version.rb
+++ b/lib/semian/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Semian
-  VERSION = "0.19.0"
+  VERSION = "0.19.1"
 end


### PR DESCRIPTION
Includes https://github.com/Shopify/semian/pull/494

Ensures Semian Trilogy Adapter works correctly with Rails edge.