### PR TITLE
Use ActiveRecord::ConnectionNotEstablished as base error for TrilogyAdapter

### DIFF
--- a/lib/semian/activerecord_trilogy_adapter.rb
+++ b/lib/semian/activerecord_trilogy_adapter.rb
@@ -9,7 +9,7 @@ module ActiveRecord
     class TrilogyAdapter
       ActiveRecord::ActiveRecordError.include(::Semian::AdapterError)
 
-      class SemianError < StatementInvalid
+      class SemianError < ConnectionNotEstablished
         def initialize(semian_identifier, *args)
           super(*args)
           @semian_identifier = semian_identifier


### PR DESCRIPTION
One part of the design of semian is that the exception it raises should ideally be caught by naive `rescue SomeClient::BaseConnectionError`.

The reason is that semian raise a fast error when it thinks it's likely using the resource right now would lead to a slow network error of some kind.

FYI: @adrianna-chang-shopify (for when you get back from 🌴), @eileencodes, @pegelston 

Note:

I see `acquire_semian_resource` does:

```ruby
    rescue ActiveRecord::StatementInvalid => error
      if error.cause.is_a?(Trilogy::TimeoutError)
```

Which may indicate that the upstream adapter is also not properly translating the client timeout into a proper network related error (`StatementInvalid` being the kitchen sink). I'll have a check upstream as well.