### PR TITLE
AR Trilogy Adapter: Handle AdapterTimeout and ConnectionFailed errs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Ensure Active Record Trilogy adapter handles AdapterTimeout and ConnectionFailed exceptions. (#497)
+
 # v0.19.1
 
 * Active Record Trilogy adapter needs to patch `#raw_execute` instead of `#execute` for queries. (#494)

--- a/gemfiles/activerecord_trilogy_adapter.gemfile.lock
+++ b/gemfiles/activerecord_trilogy_adapter.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rails/rails.git
-  revision: d12f1a2f84128085ee0bdbbbe28df9ec27a9bc64
+  revision: 4e71edfca8525417597b079440d876310dd6290d
   specs:
     activemodel (7.1.0.alpha)
       activesupport (= 7.1.0.alpha)
@@ -17,13 +17,13 @@ GIT
 PATH
   remote: ..
   specs:
-    semian (0.19.0)
+    semian (0.19.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     concurrent-ruby (1.2.2)
-    connection_pool (2.4.0)
+    connection_pool (2.4.1)
     i18n (1.13.0)
       concurrent-ruby (~> 1.0)
     minitest (5.18.0)

--- a/lib/semian/activerecord_trilogy_adapter.rb
+++ b/lib/semian/activerecord_trilogy_adapter.rb
@@ -82,18 +82,12 @@ module Semian
 
     private
 
-    def acquire_semian_resource(**)
-      super
-    rescue ActiveRecord::StatementInvalid => error
-      if error.cause.is_a?(Trilogy::TimeoutError)
-        semian_resource.mark_failed(error)
-        error.semian_identifier = semian_identifier
-      end
-      raise
-    end
-
     def resource_exceptions
-      [ActiveRecord::ConnectionNotEstablished]
+      [
+        ActiveRecord::AdapterTimeout,
+        ActiveRecord::ConnectionFailed,
+        ActiveRecord::ConnectionNotEstablished,
+      ]
     end
 
     # TODO: share this with Mysql2

--- a/test/adapters/activerecord_trilogy_adapter_test.rb
+++ b/test/adapters/activerecord_trilogy_adapter_test.rb
@@ -196,6 +196,16 @@ module ActiveRecord
         end
       end
 
+      def test_connection_failed_errors_are_tagged_with_the_resource_identifier
+        @adapter.send(:raw_connection).close
+
+        error = assert_raises(ActiveRecord::ConnectionFailed) do
+          @adapter.execute("SELECT 1 + 1;")
+        end
+
+        assert_equal(@adapter.semian_identifier, error.semian_identifier)
+      end
+
       def test_other_mysql_errors_are_not_tagged_with_the_resource_identifier
         error = assert_raises(ActiveRecord::StatementInvalid) do
           @adapter.execute("SYNTAX ERROR!")


### PR DESCRIPTION
See https://github.com/Shopify/semian/pull/497

This PR ensures that `ActiveRecord::AdapterTimeout` errors are handled for the AR Trilogy Adapter. As of https://github.com/rails/rails/pull/48272/commits/785f65680b55a33e02cd5614e709b99b1fe6218b, TimeoutErrors are translated to AdapterTimeout errors in Rails. As such, we no longer need special handling in `#acquire_semian_resource` for such errors.

This commit also ensures that ActiveRecord::ConnectionFailed errors are classified as resource exceptions. These are network-related exceptions and should be handled by Semian. I've added a corresponding test.

cc @casperisfine @etiennebarrie 