### PR TITLE
Allow passing --with-openssl-dir for a custom OpenSSL installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Ensure Active Record Trilogy adapter handles AdapterTimeout and ConnectionFailed exceptions. (#497)
+* Allow passing --with-openssl-dir for a custom OpenSSL installation. (#499)
 
 # v0.19.1
 

--- a/ext/semian/extconf.rb
+++ b/ext/semian/extconf.rb
@@ -15,6 +15,8 @@ end
 
 require "mkmf"
 
+dir_config("openssl")
+
 abort "openssl is missing. please install openssl." unless find_header("openssl/sha.h")
 abort "openssl is missing. please install openssl." unless find_library("crypto", "SHA1")
 


### PR DESCRIPTION
OpenSSL isn't located on standard paths on my Linux machine and thus I can't get Semian gem to install.

Before the flag
```
❯ ruby ext/semian/extconf.rb
checking for openssl/sha.h... no
openssl is missing. please install openssl.
*** ext/semian/extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
        --with-opt-dir
        --without-opt-dir
        --with-opt-include
        --without-opt-include=${opt-dir}/include
        --with-opt-lib
        --without-opt-lib=${opt-dir}/lib
        --with-make-prog
        --without-make-prog
        --srcdir=ext/semian
        --curdir
        --ruby=/nix/store/3ay21xsh45kjqfpsan7xmnf3mbng29d7-ruby-3.0.2/bin/$(RUBY_BASE_NAME)
```

After the flag
```
❯ ruby ext/semian/extconf.rb --with-openssl-dir=$(readlink -f result)
checking for openssl/sha.h... yes
checking for SHA1() in -lcrypto... yes
checking for sys/ipc.h... yes
checking for sys/sem.h... yes
checking for sys/types.h... yes
checking for rb_thread_blocking_region()... no
checking for rb_thread_call_without_gvl()... yes
creating Makefile
```