### PR TITLE
Richer error handling when a semaphore array has been deleted:

### DIFF
--- a/ext/semian/resource.c
+++ b/ext/semian/resource.c
@@ -63,6 +63,8 @@ semian_resource_acquire(int argc, VALUE *argv, VALUE self)
   if (res.error != 0) {
     if (res.error == EAGAIN) {
       rb_raise(eTimeout, "timed out waiting for resource '%s'", res.name);
+    } else if (res.error == EINVAL && get_semaphore(res.sem_id) == -1 && errno == ENOENT) {
+      rb_raise(eSemaphoreMissing, "semaphore array '%s' no longer exists", res.name);
     } else {
       raise_semian_syscall_error("semop()", res.error);
     }

--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -1,6 +1,6 @@
 #include "semian.h"
 
-VALUE eSyscall, eTimeout, eInternal;
+VALUE eSyscall, eTimeout, eInternal, eSemaphoreMissing;
 
 void Init_semian()
 {
@@ -45,6 +45,17 @@ void Init_semian()
    */
   eInternal = rb_const_get(cSemian, rb_intern("InternalError"));
   rb_global_variable(&eInternal);
+
+  /* Document-class: Semian::SemaphoreMissingError
+   *
+   * Indicates that some time after initialization, a semaphore array was no longer
+   * present when we tried to access it. This can happen because semaphores were
+   * deleted using the <code>ipcrm</code> command line tool, the
+   * <code>semctl(..., IPC_RMID)</code> syscall, or systemd's <code>RemoveIPC</code>
+   * feature.
+   */
+  eSemaphoreMissing = rb_const_get(cSemian, rb_intern("SemaphoreMissingError"));
+  rb_global_variable(&eSemaphoreMissing);
 
   rb_define_alloc_func(cResource, semian_resource_alloc);
   rb_define_method(cResource, "initialize_semaphore", semian_resource_initialize, 5);

--- a/ext/semian/sysv_semaphores.h
+++ b/ext/semian/sysv_semaphores.h
@@ -66,7 +66,7 @@ enum SEMINDEX_ENUM {
     FOREACH_SEMINDEX(GENERATE_ENUM)
 };
 
-extern VALUE eSyscall, eTimeout, eInternal;
+extern VALUE eSyscall, eTimeout, eInternal, eSemaphoreMissing;
 
 // Helper for syscall verbose debugging
 void

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -100,6 +100,7 @@ module Semian
   TimeoutError = Class.new(BaseError)
   InternalError = Class.new(BaseError)
   OpenCircuitError = Class.new(BaseError)
+  SemaphoreMissingError = Class.new(BaseError)
 
   attr_accessor :maximum_lru_size, :minimum_lru_time, :default_permissions, :namespace
 

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -407,11 +407,11 @@ class TestResource < Minitest::Test
   def test_destroy
     resource = create_resource(:testing, tickets: 1)
     resource.destroy
-    exception = assert_raises(Semian::SyscallError) do
+    exception = assert_raises(Semian::SemaphoreMissingError) do
       resource.acquire {}
     end
 
-    assert_equal("semop() failed, errno: 22 (Invalid argument)", exception.message)
+    assert_equal("semaphore array 'testing' no longer exists", exception.message)
   end
 
   def test_destroy_already_destroyed


### PR DESCRIPTION
I just spent some time troubleshooting an issue where systemd was deleting my semaphores as a result of logind.conf having RemoveIPC=yes by default.

This will:

1. Make the error slightly easier to diagnose when it shows up in logs;
2. Provide an easier handle for an application to detect and heal.