### PR TITLE
Create a more efficient regex

### DIFF
--- a/lib/semian/activerecord_trilogy_adapter.rb
+++ b/lib/semian/activerecord_trilogy_adapter.rb
@@ -91,11 +91,7 @@ module Semian
     end
 
     # TODO: share this with Mysql2
-    QUERY_ALLOWLIST = Regexp.union(
-      %r{\A(?:/\*.*?\*/)?\s*ROLLBACK}i,
-      %r{\A(?:/\*.*?\*/)?\s*COMMIT}i,
-      %r{\A(?:/\*.*?\*/)?\s*RELEASE\s+SAVEPOINT}i,
-    )
+    QUERY_ALLOWLIST = %r{\A(?:/\*.*?\*/)?\s*(ROLLBACK|COMMIT|RELEASE\s+SAVEPOINT)}i
 
     def query_allowlisted?(sql, *)
       QUERY_ALLOWLIST.match?(sql)


### PR DESCRIPTION
```
require 'benchmark'

# Original regular expressions
original = Regexp.union(
  %r{\A(?:/\*.*?\*/)?\s*ROLLBACK}i,
  %r{\A(?:/\*.*?\*/)?\s*COMMIT}i,
  %r{\A(?:/\*.*?\*/)?\s*RELEASE\s+SAVEPOINT}i,
)

# Combined regular expression
combined = %r{\A(?:/\*.*?\*/)?\s*(ROLLBACK|COMMIT|RELEASE\s+SAVEPOINT)}i

# Test string
sql = "/* comment */ COMMIT"

n = 1_000_000
Benchmark.bm do |x|
  x.report("original:") { n.times { original.match?(sql) } }
  x.report("combined:") { n.times { combined.match?(sql) } }
end
```

![image](https://github.com/Shopify/semian/assets/9895648/340a1f9f-0026-4cee-a499-5239f2e8ca29)

More complicated benchmark:
![image](https://github.com/Shopify/semian/assets/9895648/4dd6c1cc-ea99-44d9-ba3b-f399ee80de89)

