### PR TITLE
Return early from allow list when possible

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,8 @@ inherit_gem:
 AllCops:
   TargetRubyVersion: 2.7
   NewCops: enable
+  Exclude:
+    - test/allow_list_bench.rb
 
 Layout/LineLength:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "rake-compiler"
 
 group :test do
   gem "benchmark-memory"
+  gem "benchmark-ips"
   gem "memory_profiler"
   gem "minitest"
   gem "mocha"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    benchmark-ips (2.13.0)
     benchmark-memory (0.2.0)
       memory_profiler (~> 1)
     byebug (11.1.3)
@@ -112,6 +113,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord!
+  benchmark-ips
   benchmark-memory
   grpc (= 1.47.0)
   hiredis (~> 0.6)

--- a/lib/semian/activerecord_trilogy_adapter.rb
+++ b/lib/semian/activerecord_trilogy_adapter.rb
@@ -42,9 +42,12 @@ module Semian
     # control statements.
     class << self
       def query_allowlisted?(sql, *)
-        tx_command_statement = sql.end_with?("T") || sql.end_with?("K") # COMMIT, ROLLBACK
-        savepoint_statement = sql.end_with?("_1") || sql.end_with?("_2") # RELEASE SAVEPOINT. Nesting past _3 levels won't get bypassed.
+        # COMMIT, ROLLBACK
+        tx_command_statement = sql.end_with?("T") || sql.end_with?("K")
+
+        # RELEASE SAVEPOINT. Nesting past _3 levels won't get bypassed.
         # Active Record does not send trailing spaces or `;`, so we are in the realm of hand crafted queries here.
+        savepoint_statement = sql.end_with?("_1") || sql.end_with?("_2")
         unclear = sql.end_with?(" ") || sql.end_with?(";")
 
         if !tx_command_statement && !savepoint_statement && !unclear

--- a/lib/semian/activerecord_trilogy_adapter.rb
+++ b/lib/semian/activerecord_trilogy_adapter.rb
@@ -45,7 +45,14 @@ module Semian
     # this method to be ~20x faster in the common case vs matching the full regular expression
     class << self
       def query_allowlisted?(sql, *)
-        if !sql.end_with?("T") && !sql.end_with?("K") && !sql.end_with?("_1") && !sql.end_with?("_2")
+        # Any nesting pass _3 levels is won't get bypassed. I think that is fine once
+        # you are 3 level deep in nested transactions you have bigger problems.
+        unlikely_to_be_tx_control_statement = !sql.end_with?("T") && !sql.end_with?("K") && !sql.end_with?("_1")\
+        && !sql.end_with?("_2")
+        # ActiveRecord does not send trailing spaces of ; we are in the realm of hand crafted queries here
+        unclear = sql.end_with?(" ") || sql.end_with?(";")
+
+        if unlikely_to_be_tx_control_statement && !unclear
           false
         else
           QUERY_ALLOWLIST.match?(sql)

--- a/lib/semian/activerecord_trilogy_adapter.rb
+++ b/lib/semian/activerecord_trilogy_adapter.rb
@@ -32,17 +32,14 @@ module Semian
     QUERY_ALLOWLIST = %r{\A(?:/\*.*?\*/)?\s*(ROLLBACK|COMMIT|RELEASE\s+SAVEPOINT)}i
 
     # The common case here is NOT to have transaction management statements, therefore
-    # we are exploiting the fact that ActiveRecord will use COMMIT/ROLLBACK as
+    # we are exploiting the fact that Active Record will use COMMIT/ROLLBACK as
     # the suffix of the command string and
     # name savepoints by level of nesting as `active_record_1` ... n.
     #
-    # Since looking at the last characters in a sring using `end_with?` is a LOT cheaper than
+    # Since looking at the last characters in a string using `end_with?` is a LOT cheaper than
     # running a regex, we are returning early if the last characters of
     # the SQL statements are NOT the last characters of the known transaction
-    # control statements
-    #
-    # Running `test/alllow_list_bench.rb` as of now (Dec 2023 using ruby 3.1) shows
-    # this method to be ~20x faster in the common case vs matching the full regular expression
+    # control statements.
     class << self
       def query_allowlisted?(sql, *)
         # Any nesting pass _3 levels is won't get bypassed. I think that is fine once

--- a/test/adapters/activerecord_trilogy_adapter_test.rb
+++ b/test/adapters/activerecord_trilogy_adapter_test.rb
@@ -329,26 +329,25 @@ module ActiveRecord
       def test_query_allowlisted_returns_false_for_binary_sql
         binary_query = File.read(File.expand_path("../../fixtures/binary.sql", __FILE__))
 
-        refute(@adapter.send(:query_allowlisted?, binary_query))
+        refute(Semian::ActiveRecordTrilogyAdapter.query_allowlisted?(binary_query))
       end
 
-      def test_semian_allows_rollback_to_safepoint
+      def test_semian_allows_release_savepoint
         @adapter.execute("START TRANSACTION;")
-        @adapter.execute("SAVEPOINT foobar;")
 
         Semian[:mysql_testing].acquire do
-          @adapter.execute("ROLLBACK TO foobar;")
+          @adapter.execute("RELEASE SAVEPOINT active_record_99;")
         end
 
         @adapter.execute("ROLLBACK;")
       end
 
-      def test_semian_allows_release_savepoint
+      def test_semian_allows_rollback_to_savepoint
         @adapter.execute("START TRANSACTION;")
-        @adapter.execute("SAVEPOINT foobar;")
+        @adapter.execute("SAVEPOINT active_record_99;")
 
         Semian[:mysql_testing].acquire do
-          @adapter.execute("RELEASE SAVEPOINT foobar;")
+          @adapter.execute("ROLLBACK TO SAVEPOINT active_record_99;")
         end
 
         @adapter.execute("ROLLBACK;")

--- a/test/adapters/activerecord_trilogy_adapter_test.rb
+++ b/test/adapters/activerecord_trilogy_adapter_test.rb
@@ -306,7 +306,7 @@ module ActiveRecord
         @adapter.execute("START TRANSACTION;")
 
         Semian[:mysql_testing].acquire do
-          @adapter.execute("ROLLBACK;")
+          @adapter.execute("ROLLBACK")
         end
       end
 
@@ -314,7 +314,7 @@ module ActiveRecord
         @adapter.execute("START TRANSACTION;")
 
         Semian[:mysql_testing].acquire do
-          @adapter.execute("/*foo:bar*/ ROLLBACK;")
+          @adapter.execute("/*foo:bar*/ ROLLBACK")
         end
       end
 
@@ -322,7 +322,7 @@ module ActiveRecord
         @adapter.execute("START TRANSACTION;")
 
         Semian[:mysql_testing].acquire do
-          @adapter.execute("COMMIT;")
+          @adapter.execute("COMMIT")
         end
       end
 
@@ -334,9 +334,10 @@ module ActiveRecord
 
       def test_semian_allows_release_savepoint
         @adapter.execute("START TRANSACTION;")
+        @adapter.execute("SAVEPOINT active_record_2;")
 
         Semian[:mysql_testing].acquire do
-          @adapter.execute("RELEASE SAVEPOINT active_record_99;")
+          @adapter.execute("RELEASE SAVEPOINT active_record_2")
         end
 
         @adapter.execute("ROLLBACK;")
@@ -344,13 +345,13 @@ module ActiveRecord
 
       def test_semian_allows_rollback_to_savepoint
         @adapter.execute("START TRANSACTION;")
-        @adapter.execute("SAVEPOINT active_record_99;")
+        @adapter.execute("SAVEPOINT active_record_1;")
 
         Semian[:mysql_testing].acquire do
-          @adapter.execute("ROLLBACK TO SAVEPOINT active_record_99;")
+          @adapter.execute("ROLLBACK TO SAVEPOINT active_record_1")
         end
 
-        @adapter.execute("ROLLBACK;")
+        @adapter.execute("ROLLBACK")
       end
 
       def test_changes_timeout_when_half_open_and_configured

--- a/test/allow_list_bench.rb
+++ b/test/allow_list_bench.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "semian"
+require "active_record"
+require "semian/activerecord_trilogy_adapter"
+require "benchmark/ips"
+
+# sql_commit = "/*key:value,key:morevalue,morekey:morevalue,id:IDIDIDIDI,anotherkey:anothervalue,k:v,k:v*/ COMMIT"
+
+# Common case
+sql_not_commit = "/*key:value,key:morevalue,morekey:morevalue,id:IDIDIDIDID,anotherkey:anothervalue,k:v,k:v*/ SELECT /*+ 1111111111111111111111111*/ `line_items`.`id`, `line_items`.`shop_id`, `line_items`.`title`, `line_items`.`sku`, `line_items`.`vendor`,`line_items`.`variant_id`, `line_items`.`variant_title`, `line_items`.`order_id`, `line_items`.`currency`, `line_items`.`presentment_price`, `line_items`.`price`, `line_items`.`gift_card` FROM `line_items` WHERE `line_items`.`id` = ASKJAKJSDASDKJ"
+
+Benchmark.ips do |x|
+  x.report("end-with-case?") do
+    Semian::ActiveRecordTrilogyAdapter.query_allowlisted?(sql_not_commit)
+  end
+
+  x.report("regex") { Semian::ActiveRecordTrilogyAdapter::QUERY_ALLOWLIST.match?(sql_not_commit) }
+  x.compare!
+end


### PR DESCRIPTION
# What is this?

## Behaviour change: 

Savepoints that don't follow the activerecord pattern `active_record_savepoint_#{nesting_level}` or that are nested more than two levels are not going to bypass the circuit anymore.

I think this is okay because in the end this is a  best effort scenario on an overloaded database and this IS an active record adapter. 



In the trilogy adapter. 

We look at every single query to see wether or not it should be allowed to  pass thru the circuit if it happens to be a transaction control statement, (COMMIT/ROLLBACK/RELEASE SAVEPOINT) because we want to try our hardest to make sure we don't pile open transactions onto MySQL even if the underlying database is overloaded.

Large queries, including queries with long comments (often the case when using marginalia to pass metadata around) will in aggregate use quite a bit of CPU just running regular expressions.

We can exploit the fact that active record trilogy uses a set pattern for savepoint  names  (`active_record_#{nesting_level}" )  and uses ROLLBACK and COMMIT without any extra characters in the end of the statement to simply return early in most queries by inspecting the last few characters.

FWIW

```
ruby 3.1.4p223 (2023-03-30 revision 2ec786f0d7) [x86_64-linux]
Warming up --------------------------------------
      end-with-case?   356.147k i/100ms
               regex    20.823k i/100ms
Calculating -------------------------------------
      end-with-case?      3.523M (± 1.9%) i/s -     17.807M in   5.056666s
               regex    206.105k (± 1.2%) i/s -      1.041M in   5.052247s

Comparison:
      end-with-case?:  3522827.5 i/s
               regex:   206105.0 i/s - 17.09x  slower

```