### PR TITLE
Fix valid_raw_connection check

### DIFF
--- a/lib/semian/rails.rb
+++ b/lib/semian/rails.rb
@@ -39,7 +39,7 @@ module Semian
     #   - @raw_connection is for 7.0.x
     #   - @connection is for versions below 6.1.x and below
     def client_connection
-      if respond_to?(:valid_raw_connection)
+      if respond_to?(:valid_raw_connection, true)
         valid_raw_connection
       elsif instance_variable_defined?(:@raw_connection)
         @raw_connection


### PR DESCRIPTION
When upgrading to Rails 7.1, I observed that the client_connection was `nil` sometimes. It was found out that this is caused by `@raw_connection` being used instead of `valid_raw_connection`. We are using `respond_to?` without a second parameter but the method `valid_raw_connection` is private.

```ruby
pry(#<ActiveRecord::ConnectionAdapters::VitessMysql2Adapter>)> self.class
=> ActiveRecord::ConnectionAdapters::VitessMysql2Adapter
pry(#<ActiveRecord::ConnectionAdapters::VitessMysql2Adapter>)> ::Rails.version
=> "7.1.2"
pry(#<ActiveRecord::ConnectionAdapters::VitessMysql2Adapter>)> respond_to?(:valid_raw_connection)
=> false
pry(#<ActiveRecord::ConnectionAdapters::VitessMysql2Adapter>)> respond_to?(:valid_raw_connection, true)
=> true
```