### PR TITLE
Fix: Trilogy ActiveRecord adapter to be compatible with latest Rails edge.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,3 +54,6 @@ Style/SingleLineMethods:
 
 Style/SpecialGlobalVars:
   Enabled: false
+
+Minitest/AssertInDelta:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix: Trilogy ActiveRecord adapter to be compatible with latest Rails edge.
+
 # v0.21.2
 * Change: Trilogy ActiveRecord adapter will not bypass "SAVEPOINT RELEASE" unless it uses the ActiveRecord default name and only 2 levels of nesting
 * Change: The bypass for COMMIT/ROLLBACK statements assumes current ActiveRecord behaviour, that is no blank spaces or ";" chracter at the end of the statement

--- a/lib/semian/activerecord_trilogy_adapter.rb
+++ b/lib/semian/activerecord_trilogy_adapter.rb
@@ -100,17 +100,17 @@ module Semian
     end
 
     def with_resource_timeout(temp_timeout)
-      if connection.nil?
+      if @raw_connection.nil?
         prev_read_timeout = @config[:read_timeout] || 0
         @config.merge!(read_timeout: temp_timeout) # Create new client with temp_timeout for read timeout
       else
-        prev_read_timeout = connection.read_timeout
-        connection.read_timeout = temp_timeout
+        prev_read_timeout = @raw_connection.read_timeout
+        @raw_connection.read_timeout = temp_timeout
       end
       yield
     ensure
       @config.merge!(read_timeout: prev_read_timeout)
-      connection&.read_timeout = prev_read_timeout
+      @raw_connection&.read_timeout = prev_read_timeout
     end
 
     private

--- a/test/adapters/activerecord_trilogy_adapter_test.rb
+++ b/test/adapters/activerecord_trilogy_adapter_test.rb
@@ -417,6 +417,14 @@ module ActiveRecord
         end
       end
 
+      def test_with_resource_timeout
+        assert_equal(2.0, @adapter.raw_connection.read_timeout)
+        @adapter.with_resource_timeout(0.5) do
+          assert_equal(0.5, @adapter.raw_connection.read_timeout)
+        end
+        assert_equal(2.0, @adapter.raw_connection.read_timeout)
+      end
+
       private
 
       def trilogy_adapter(**config_overrides)


### PR DESCRIPTION
The `connection` method was removed in https://github.com/rails/rails/commit/6f3b46b02d190b18747a27772b0511dab71c8315