### PR TITLE
trigger semians when mysql connections are exhausted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Change: semians will trigger on ER_PROXYSQL_MAX_CONN_TIMEOUT (#520)
+
 # v0.21.3
 
 * Fix: Trilogy ActiveRecord adapter to be compatible with latest Rails edge.

--- a/lib/semian/mysql2.rb
+++ b/lib/semian/mysql2.rb
@@ -28,6 +28,8 @@ module Semian
       /Too many connections/i,
       /closed MySQL connection/i,
       /Timeout waiting for a response/i,
+      /No matching servers with free connections/i,
+      /Max connect timeout reached while reaching hostgroup/i,
     )
 
     ResourceBusyError = ::Mysql2::ResourceBusyError


### PR DESCRIPTION
# Problem
- https://github.com/Shopify/resiliency/issues/3354
- https://github.com/sysown/proxysql/blob/v2.x/include/proxysql_structs.h#L455 is not currently picked up as a semian-able error
- [relevant exception in bugsnag](https://app.bugsnag.com/shopify/shopify-production/errors/654110aef7394c0008c66977?filters[event.since]=all&event_id=661939e500e6e05dab5c0000)

# Solution
- update the regex array for connection errors to catch E9001