### PR TITLE
Re-enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,12 @@
+---
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: "/"
+    directory: /
     schedule:
       interval: daily
   - package-ecosystem: bundler
-    directory: "/"
+    directory: /
     schedule:
       interval: daily
     open-pull-requests-limit: 100

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,12 @@
----
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: /
+    directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 100
+    insecure-external-code-execution: allow


### PR DESCRIPTION
Dependabot was disabled in 2022 alongside [another PR](https://github.com/Shopify/semian/pull/460). We'd like to get it back in working order to keep our dependencies up-to-date.