### PR TITLE
Minor fixes to example docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,14 +270,14 @@ SEMIAN_PARAMETERS = {
   dynamic: true,
 }
 
-class CurrentSemianSubResource < ActiveSupport::Attributes
+class CurrentSemianSubResource < ActiveSupport::CurrentAttributes
  attribute :name
 end
 
 Semian::NetHTTP.semian_configuration = proc do |host, port|
   name = "#{host}_#{port}"
   if (sub_resource_name = CurrentSemianSubResource.name)
-    name << "_#{name}"
+    name << "_#{sub_resource_name}"
   end
   SEMIAN_PARAMETERS.merge(name: name)
 end

--- a/README.md
+++ b/README.md
@@ -271,22 +271,22 @@ SEMIAN_PARAMETERS = {
 }
 
 class CurrentSemianSubResource < ActiveSupport::CurrentAttributes
- attribute :name
+ attribute :sub_name
 end
 
 Semian::NetHTTP.semian_configuration = proc do |host, port|
   name = "#{host}_#{port}"
-  if (sub_resource_name = CurrentSemianSubResource.name)
+  if (sub_resource_name = CurrentSemianSubResource.sub_name)
     name << "_#{sub_resource_name}"
   end
   SEMIAN_PARAMETERS.merge(name: name)
 end
 
 # Two requests to example.com can use two different semian resources,
-# as long as `CurrentSemianSubResource.name` is set accordingly:
-# CurrentSemianSubResource.set(name: "sub_resource_1") { Net::HTTP.get_response(URI("http://example.com")) }
+# as long as `CurrentSemianSubResource.sub_name` is set accordingly:
+# CurrentSemianSubResource.set(sub_name: "sub_resource_1") { Net::HTTP.get_response(URI("http://example.com")) }
 # and:
-# CurrentSemianSubResource.set(name: "sub_resource_2") { Net::HTTP.get_response(URI("http://example.com")) }
+# CurrentSemianSubResource.set(sub_name: "sub_resource_2") { Net::HTTP.get_response(URI("http://example.com")) }
 ```
 
 For most purposes, `"#{host}_#{port}"` is a good default `name`. Custom `name` formats


### PR DESCRIPTION
A couple of minor mistakes I found in the docs when working through an implementation of dynamic sub resources.

1. `ActiveSupport::CurrentAttributes` is the correct class [docs](https://api.rubyonrails.org/classes/ActiveSupport/CurrentAttributes.html) [[code](https://github.com/Shopify/semian/pull/547/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L273)]
2. `sub_resourece_name` was assigned but then `name` was shoveled incorrectly [[code](https://github.com/Shopify/semian/pull/547/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L280)]
3. Using `attribute :name` will result in infinite recursion, presumably due to it trying to override the `.name` class method [[code](https://github.com/Shopify/semian/pull/547/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L274)]