### PR TITLE
Avoid method redefinition warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,4 +144,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.4.21
+   2.5.16

--- a/lib/semian/protected_resource.rb
+++ b/lib/semian/protected_resource.rb
@@ -4,7 +4,7 @@ module Semian
   class ProtectedResource
     extend Forwardable
 
-    def_delegators :@bulkhead, :destroy, :count, :semid, :tickets, :registered_workers
+    def_delegators :@bulkhead, :count, :semid, :tickets, :registered_workers
     def_delegators :@circuit_breaker,
       :reset,
       :mark_failed,

--- a/lib/semian/resource.rb
+++ b/lib/semian/resource.rb
@@ -9,6 +9,12 @@ module Semian
       def instance(name, **kwargs)
         Semian.resources[name] ||= ProtectedResource.new(name, new(name, **kwargs), nil)
       end
+
+      private
+
+      def redefinable(method_name)
+        alias_method(method_name, method_name) # Silence method redefinition warnings
+      end
     end
 
     def initialize(name, tickets: nil, quota: nil, permissions: Semian.default_permissions, timeout: 0)
@@ -26,41 +32,41 @@ module Semian
       @name = name
     end
 
-    def reset_registered_workers!
+    redefinable def reset_registered_workers!
     end
 
-    def destroy
+    redefinable def destroy
     end
 
-    def unregister_worker
+    redefinable def unregister_worker
     end
 
-    def acquire(*)
+    redefinable def acquire(*)
       wait_time = 0
       yield wait_time
     end
 
-    def count
+    redefinable def count
       0
     end
 
-    def tickets
+    redefinable def tickets
       0
     end
 
-    def registered_workers
+    redefinable def registered_workers
       0
     end
 
-    def semid
+    redefinable def semid
       0
     end
 
-    def key
+    redefinable def key
       "0x00000000"
     end
 
-    def in_use?
+    redefinable def in_use?
       false
     end
   end

--- a/test/adapters/net_http_test.rb
+++ b/test/adapters/net_http_test.rb
@@ -525,13 +525,17 @@ class TestNetHTTP < Minitest::Test
     orig_semian_options = Semian::NetHTTP.semian_configuration
     Semian::NetHTTP.instance_variable_set(:@semian_configuration, nil)
     mutated_objects = {}
-    Semian::NetHTTP.send(:alias_method, :orig_semian_resource, :semian_resource)
-    Semian::NetHTTP.send(:alias_method, :orig_raw_semian_options, :raw_semian_options)
-    Semian::NetHTTP.send(:define_method, :semian_resource) do
+    Semian::NetHTTP.alias_method(:orig_semian_resource, :semian_resource)
+    Semian::NetHTTP.alias_method(:orig_raw_semian_options, :raw_semian_options)
+
+    Semian::NetHTTP.alias_method(:semian_resource, :semian_resource) # Silence redefinition warnings
+    Semian::NetHTTP.define_method(:semian_resource) do
       mutated_objects[self] = [@semian_resource, @raw_semian_options] unless mutated_objects.key?(self)
       orig_semian_resource
     end
-    Semian::NetHTTP.send(:define_method, :raw_semian_options) do
+
+    Semian::NetHTTP.alias_method(:raw_semian_options, :raw_semian_options) # Silence redefinition warnings
+    Semian::NetHTTP.define_method(:raw_semian_options) do
       mutated_objects[self] = [@semian_resource, @raw_semian_options] unless mutated_objects.key?(self)
       orig_raw_semian_options
     end
@@ -541,9 +545,14 @@ class TestNetHTTP < Minitest::Test
   ensure
     Semian::NetHTTP.instance_variable_set(:@semian_configuration, nil)
     Semian::NetHTTP.semian_configuration = orig_semian_options
-    Semian::NetHTTP.send(:alias_method, :semian_resource, :orig_semian_resource)
-    Semian::NetHTTP.send(:alias_method, :raw_semian_options, :orig_raw_semian_options)
-    Semian::NetHTTP.send(:undef_method, :orig_semian_resource, :orig_raw_semian_options)
+
+    Semian::NetHTTP.alias_method(:semian_resource, :semian_resource) # Silence redefinition warnings
+    Semian::NetHTTP.alias_method(:semian_resource, :orig_semian_resource)
+
+    Semian::NetHTTP.alias_method(:raw_semian_options, :raw_semian_options) # Silence redefinition warnings
+    Semian::NetHTTP.alias_method(:raw_semian_options, :orig_raw_semian_options)
+
+    Semian::NetHTTP.undef_method(:orig_semian_resource, :orig_raw_semian_options)
     mutated_objects.each do |instance, (res, opt)| # Sadly, only way to fully restore cached properties
       instance.instance_variable_set(:@semian_resource, res)
       instance.instance_variable_set(:@raw_semian_options, opt)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ require "rubygems"
 require "bundler/setup"
 
 require "minitest/autorun"
+$VERBOSE = true
 require "semian"
 require "toxiproxy"
 require "tempfile"


### PR DESCRIPTION
Ruby warnings often point to mistakes so it's a good idea to enable them in the test suite.