### PR TITLE
Explicit support for acquire_semaphore/release_semaphore in semian resources

### DIFF
--- a/ext/semian/resource.h
+++ b/ext/semian/resource.h
@@ -33,9 +33,38 @@ semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VAL
  *
  * If no timeout argument is provided, the default timeout passed to Semian.register will be used.
  *
+ * The given block is executed with the semaphore held and, when the block
+ * exits, the semaphore is automatically released.
  */
 VALUE
 semian_resource_acquire(int argc, VALUE *argv, VALUE self);
+
+/*
+ * call-seq:
+ *    resource.acquire_semaphore(timeout: default_timeout) -> wait_time
+ *
+ * Acquires a resource. The call will block for <code>timeout</code> seconds if a ticket
+ * is not available. If no ticket is available within the timeout period, Semian::TimeoutError
+ * will be raised.
+ *
+ * If no timeout argument is provided, the default timeout passed to Semian.register will be used.
+ *
+ * Note: The caller is responsible for releasing the semaphore when done by calling release_semaphore.
+ */
+VALUE
+semian_resource_acquire_semaphore(int argc, VALUE *argv, VALUE self);
+
+/*
+ * call-seq:
+ *    resource.release_semaphore() -> nil
+ *
+ * Releases a resource previously acquired with acquire_semaphore.
+ *
+ * Note: The method is NOT idempotent. The caller must ensure that the method is called exactly
+ * as many times as acquire_semaphore.
+ */
+VALUE
+semian_resource_release_semaphore(VALUE self);
 
 /*
  * call-seq:

--- a/ext/semian/semian.c
+++ b/ext/semian/semian.c
@@ -60,6 +60,8 @@ void Init_semian()
   rb_define_alloc_func(cResource, semian_resource_alloc);
   rb_define_method(cResource, "initialize_semaphore", semian_resource_initialize, 5);
   rb_define_method(cResource, "acquire", semian_resource_acquire, -1);
+  rb_define_method(cResource, "acquire_semaphore", semian_resource_acquire_semaphore, -1);
+  rb_define_method(cResource, "release_semaphore", semian_resource_release_semaphore, 0);
   rb_define_method(cResource, "count", semian_resource_count, 0);
   rb_define_method(cResource, "semid", semian_resource_id, 0);
   rb_define_method(cResource, "key", semian_resource_key, 0);

--- a/lib/semian/resource.rb
+++ b/lib/semian/resource.rb
@@ -46,6 +46,13 @@ module Semian
       yield wait_time
     end
 
+    redefinable def acquire_semaphore
+      0
+    end
+
+    redefinable def release_semaphore
+    end
+
     redefinable def count
       0
     end


### PR DESCRIPTION
We're working on using Semian in a project that uses Ruby fibers and we wanted to implement MySQL bulkheads in a way where we would share the same semian resource semaphore (ticket) between multiple fibers. To be able to do that, we need to be able to acquire a semaphore without passing a block into the call and then release the semaphore later at the time of our choosing.

This PR extracts the semaphore acquisition and release logic into separate methods making the described scenario possible.