### PR TITLE
Allow to disable bulkheads in a given thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Change: semians will trigger on ER_PROXYSQL_MAX_CONN_TIMEOUT (#520)
 * Change: added support for dynamic semian_configurations to the Semian Redis adapter
+* Change: `Semian.disable_bulkheads_for_thread` disables bulkheads for the given thread
 
 # v0.21.3
 

--- a/test/semian_test.rb
+++ b/test/semian_test.rb
@@ -171,6 +171,21 @@ class TestSemian < Minitest::Test
     ENV.delete("SEMIAN_BULKHEAD_DISABLED")
   end
 
+  def test_disabled_bulkhead_via_thread
+    Semian.disable_bulkheads_for_thread(Thread.current) do
+      resource = Semian.register(
+        :disabled_bulkhead_via_env,
+        bulkhead: true,
+        tickets: 1,
+        success_threshold: 1,
+        error_threshold: 1,
+        error_timeout: 1,
+      )
+
+      assert_nil(resource.bulkhead)
+    end
+  end
+
   def test_disabled_circuit_breaker
     resource = Semian.register(
       :disabled_circuit_breaker,


### PR DESCRIPTION
The default Semian's bulkhead implementation being not fiber safe makes it hard to experiment with concurrency in a larger app which relies on that implementation.

I'd like to introduce `Semian.disable_bulkheads_for_thread` which will let me experiment with async IO in an app that's using Semian's non-fiber-safe bulkheads.

Example:

```ruby
Semian.disable_bulkheads_for_thread(Thread.current) do
  Async do
     # current thread has bulkheads disabled and can use ActiveRecord/Trilogy
  end
end
```


Without something like this, the 2nd fiber that tries to hit Activerecord fails with:

```
ActiveRecord::ConnectionAdapters::TrilogyAdapter::ResourceBusyError: [mysql_shard_0] timed out waiting for resource '1000mysql_shard_0'
```