### PR TITLE
Support only Ruby 3.2 and onward

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,10 +32,10 @@ jobs:
       fail-fast: true
       matrix:
         ruby:
+          - "3.4"
+          - "3.3"
           - "3.2"
           - "3.1"
-          - "3.0"
-          - "2.7"
     services:
       mysql:
         image: mysql:5.7
@@ -109,10 +109,10 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - "3.4"
+          - "3.3"
           - "3.2"
           - "3.1"
-          - "3.0"
-          - "2.7"
         gemfile:
           - grpc
           - mysql2

--- a/semian.gemspec
+++ b/semian.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
     "source_code_uri" => "https://github.com/Shopify/semian",
   }
 
-  s.required_ruby_version = ">= 2.7.0"
+  s.required_ruby_version = ">= 3.2.0"
 
   s.files = Dir["{lib,ext}/**/**/*.{rb,h,c}"]
   s.files += ["LICENSE.md", "README.md"]


### PR DESCRIPTION
We noticed that Dependabot has stopped being able to issue updates due to the gemspec specifying Ruby 2.7+, but we have optional dependencies that require ruby 3.1+. While our `.ruby-version` file specifies 3.2, Dependabot only reads the gemspec and not the ruby-version file. This is a known bug (https://github.com/dependabot/dependabot-core/issues/10108) that has not been addressed.

Looking at Ruby's [deprecation schedule](https://www.ruby-lang.org/en/downloads/branches/), 2.7 was EOL in 2023 and 3.1 will be EOL in a month. This gives us good reason to support 3.2+ going forward, bringing the gemspec in line with our testing versions.

 - Bump gemspec to use Ruby 3.2+
 - Drop 2.7 and 3.0 from testing, add 3.3 and 3.4