### PR TITLE
Attempt acquiring semaphore before releasing GVL

### DIFF
--- a/ext/semian/sysv_semaphores.c
+++ b/ext/semian/sysv_semaphores.c
@@ -1,5 +1,6 @@
 #include "sysv_semaphores.h"
 #include <time.h>
+#include <stdbool.h>
 
 static key_t
 generate_key(const char *name);


### PR DESCRIPTION
Particularly when there are multiple threads waiting to run, there is a cost to releasing the GVL that outweighs the benefit for short system calls.

This commit changes acquire_semaphore_without_gvl to attempt to acquire the semaphore while also including IPC_NOWAIT in flags, which should return immediately if the request isn't available.

Discovered from looking at profiles with @rwstauner and @tenderworks 