### PR TITLE
Patch ConnectionPool to carry semian_resource

### DIFF
--- a/lib/semian/connection_pool.rb
+++ b/lib/semian/connection_pool.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "connection_pool"
+
+# This is not a real Semian adapter, but a shim to make
+# ConnectionPool instance carry semian_resource reference.
+# Example:
+#
+# semian_resource = ::Redis.new(...).semian_resource
+# ConnectionPool.new(size: 5, timeout: 0, semian_resource: semian_resource) do
+#   ::Redis.new(...)
+# end
+
+class ConnectionPool
+  module WithSemianResource
+    def initialize(options = {}, &block)
+      super
+      @semian_resource = options[:semian_resource]
+    end
+
+    attr_reader :semian_resource
+  end
+end
+
+ConnectionPool.prepend(ConnectionPool::WithSemianResource)

--- a/test/adapters/connection_pool_test.rb
+++ b/test/adapters/connection_pool_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "semian/connection_pool"
+
+class TestConnectionPool < Minitest::Test
+  def test_with_semian_resource
+    pool = ConnectionPool.new(
+      size: 1,
+      timeout: 0,
+      semian_resource: Semian::Resource.new("blah"),
+    ) do
+      Object.new
+    end
+
+    refute_nil(pool.semian_resource)
+    assert_equal("blah", pool.semian_resource.name)
+  end
+end


### PR DESCRIPTION
I've been working on replacing references to a single global `Redis` connection in one of the Shopify apps with a `ConnectionPool`-wrapped `Redis` to make it thread-safe.

I found that so many spots expect to be able to call `semian_resource` on that connection object. And I don't think we should require those to go check out connection from a pool via `@redis_pool.with { conn.semian_resource }` to access `semian_resource`.

Instead, we could add `semian_resource` as an accessor on `ConnectionPool` for convenience.

Example of using that with Redis:

```
semian_resource = ::Redis.new(...).semian_resource
ConnectionPool.new(size: 5, timeout: 0, semian_resource: semian_resource) do
  ::Redis.new(...)
end
```

cc @byroot @danmayer for review