### PR TITLE
Fix docker compose tests

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -41,8 +41,6 @@ services:
       - -c
       - |-
           ./scripts/run_tests.sh
-    profiles:
-      - test
 
   toxiproxy:
     image: ghcr.io/shopify/toxiproxy:2.12.0
@@ -58,8 +56,7 @@ services:
 
   mysql:
     container_name: mysql
-    image: mysql
-    command: --default-authentication-plugin=mysql_native_password
+    image: mysql:9.3
     environment:
-      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      MYSQL_ROOT_PASSWORD: root
       MYSQL_ROOT_HOST: "%"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -33,6 +33,7 @@ services:
   test:
     <<: *base
     container_name: semian-tests
+    hostname: http-server  # this is important because it's also serving as an http server
     build:
       context: ../
       dockerfile: dockerfiles/semian-ci
@@ -41,6 +42,8 @@ services:
       - -c
       - |-
           ./scripts/run_tests.sh
+    profiles:
+      - test
 
   toxiproxy:
     image: ghcr.io/shopify/toxiproxy:2.12.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,10 @@ jobs:
       ports:
         - 31150:31050
         - 31050:31050
-      # NOTE: Container required be accessed by hostname semian,
+      # NOTE: Container required be accessed by hostname http-server,
       #       because upstream to toxiproxy should have access
       #       to the same container
-      options: --hostname semian
+      options: --hostname http-server
     env:
       CI: "1"
       BUNDLE_GEMFILE: Gemfile
@@ -97,10 +97,10 @@ jobs:
       ports:
         - 31150:31050
         - 31050:31050
-      # NOTE: Container required be accessed by hostname semian,
+      # NOTE: Container required be accessed by hostname http-server,
       #       because upstream to toxiproxy should have access
       #       to the same container
-      options: --hostname semian
+      options: --hostname http-server
     env:
       CI: "1"
       SEED: 58485

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,9 +37,9 @@ jobs:
           - "3.2"
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:9.3
         env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+          MYSQL_ROOT_PASSWORD: root
         options: >-
           --health-cmd="mysqladmin ping"
           --health-interval=10s
@@ -144,9 +144,9 @@ jobs:
             adapter: activerecord_trilogy_adapter
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:9.3
         env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+          MYSQL_ROOT_PASSWORD: root
         options: >-
           --health-cmd="mysqladmin ping"
           --health-interval=10s

--- a/README.md
+++ b/README.md
@@ -917,7 +917,7 @@ If you make any changes to `.devcontainer/` you'd need to recreate the container
 Run tests in containers:
 
 ```shell
-$ docker-compose -f ./.devcontainer/docker-compose.yml run --rm test
+$ docker-compose -f ./.devcontainer/docker-compose.yml --profile test run --rm test
 ```
 
 Running Tests:

--- a/dockerfiles/semian-ci
+++ b/dockerfiles/semian-ci
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install --no-install-recommends -y \
       build-essential \
       libssl-dev \
-      netcat \
+      default-mysql-client \
  && rm -rf /var/lib/apt/lists/* \
  && gem install bundler
 

--- a/examples/activerecord_trilogy_adapter/00_circuit_minimal.rb
+++ b/examples/activerecord_trilogy_adapter/00_circuit_minimal.rb
@@ -17,6 +17,9 @@ SEMIAN_PARAMETERS = {
 configuration = {
   adapter: "trilogy",
   username: "root",
+  password: "root",
+  ssl: true,
+  ssl_mode: 3,
   host: ENV.fetch("MYSQL_HOST", "localhost"),
   port: Integer(ENV.fetch("MYSQL_PORT", 3306)),
   database: "mysql",

--- a/examples/activerecord_trilogy_adapter/03_circuit_open.rb
+++ b/examples/activerecord_trilogy_adapter/03_circuit_open.rb
@@ -30,6 +30,9 @@ puts "  " + "Bulkhead is DISABLED.".blue.underline
 configuration = {
   adapter: "trilogy",
   username: "root",
+  password: "root",
+  ssl: true,
+  ssl_mode: 3,
   host: host,
   port: unhealthy_port,
   database: "mysql",

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -18,7 +18,7 @@ fi
 
 echo "Waiting for MySQL to start."
 attempts=0
-while ! nc -w 1 mysql 3306 | grep -q "mysql"; do
+while ! mysql -h mysql -uroot -proot -e "SELECT 0 as id;"; do
   sleep 1
   attempts=$((attempts + 1))
   if (( attempts > 60 )); then

--- a/test/adapters/activerecord_trilogy_adapter_test.rb
+++ b/test/adapters/activerecord_trilogy_adapter_test.rb
@@ -27,6 +27,9 @@ module ActiveRecord
         @configuration = {
           adapter: "trilogy",
           username: "root",
+          password: "root",
+          ssl: true,
+          ssl_mode: 3,
           host: SemianConfig["toxiproxy_upstream_host"],
           port: SemianConfig["mysql_toxiproxy_port"],
           read_timeout: 2,
@@ -395,7 +398,7 @@ module ActiveRecord
       end
 
       def test_trilogy_default_read_timeout
-        client = ::Trilogy.new(@configuration.slice(:username, :host, :port))
+        client = ::Trilogy.new(@configuration.slice(:username, :password, :ssl, :ssl_mode, :host, :port))
 
         assert_equal(0, client.read_timeout)
       end

--- a/test/adapters/mysql2_test.rb
+++ b/test/adapters/mysql2_test.rb
@@ -35,6 +35,8 @@ class TestMysql2 < Minitest::Test
     resource = Mysql2::Client.new(
       host: SemianConfig["toxiproxy_upstream_host"],
       port: SemianConfig["mysql_toxiproxy_port"],
+      username: "root",
+      password: "root",
       semian: false,
     ).semian_resource
 
@@ -310,6 +312,8 @@ class TestMysql2 < Minitest::Test
     client = Mysql2::Client.new(
       host: SemianConfig["toxiproxy_upstream_host"],
       port: SemianConfig["mysql_toxiproxy_port"],
+      username: "root",
+      password: "root",
     )
 
     assert_equal(2, client.query("SELECT 1 + 1 as sum;").to_a.first["sum"])
@@ -405,6 +409,8 @@ class TestMysql2 < Minitest::Test
       reconnect: true,
       host: SemianConfig["toxiproxy_upstream_host"],
       port: SemianConfig["mysql_toxiproxy_port"],
+      username: "root",
+      password: "root",
       semian: SEMIAN_OPTIONS.merge(semian_options),
     )
   end

--- a/test/adapters/rails_tests.rb
+++ b/test/adapters/rails_tests.rb
@@ -27,6 +27,10 @@ module RailsTests
       prepared_statements: false,
       host: SemianConfig["toxiproxy_upstream_host"],
       port: SemianConfig["mysql_toxiproxy_port"],
+      username: "root",
+      password: "root",
+      ssl: true,
+      ssl_mode: 3,
       semian: SEMIAN_OPTIONS,
     }
 

--- a/test/config/hosts.yml
+++ b/test/config/hosts.yml
@@ -11,7 +11,7 @@ redis_host: redis
 redis_port: 6379
 redis_toxiproxy_port: 16379
 
-http_host: semian
+http_host: http-server
 http_port_service_a: 31050
 http_port_service_b: 31150
 http_toxiproxy_port: 31051


### PR DESCRIPTION
Testing locally just doesn't work for two reasons:

# Mysql Update
docker compose does not have a pinned mysql version, and so when we tried to run it, it started pulling v9, which doesn't like mysql native password plugin.

So, we decided to fix forward and just fix our tests to run on v9, which requires a password by default. This meant a few changes:

1. Start using a password and SSL (but we set the mode to 3, meaning "no verify", to simplify our setup)
2. Stop using netcat to test if mysql is up, and use mysql-client instead

# HTTP Tests

The way HTTP tests work is by spinning a MockServer that is running from within the same semian container (convoluted, I know), but there is an expectation of the hostname to be `semian`, which just isn't the case when we're running tests. So I fix the hostname and also make it clearer
