### PR TITLE
Update init config validation to info mode + Update msg

### DIFF
--- a/lib/semian/configuration_validator.rb
+++ b/lib/semian/configuration_validator.rb
@@ -9,8 +9,8 @@ module Semian
       @force_config_validation = force_config_validation?
 
       unless @force_config_validation
-        Semian.logger.warn(
-          "Semian is running in log-mode for configuration validation. This means that Semian will not raise an error if the configuration is invalid. This is not recommended for production environments.\n\n[IMPORTANT] IN FUTURE RELEASES, STRICT CONFIGURATION VALIDATION WILL BE THE DEFAULT BEHAVIOR. PLEASE UPDATE YOUR CONFIGURATION TO USE `force_config_validation: true` TO ENABLE STRICT CONFIGURATION VALIDATION. ALLOWING MISCONFIGURATIONS IN FUTURE RELEASES WILL BREAK YOUR SEMIAN.\n---\n",
+        Semian.logger.info(
+          "Semian is running in log-mode for configuration validation. This means that Semian will not raise an error if the configuration is invalid. This is not recommended for production environments.\n\n[IMPORTANT] PLEASE UPDATE YOUR CONFIGURATION TO USE `force_config_validation: true` TO ENABLE STRICT CONFIGURATION VALIDATION.\n---\n",
         )
       end
     end


### PR DESCRIPTION
Addressing issue https://github.com/Shopify/semian/issues/633

To avoid noise, we downgrade the log from using `warn` to `info` and update the initialize message for correctness.