### PR TITLE
Only check bulkhead configuration if semaphores are enabled

### DIFF
--- a/lib/semian/configuration_validator.rb
+++ b/lib/semian/configuration_validator.rb
@@ -50,7 +50,7 @@ module Semian
     end
 
     def validate_bulkhead_configuration!
-      return if ENV.key?("SEMIAN_BULKHEAD_DISABLED")
+      return if ENV.key?("SEMIAN_BULKHEAD_DISABLED") || !Semian.semaphores_enabled?
       return unless @configuration.fetch(:bulkhead, true)
 
       tickets = @configuration[:tickets]


### PR DESCRIPTION
We're currently checking bulkhead configurations on environments that do not support bulkheads.

This is having the adverse effect of the validations going off in development environments, because we intentionally set MAX_TICKETS to 0 in these environments