### PR TITLE
Fix unbound growth of consumers WeakRef Array

### DIFF
--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -199,7 +199,7 @@ module Semian
     # If consumer who retrieved / registered by a Semian::Adapter, keep track
     # of who the consumer was so that we can clear the resource reference if needed.
     consumer = args.delete(:consumer)
-    if consumer&.class&.include?(Semian::Adapter)
+    if consumer&.class&.include?(Semian::Adapter) && !args[:dynamic]
       consumer_set = (consumers[name] ||= ObjectSpace::WeakMap.new)
       consumer_set[consumer] = true
     end

--- a/test/adapter_test.rb
+++ b/test/adapter_test.rb
@@ -96,6 +96,16 @@ class TestSemianAdapter < Minitest::Test
     assert_nil(dynamic_client.instance_variable_get("@semian_options"))
   end
 
+  def test_dynamic_adapter_not_registered_as_consumer
+    assert_empty(Semian.consumers)
+
+    dynamic_client = Semian::DynamicAdapterTestClient.new(quota: 0.5)
+    resource = dynamic_client.semian_resource
+
+    assert_equal(resource, Semian.resources[dynamic_client.semian_identifier])
+    assert_empty(Semian.consumers)
+  end
+
   class MyAdapterError < StandardError
     include Semian::AdapterError
   end


### PR DESCRIPTION
Previously we used an array of WeakRef to track the list of consumers of a give resource. Although the weakref would allow the referenced consumer to be collected by GC, the WeakRef itself consumes some memory and the array could grow unbounded.

@luke-gruber and I found this large array while profiling
@franciscojmc and I investigated and found the sources of the problem.

This PR applies two fixes for (essentially) the same problem

The first commit swaps the Array full of individual WeakRefs for a single WeakMap. This both avoids adding duplicate copies of the same adapter and leans on the RubyVM to prune stale references.

The second commit observes that previously, when using `dynamic: true`, [we never memoize `@semian_resource` on the adapter](https://github.com/Shopify/semian/blob/d8090bfc8473546ec1f633b6690c564dbb8292a2/lib/semian/adapter.rb#L28), and so there's no need to track it as a "consumer". Previously this meant we would continuously be registering duplicate copies of the same adapter as a consumer.

cc @tenderworks and @whatisinternet who have also looked in this area previously