### PR TITLE
Add semian resource name to logs

### DIFF
--- a/lib/semian/configuration_validator.rb
+++ b/lib/semian/configuration_validator.rb
@@ -32,7 +32,7 @@ module Semian
       if @force_config_validation
         raise ArgumentError, message
       else
-        Semian.logger.warn("[SEMIAN_CONFIG_WARNING]: #{message}")
+        Semian.logger.warn("[SEMIAN_CONFIG_WARNING]: Semian Adapter #{@name}: #{message}")
       end
     end
 


### PR DESCRIPTION
- Add resource name to the semian configuration validator warning logs so that we can identify exactly what resource configuration needs to be fixed.