### PR TITLE
Remove redundant semian naming from error messages

### DIFF
--- a/lib/semian/adapter.rb
+++ b/lib/semian/adapter.rb
@@ -49,8 +49,7 @@ module Semian
       last_error = nil unless last_error.is_a?(Exception) # Net::HTTPServerError is not an exception
       raise self.class::CircuitOpenError.new(semian_identifier, message), cause: last_error
     rescue ::Semian::BaseError => error
-      message = "Semian Resource #{semian_identifier}: #{error.message}"
-      raise self.class::ResourceBusyError.new(semian_identifier, message)
+      raise self.class::ResourceBusyError.new(semian_identifier, error.message)
     rescue *resource_exceptions => error
       error.semian_identifier = semian_identifier if error.respond_to?(:semian_identifier=)
       raise

--- a/lib/semian/circuit_breaker.rb
+++ b/lib/semian/circuit_breaker.rb
@@ -39,7 +39,7 @@ module Semian
     def acquire(resource = nil, &block)
       transition_to_half_open if transition_to_half_open?
 
-      raise OpenCircuitError, "Circuit breaker is open for resource: #{@name}" unless request_allowed?
+      raise OpenCircuitError unless request_allowed?
 
       result = nil
       begin


### PR DESCRIPTION
- Removed semian resource name from ResourceBusyError and OpenCircuitError messages since it was redundant. Both of these errors are an instance of SemianError, and this object takes semian identifier and message and modifies the message to contain semian resource name.