### PR TITLE
Make variables thread safe and introduce concurrent-ruby gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "rake"
 gem "rake-compiler"
+gem "concurrent-ruby"
 
 group :test do
   gem "benchmark-memory"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,6 +184,7 @@ DEPENDENCIES
   benchmark-ips
   benchmark-memory
   bigdecimal
+  concurrent-ruby
   debug
   grpc (= 1.74.1)
   hiredis (~> 0.6)

--- a/gemfiles/activerecord_trilogy_adapter.gemfile
+++ b/gemfiles/activerecord_trilogy_adapter.gemfile
@@ -8,6 +8,7 @@ gem "minitest"
 gem "mocha"
 gem "toxiproxy"
 gem "webrick"
+gem "concurrent-ruby"
 
 gem "trilogy", "~> 2.4"
 gem "activerecord", github: "rails/rails"

--- a/gemfiles/grpc.gemfile
+++ b/gemfiles/grpc.gemfile
@@ -8,6 +8,7 @@ gem "minitest"
 gem "mocha"
 gem "toxiproxy"
 gem "webrick"
+gem "concurrent-ruby"
 
 gem "grpc"
 

--- a/gemfiles/mysql2.gemfile
+++ b/gemfiles/mysql2.gemfile
@@ -10,6 +10,7 @@ gem "minitest"
 gem "mocha"
 gem "toxiproxy"
 gem "webrick"
+gem "concurrent-ruby"
 
 gem "mysql2", "~> 0.5"
 

--- a/gemfiles/net_http.gemfile
+++ b/gemfiles/net_http.gemfile
@@ -9,5 +9,6 @@ gem "minitest"
 gem "mocha"
 gem "toxiproxy"
 gem "webrick"
+gem "concurrent-ruby"
 
 gemspec path: "../"

--- a/gemfiles/rails.gemfile
+++ b/gemfiles/rails.gemfile
@@ -8,6 +8,7 @@ gem "minitest"
 gem "mocha"
 gem "toxiproxy"
 gem "webrick"
+gem "concurrent-ruby"
 
 gem "mysql2", "~> 0.5"
 gem "activerecord", ">= 7.0.3"

--- a/gemfiles/rails_mysql2.gemfile
+++ b/gemfiles/rails_mysql2.gemfile
@@ -8,6 +8,7 @@ gem "minitest"
 gem "mocha"
 gem "toxiproxy"
 gem "webrick"
+gem "concurrent-ruby"
 
 gem "mysql2", "~> 0.5"
 gem "activerecord", ">= 7.0.3"

--- a/gemfiles/rails_trilogy.gemfile
+++ b/gemfiles/rails_trilogy.gemfile
@@ -8,6 +8,7 @@ gem "minitest"
 gem "mocha"
 gem "toxiproxy"
 gem "webrick"
+gem "concurrent-ruby"
 
 gem "trilogy", "~> 2.4"
 # we can share the Gemfile with rails mysql2 once activerecord is released with the trilogy adapter

--- a/gemfiles/redis_4.gemfile
+++ b/gemfiles/redis_4.gemfile
@@ -8,6 +8,7 @@ gem "minitest"
 gem "mocha"
 gem "toxiproxy"
 gem "webrick"
+gem "concurrent-ruby"
 
 gem "hiredis-client"
 gem "hiredis", "~> 0.6"

--- a/gemfiles/redis_5.gemfile
+++ b/gemfiles/redis_5.gemfile
@@ -8,6 +8,7 @@ gem "minitest"
 gem "mocha"
 gem "toxiproxy"
 gem "webrick"
+gem "concurrent-ruby"
 
 gem "hiredis", "~> 0.6"
 gem "hiredis-client", ">= 0.12.0"

--- a/gemfiles/redis_client.gemfile
+++ b/gemfiles/redis_client.gemfile
@@ -8,6 +8,7 @@ gem "minitest"
 gem "mocha"
 gem "toxiproxy"
 gem "webrick"
+gem "concurrent-ruby"
 
 gem "hiredis-client", github: "redis-rb/redis-client"
 gem "hiredis", "~> 0.6"

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -124,6 +124,8 @@ module Semian
   self.resources = LRUHash.new
   self.consumers = Concurrent::Map.new
 
+  @reset_mutex = Mutex.new
+
   def issue_disabled_semaphores_warning
     return if defined?(@warning_issued)
 
@@ -260,8 +262,10 @@ module Semian
   end
 
   def reset!
-    self.consumers = Concurrent::Map.new
-    self.resources = LRUHash.new
+    @reset_mutex.synchronize do
+      self.consumers = Concurrent::Map.new
+      self.resources = LRUHash.new
+    end
   end
 
   THREAD_BULKHEAD_DISABLED_VAR = :semian_bulkheads_disabled

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -4,6 +4,7 @@ require "forwardable"
 require "logger"
 require "weakref"
 require "thread"
+require "concurrent-ruby"
 
 require "semian/version"
 require "semian/instrumentable"
@@ -252,11 +253,11 @@ module Semian
 
   # Retrieves a hash of all registered resource consumers.
   def consumers
-    @consumers ||= {}
+    @consumers ||= Concurrent::Map.new
   end
 
   def reset!
-    @consumers = {}
+    @consumers = Concurrent::Map.new
     @resources = LRUHash.new
   end
 

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -111,6 +111,16 @@ module Semian
   self.default_permissions = 0660
   self.default_force_config_validation = false
 
+  def thread_safe?
+    return @thread_safe if defined?(@thread_safe)
+
+    @thread_safe = true
+  end
+
+  def thread_safe=(thread_safe)
+    @thread_safe = thread_safe
+  end
+
   self.resources = LRUHash.new
   self.consumers = Concurrent::Map.new
 
@@ -262,16 +272,6 @@ module Semian
   def reset!
     self.consumers = Concurrent::Map.new
     self.resources = LRUHash.new
-  end
-
-  def thread_safe?
-    return @thread_safe if defined?(@thread_safe)
-
-    @thread_safe = true
-  end
-
-  def thread_safe=(thread_safe)
-    @thread_safe = thread_safe
   end
 
   THREAD_BULKHEAD_DISABLED_VAR = :semian_bulkheads_disabled

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -234,7 +234,7 @@ module Semian
     resource = resources.delete(name)
     if resource
       resource.bulkhead&.unregister_worker
-      consumers_for_resource = consumers.delete(name) || {}
+      consumers_for_resource = consumers.delete(name) || Concurrent::Map.new
       consumers_for_resource.each_key(&:clear_semian_resource)
     end
   end

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -259,16 +259,6 @@ module Semian
     end
   end
 
-  # # Retrieves a hash of all registered resources.
-  # def resources
-  #   @resources ||= LRUHash.new
-  # end
-
-  # Retrieves a hash of all registered resource consumers.
-  # def consumers
-  #   @consumers ||= Concurrent::Map.new
-  # end
-
   def reset!
     self.consumers = Concurrent::Map.new
     self.resources = LRUHash.new

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -111,6 +111,8 @@ module Semian
   self.default_permissions = 0660
   self.default_force_config_validation = false
 
+  # We only allow disabling thread-safety for parts of the code that are on the hot path.
+  # Since locking there could have a significant impact. Everything else is enforced thread safety
   def thread_safe?
     return @thread_safe if defined?(@thread_safe)
 

--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -104,12 +104,15 @@ module Semian
   OpenCircuitError = Class.new(BaseError)
   SemaphoreMissingError = Class.new(BaseError)
 
-  attr_accessor :maximum_lru_size, :minimum_lru_time, :default_permissions, :namespace, :default_force_config_validation
+  attr_accessor :maximum_lru_size, :minimum_lru_time, :default_permissions, :namespace, :default_force_config_validation, :resources, :consumers
 
   self.maximum_lru_size = 500
   self.minimum_lru_time = 300 # 300 seconds / 5 minutes
   self.default_permissions = 0660
   self.default_force_config_validation = false
+
+  self.resources = LRUHash.new
+  self.consumers = Concurrent::Map.new
 
   def issue_disabled_semaphores_warning
     return if defined?(@warning_issued)
@@ -246,19 +249,19 @@ module Semian
     end
   end
 
-  # Retrieves a hash of all registered resources.
-  def resources
-    @resources ||= LRUHash.new
-  end
+  # # Retrieves a hash of all registered resources.
+  # def resources
+  #   @resources ||= LRUHash.new
+  # end
 
   # Retrieves a hash of all registered resource consumers.
-  def consumers
-    @consumers ||= Concurrent::Map.new
-  end
+  # def consumers
+  #   @consumers ||= Concurrent::Map.new
+  # end
 
   def reset!
-    @consumers = Concurrent::Map.new
-    @resources = LRUHash.new
+    self.consumers = Concurrent::Map.new
+    self.resources = LRUHash.new
   end
 
   def thread_safe?

--- a/lib/semian/instrumentable.rb
+++ b/lib/semian/instrumentable.rb
@@ -28,11 +28,5 @@ module Semian
     def notify(*args)
       subscribers.values.each { |subscriber| subscriber.call(*args) }
     end
-
-    private
-
-    def subscribers
-      self.class.subscribers
-    end
   end
 end

--- a/lib/semian/instrumentable.rb
+++ b/lib/semian/instrumentable.rb
@@ -4,19 +4,15 @@ require "concurrent-ruby"
 
 module Semian
   module Instrumentable
-    extend self
-
-    attr_accessor :subscribers
-
-    self.subscribers = Concurrent::Map.new
+    SUBSCRIBERS = Concurrent::Map.new
 
     def subscribe(name = rand, &block)
-      subscribers[name] = block
+      SUBSCRIBERS[name] = block
       name
     end
 
     def unsubscribe(name)
-      subscribers.delete(name)
+      SUBSCRIBERS.delete(name)
     end
 
     # Args:
@@ -26,7 +22,7 @@ module Semian
     #   adapter (string)
     #   payload (optional)
     def notify(*args)
-      subscribers.values.each { |subscriber| subscriber.call(*args) }
+      SUBSCRIBERS.values.each { |subscriber| subscriber.call(*args) }
     end
   end
 end

--- a/lib/semian/instrumentable.rb
+++ b/lib/semian/instrumentable.rb
@@ -4,6 +4,10 @@ require "concurrent-ruby"
 
 module Semian
   module Instrumentable
+    extend self
+
+    self.subscribers = Concurrent::Map.new
+
     def subscribe(name = rand, &block)
       subscribers[name] = block
       name
@@ -26,7 +30,7 @@ module Semian
     private
 
     def subscribers
-      @subscribers ||= Concurrent::Map.new
+      self.class.subscribers
     end
   end
 end

--- a/lib/semian/instrumentable.rb
+++ b/lib/semian/instrumentable.rb
@@ -6,6 +6,8 @@ module Semian
   module Instrumentable
     extend self
 
+    attr_accessor :subscribers
+
     self.subscribers = Concurrent::Map.new
 
     def subscribe(name = rand, &block)

--- a/lib/semian/instrumentable.rb
+++ b/lib/semian/instrumentable.rb
@@ -15,6 +15,10 @@ module Semian
       SUBSCRIBERS.delete(name)
     end
 
+    def subscribers
+      SUBSCRIBERS
+    end
+
     # Args:
     #   event (string)
     #   resource (Object)

--- a/lib/semian/instrumentable.rb
+++ b/lib/semian/instrumentable.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "concurrent-ruby"
+
 module Semian
   module Instrumentable
     def subscribe(name = rand, &block)
@@ -24,7 +26,7 @@ module Semian
     private
 
     def subscribers
-      @subscribers ||= {}
+      @subscribers ||= Concurrent::Map.new
     end
   end
 end

--- a/lib/semian/simple_integer.rb
+++ b/lib/semian/simple_integer.rb
@@ -29,7 +29,7 @@ module Semian
   module ThreadSafe
     class Integer
       def initialize
-        @atom = Concurrent::Atom.new(0)
+        @atom = Concurrent::AtomicFixnum.new(0)
       end
 
       def value
@@ -37,7 +37,7 @@ module Semian
       end
 
       def value=(new_value)
-        @atom.reset(new_value)
+        @atom.value = new_value
       end
 
       def increment(val = 1)
@@ -45,7 +45,7 @@ module Semian
       end
 
       def reset
-        @atom.reset(0)
+        @atom.value = 0
       end
 
       def destroy

--- a/lib/semian/simple_integer.rb
+++ b/lib/semian/simple_integer.rb
@@ -41,7 +41,7 @@ module Semian
       end
 
       def increment(val = 1)
-        @atom.swap { |current| current + val }
+        @atom.increment(val)
       end
 
       def reset

--- a/lib/semian/simple_integer.rb
+++ b/lib/semian/simple_integer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "thread"
+require "concurrent"
 
 module Semian
   module Simple
@@ -26,14 +27,29 @@ module Semian
   end
 
   module ThreadSafe
-    class Integer < Simple::Integer
-      def initialize(*)
-        super
-        @lock = Mutex.new
+    class Integer
+      def initialize
+        @atom = Concurrent::Atom.new(0)
       end
 
-      def increment(*)
-        @lock.synchronize { super }
+      def value
+        @atom.value
+      end
+
+      def value=(new_value)
+        @atom.reset(new_value)
+      end
+
+      def increment(val = 1)
+        @atom.swap { |current| current + val }
+      end
+
+      def reset
+        @atom.reset(0)
+      end
+
+      def destroy
+        reset
       end
     end
   end

--- a/lib/semian/simple_sliding_window.rb
+++ b/lib/semian/simple_sliding_window.rb
@@ -4,92 +4,62 @@ require "thread"
 require "concurrent"
 
 module Semian
+  # Shared sliding window behavior that can be mixed into classes
+  # that provide different underlying storage mechanisms
+  module SlidingWindowBehavior
+    extend Forwardable
+
+    def_delegators :@window, :size, :last, :empty?
+    attr_reader :max_size
+
+    # A sliding window is a structure that stores the most @max_size recent timestamps
+    # like this: if @max_size = 4, current time is 10, @window =[5,7,9,10].
+    # Another push of (11) at 11 sec would make @window [7,9,10,11], shifting off 5.
+
+    def reject!(&block)
+      @window.reject!(&block)
+      self
+    end
+
+    def push(value)
+      resize_to(@max_size - 1) # make room
+      @window << value
+      self
+    end
+    alias_method :<<, :push
+
+    def clear
+      @window.clear
+      self
+    end
+    alias_method :destroy, :clear
+
+    private
+
+    def resize_to(size)
+      @window = @window.last(size) if @window.size >= size
+    end
+  end
+
   module Simple
     class SlidingWindow # :nodoc:
-      extend Forwardable
-
-      def_delegators :@window, :size, :last, :empty?
-      attr_reader :max_size
-
-      # A sliding window is a structure that stores the most @max_size recent timestamps
-      # like this: if @max_size = 4, current time is 10, @window =[5,7,9,10].
-      # Another push of (11) at 11 sec would make @window [7,9,10,11], shifting off 5.
+      include SlidingWindowBehavior
 
       def initialize(max_size:)
         @max_size = max_size
         @window = []
-      end
-
-      def reject!(&block)
-        @window.reject!(&block)
-      end
-
-      def push(value)
-        resize_to(@max_size - 1) # make room
-        @window << value
-        self
-      end
-      alias_method :<<, :push
-
-      def clear
-        @window.clear
-        self
-      end
-      alias_method :destroy, :clear
-
-      private
-
-      def resize_to(size)
-        @window = @window.last(size) if @window.size >= size
       end
     end
   end
 
   module ThreadSafe
     class SlidingWindow
-      attr_reader :max_size
+      include SlidingWindowBehavior
 
       def initialize(max_size:)
         @max_size = max_size
-        @window_atom = Concurrent::Atom.new([])
+        @window = Concurrent::Array.new
       end
-
-      def size
-        @window_atom.value.size
-      end
-
-      def last
-        @window_atom.value.last
-      end
-
-      def empty?
-        @window_atom.value.empty?
-      end
-
-      def reject!(&block)
-        @window_atom.swap do |window|
-          window.reject(&block)
-        end
-        self
-      end
-
-      def push(value)
-        @window_atom.swap do |window|
-          if window.size < @max_size
-            window + [value]
-          else
-            window.last(@max_size - 1) + [value]
-          end
-        end
-        self
-      end
-      alias_method :<<, :push
-
-      def clear
-        @window_atom.reset([])
-        self
-      end
-      alias_method :destroy, :clear
     end
   end
 end

--- a/lib/semian/simple_sliding_window.rb
+++ b/lib/semian/simple_sliding_window.rb
@@ -75,10 +75,11 @@ module Semian
 
       def push(value)
         @window_atom.swap do |window|
-          new_window = window.dup
-          new_window = resize_to(new_window, @max_size - 1) # make room
-          new_window << value
-          new_window
+          if window.size < @max_size
+            window + [value]
+          else
+            window.last(@max_size - 1) + [value]
+          end
         end
         self
       end
@@ -89,12 +90,6 @@ module Semian
         self
       end
       alias_method :destroy, :clear
-
-      private
-
-      def resize_to(window, size)
-        window.size >= size ? window.last(size) : window
-      end
     end
   end
 end

--- a/lib/semian/simple_sliding_window.rb
+++ b/lib/semian/simple_sliding_window.rb
@@ -47,8 +47,6 @@ module Semian
 
   module ThreadSafe
     class SlidingWindow
-      extend Forwardable
-
       attr_reader :max_size
 
       def initialize(max_size:)

--- a/lib/semian/simple_sliding_window.rb
+++ b/lib/semian/simple_sliding_window.rb
@@ -4,8 +4,6 @@ require "thread"
 require "concurrent"
 
 module Semian
-  # Shared sliding window behavior that can be mixed into classes
-  # that provide different underlying storage mechanisms
   module SlidingWindowBehavior
     extend Forwardable
 

--- a/lib/semian/simple_sliding_window.rb
+++ b/lib/semian/simple_sliding_window.rb
@@ -72,12 +72,13 @@ module Semian
         @window_atom.swap do |window|
           window.reject(&block)
         end
+        self
       end
 
       def push(value)
         @window_atom.swap do |window|
           new_window = window.dup
-          new_window = new_window.last(@max_size - 1) if new_window.size >= @max_size
+          new_window = resize_to(new_window, @max_size - 1) # make room
           new_window << value
           new_window
         end
@@ -90,6 +91,12 @@ module Semian
         self
       end
       alias_method :destroy, :clear
+
+      private
+
+      def resize_to(window, size)
+        window.size >= size ? window.last(size) : window
+      end
     end
   end
 end

--- a/test/adapter_test.rb
+++ b/test/adapter_test.rb
@@ -78,24 +78,18 @@ class TestSemianAdapter < Minitest::Test
     end
 
     identifier = clients[0].semian_identifier
-    consumer_map = Semian.consumers[identifier]
 
     assert_kind_of(
       ObjectSpace::WeakMap,
-      consumer_map,
+      Semian.consumers[identifier],
       "Consumers must be stored in WeakMap to allow garbage collection",
     )
-    assert_equal(10, consumer_map.size, "All consumers should be registered")
+    assert_equal(10, Semian.consumers[identifier].size, "All consumers should be registered")
 
     clients.clear
     Semian.unregister(identifier)
 
-    remaining_consumers = Semian.consumers[identifier]
-
-    assert(
-      remaining_consumers.nil? || remaining_consumers.empty?,
-      "Unregister should clean up consumer references - got #{remaining_consumers}",
-    )
+    assert_nil(Semian.consumers[identifier], "Unregister should remove consumer map entirely")
   end
 
   def test_does_not_memoize_dynamic_options

--- a/test/adapter_test.rb
+++ b/test/adapter_test.rb
@@ -79,17 +79,12 @@ class TestSemianAdapter < Minitest::Test
 
     identifier = clients[0].semian_identifier
 
-    assert_kind_of(
-      ObjectSpace::WeakMap,
-      Semian.consumers[identifier],
-      "Consumers must be stored in WeakMap to allow garbage collection",
-    )
-    assert_equal(10, Semian.consumers[identifier].size, "All consumers should be registered")
+    assert_equal(10, Semian.consumers[identifier].size)
 
     clients.clear
-    Semian.unregister(identifier)
+    2.times { GC.start }
 
-    assert_nil(Semian.consumers[identifier], "Unregister should remove consumer map entirely")
+    assert_operator(Semian.consumers[identifier].size, :<=, 1)
   end
 
   def test_does_not_memoize_dynamic_options

--- a/test/adapter_test.rb
+++ b/test/adapter_test.rb
@@ -82,7 +82,7 @@ class TestSemianAdapter < Minitest::Test
     assert_equal(10, Semian.consumers[identifier].size)
 
     clients.clear
-    
+
     2.times { GC.start(full_mark: true, immediate_sweep: true) }
 
     assert_equal(0, Semian.consumers[identifier].size)

--- a/test/adapter_test.rb
+++ b/test/adapter_test.rb
@@ -255,8 +255,6 @@ class TestSemianAdapter < Minitest::Test
 
     Semian.notify("test_event", "test_resource", "test_scope", "test_adapter", extra: "payload")
 
-    sleep(0.01)
-
     assert_equal(3, notifications_received.size)
 
     received_subscribers = notifications_received.map { |n| n[:subscriber] }.sort
@@ -280,8 +278,6 @@ class TestSemianAdapter < Minitest::Test
     assert_equal(initial_subscribers_size + 2, Semian.send(:subscribers).size)
 
     Semian.notify("test_event2", "test_resource2", "test_scope2", "test_adapter2")
-
-    sleep(0.01)
 
     assert_equal(2, notifications_received.size)
 

--- a/test/adapter_test.rb
+++ b/test/adapter_test.rb
@@ -122,6 +122,59 @@ class TestSemianAdapter < Minitest::Test
     assert_equal("[my_service] Same Prefix", error.message)
   end
 
+  def test_concurrent_consumer_registration
+    threads = []
+    thread_count = 5
+    clients_created = Concurrent::Array.new
+    exceptions_caught = Concurrent::AtomicFixnum.new(0)
+    
+    thread_count.times do |i|
+      threads << Thread.new do
+        begin
+          client = Semian::AdapterTestClient.new(
+            quota: 0.5, 
+            name: "thread_test_#{i}"
+          )
+          
+          resource = client.semian_resource
+          
+          clients_created << { 
+            client: client, 
+            resource: resource, 
+            identifier: client.semian_identifier,
+            thread_id: i
+          }
+        rescue => e
+          exceptions_caught.increment
+        end
+      end
+    end
+    
+    threads.each(&:join)
+    
+    assert_equal(0, exceptions_caught.value, "No exceptions should occur during concurrent consumer registration")
+    
+    assert_equal(thread_count, clients_created.size, "All clients should be registered")
+    
+    clients_created.each do |client_data|
+      client = client_data[:client]
+      identifier = client_data[:identifier]
+      
+      assert(Semian.consumers.key?(identifier), "Consumer should be registered for identifier: #{identifier}")
+      
+      consumer_map = Semian.consumers[identifier]
+      assert_kind_of(ObjectSpace::WeakMap, consumer_map, "Consumer map should be a WeakMap")
+      assert(consumer_map.key?(client), "Client should be registered in consumer map")
+    end
+    
+    clients_created.each do |client_data|
+      resource = client_data[:resource]
+      identifier = client_data[:identifier]
+      
+      assert_equal(resource, Semian.resources[identifier], "Resource should match registered resource")
+    end
+  end
+
   def without_gc
     GC.disable
     yield

--- a/test/adapter_test.rb
+++ b/test/adapter_test.rb
@@ -82,7 +82,8 @@ class TestSemianAdapter < Minitest::Test
     assert_equal(10, Semian.consumers[identifier].size)
 
     clients.clear
-    2.times { GC.start }
+    
+    2.times { GC.start(full_mark: true, immediate_sweep: true) }
 
     assert_equal(0, Semian.consumers[identifier].size)
   end

--- a/test/adapter_test.rb
+++ b/test/adapter_test.rb
@@ -127,50 +127,49 @@ class TestSemianAdapter < Minitest::Test
     thread_count = 5
     clients_created = Concurrent::Array.new
     exceptions_caught = Concurrent::AtomicFixnum.new(0)
-    
+
     thread_count.times do |i|
       threads << Thread.new do
-        begin
-          client = Semian::AdapterTestClient.new(
-            quota: 0.5, 
-            name: "thread_test_#{i}"
-          )
-          
-          resource = client.semian_resource
-          
-          clients_created << { 
-            client: client, 
-            resource: resource, 
-            identifier: client.semian_identifier,
-            thread_id: i
-          }
-        rescue => e
-          exceptions_caught.increment
-        end
+        client = Semian::AdapterTestClient.new(
+          quota: 0.5,
+          name: "thread_test_#{i}",
+        )
+
+        resource = client.semian_resource
+
+        clients_created << {
+          client: client,
+          resource: resource,
+          identifier: client.semian_identifier,
+          thread_id: i,
+        }
+      rescue
+        exceptions_caught.increment
       end
     end
-    
+
     threads.each(&:join)
-    
+
     assert_equal(0, exceptions_caught.value, "No exceptions should occur during concurrent consumer registration")
-    
+
     assert_equal(thread_count, clients_created.size, "All clients should be registered")
-    
+
     clients_created.each do |client_data|
       client = client_data[:client]
       identifier = client_data[:identifier]
-      
+
       assert(Semian.consumers.key?(identifier), "Consumer should be registered for identifier: #{identifier}")
-      
+
       consumer_map = Semian.consumers[identifier]
+
       assert_kind_of(ObjectSpace::WeakMap, consumer_map, "Consumer map should be a WeakMap")
       assert(consumer_map.key?(client), "Client should be registered in consumer map")
     end
-    
+
     clients_created.each do |client_data|
       resource = client_data[:resource]
       identifier = client_data[:identifier]
-      
+
       assert_equal(resource, Semian.resources[identifier], "Resource should match registered resource")
     end
   end

--- a/test/semian_test.rb
+++ b/test/semian_test.rb
@@ -589,8 +589,13 @@ class TestSemian < Minitest::Test
     begin
       # Test with thread_safe = true (default)
       Semian.thread_safe = true
-      resource = Semian.register(:test_threadsafe,
-        success_threshold: 1, error_threshold: 2, error_timeout: 5, bulkhead: false)
+      resource = Semian.register(
+        :test_threadsafe,
+        success_threshold: 1,
+        error_threshold: 2,
+        error_timeout: 5,
+        bulkhead: false,
+      )
 
       # Access private instance variables to check implementation
       errors = resource.circuit_breaker.instance_variable_get(:@errors)
@@ -601,8 +606,13 @@ class TestSemian < Minitest::Test
 
       # Test with thread_safe = false
       Semian.thread_safe = false
-      resource2 = Semian.register(:test_simple,
-        success_threshold: 1, error_threshold: 2, error_timeout: 5, bulkhead: false)
+      resource2 = Semian.register(
+        :test_simple,
+        success_threshold: 1,
+        error_threshold: 2,
+        error_timeout: 5,
+        bulkhead: false,
+      )
 
       errors2 = resource2.circuit_breaker.instance_variable_get(:@errors)
       successes2 = resource2.circuit_breaker.instance_variable_get(:@successes)
@@ -623,9 +633,14 @@ class TestSemian < Minitest::Test
       Semian.thread_safe = true
 
       # With thread_safety_disabled: true, should use Simple implementation
-      resource = Semian.register(:test_override_to_simple,
-        success_threshold: 1, error_threshold: 2, error_timeout: 5, 
-        bulkhead: false, thread_safety_disabled: true)
+      resource = Semian.register(
+        :test_override_to_simple,
+        success_threshold: 1,
+        error_threshold: 2,
+        error_timeout: 5,
+        bulkhead: false,
+        thread_safety_disabled: true,
+      )
 
       errors = resource.circuit_breaker.instance_variable_get(:@errors)
       successes = resource.circuit_breaker.instance_variable_get(:@successes)
@@ -634,9 +649,14 @@ class TestSemian < Minitest::Test
       assert_instance_of(Semian::Simple::Integer, successes)
 
       # With thread_safety_disabled: false, should use ThreadSafe implementation
-      resource2 = Semian.register(:test_override_to_threadsafe,
-        success_threshold: 1, error_threshold: 2, error_timeout: 5, 
-        bulkhead: false, thread_safety_disabled: false)
+      resource2 = Semian.register(
+        :test_override_to_threadsafe,
+        success_threshold: 1,
+        error_threshold: 2,
+        error_timeout: 5,
+        bulkhead: false,
+        thread_safety_disabled: false,
+      )
 
       errors2 = resource2.circuit_breaker.instance_variable_get(:@errors)
       successes2 = resource2.circuit_breaker.instance_variable_get(:@successes)

--- a/test/semian_test.rb
+++ b/test/semian_test.rb
@@ -582,4 +582,70 @@ class TestSemian < Minitest::Test
 
     assert_instance_of(Semian::ProtectedResource, resource)
   end
+
+  def test_implementation_selection_respects_thread_safe_setting
+    original_thread_safe = Semian.thread_safe?
+
+    begin
+      # Test with thread_safe = true (default)
+      Semian.thread_safe = true
+      resource = Semian.register(:test_threadsafe,
+        success_threshold: 1, error_threshold: 2, error_timeout: 5, bulkhead: false)
+
+      # Access private instance variables to check implementation
+      errors = resource.circuit_breaker.instance_variable_get(:@errors)
+      successes = resource.circuit_breaker.instance_variable_get(:@successes)
+
+      assert_instance_of(Semian::ThreadSafe::SlidingWindow, errors)
+      assert_instance_of(Semian::ThreadSafe::Integer, successes)
+
+      # Test with thread_safe = false
+      Semian.thread_safe = false
+      resource2 = Semian.register(:test_simple,
+        success_threshold: 1, error_threshold: 2, error_timeout: 5, bulkhead: false)
+
+      errors2 = resource2.circuit_breaker.instance_variable_get(:@errors)
+      successes2 = resource2.circuit_breaker.instance_variable_get(:@successes)
+
+      assert_instance_of(Semian::Simple::SlidingWindow, errors2)
+      assert_instance_of(Semian::Simple::Integer, successes2)
+    ensure
+      # Restore original setting
+      Semian.thread_safe = original_thread_safe
+    end
+  end
+
+  def test_implementation_selection_with_thread_safety_disabled_option
+    original_thread_safe = Semian.thread_safe?
+
+    begin
+      # Test that thread_safety_disabled option overrides global setting
+      Semian.thread_safe = true
+
+      # With thread_safety_disabled: true, should use Simple implementation
+      resource = Semian.register(:test_override_to_simple,
+        success_threshold: 1, error_threshold: 2, error_timeout: 5, 
+        bulkhead: false, thread_safety_disabled: true)
+
+      errors = resource.circuit_breaker.instance_variable_get(:@errors)
+      successes = resource.circuit_breaker.instance_variable_get(:@successes)
+
+      assert_instance_of(Semian::Simple::SlidingWindow, errors)
+      assert_instance_of(Semian::Simple::Integer, successes)
+
+      # With thread_safety_disabled: false, should use ThreadSafe implementation
+      resource2 = Semian.register(:test_override_to_threadsafe,
+        success_threshold: 1, error_threshold: 2, error_timeout: 5, 
+        bulkhead: false, thread_safety_disabled: false)
+
+      errors2 = resource2.circuit_breaker.instance_variable_get(:@errors)
+      successes2 = resource2.circuit_breaker.instance_variable_get(:@successes)
+
+      assert_instance_of(Semian::ThreadSafe::SlidingWindow, errors2)
+      assert_instance_of(Semian::ThreadSafe::Integer, successes2)
+    ensure
+      # Restore original setting
+      Semian.thread_safe = original_thread_safe
+    end
+  end
 end

--- a/test/simple_integer_test.rb
+++ b/test/simple_integer_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class TestSimpleInteger < Minitest::Test
   def setup
-    @integer = ::Semian::ThreadSafe::Integer.new
+    @integer = ::Semian::Simple::Integer.new
   end
 
   def teardown
@@ -52,54 +52,6 @@ class TestSimpleInteger < Minitest::Test
       assert_equal(0, @integer.value)
     end
 
-    def test_concurrent_increment_and_access
-      threads = []
-      thread_count = 5
-      values_read = Concurrent::Array.new
-
-      thread_count.times do |_i|
-        threads << Thread.new do
-          @integer.increment(1)
-          current_value = @integer.value
-          values_read << current_value
-        end
-      end
-
-      threads.each(&:join)
-
-      assert_equal(thread_count, @integer.value)
-      assert_equal(thread_count, values_read.size)
-
-      values_read.each do |value|
-        assert_operator(value, :>=, 1, "Read value #{value} should be at least 1")
-        assert_operator(value, :<=, thread_count, "Read value #{value} should be at most #{thread_count}")
-      end
-    end
-
-    def test_concurrent_reset
-      threads = []
-
-      assert_equal(0, @integer.value, "Integer should be initialized to 0")
-
-      4.times do
-        threads << Thread.new do
-          10.times { @integer.increment(1) }
-        end
-      end
-
-      threads << Thread.new do
-        sleep(0.01) # Let some increments happen first
-        @integer.reset
-      end
-
-      threads.each(&:join)
-
-      assert_equal(0, @integer.value, "Integer should be 0 after reset")
-
-      @integer.increment(5)
-
-      assert_equal(5, @integer.value, "Integer should work normally after reset")
-    end
   end
 
   include IntegerTestCases

--- a/test/simple_integer_test.rb
+++ b/test/simple_integer_test.rb
@@ -51,6 +51,54 @@ class TestSimpleInteger < Minitest::Test
 
       assert_equal(0, @integer.value)
     end
+
+    def test_concurrent_increment_and_access
+      threads = []
+      thread_count = 5
+      values_read = Concurrent::Array.new
+      
+      thread_count.times do |i|
+        threads << Thread.new do
+          @integer.increment(1)
+          current_value = @integer.value
+          values_read << current_value
+        end
+      end
+      
+      threads.each(&:join)
+      
+      assert_equal(thread_count, @integer.value)
+      assert_equal(thread_count, values_read.size)
+      
+      values_read.each do |value|
+        assert(value >= 1, "Read value #{value} should be at least 1")
+        assert(value <= thread_count, "Read value #{value} should be at most #{thread_count}")
+      end
+    end
+
+    def test_concurrent_reset
+      threads = []
+      
+      assert_equal(0, @integer.value, "Integer should be initialized to 0")
+      
+      4.times do
+        threads << Thread.new do
+          10.times { @integer.increment(1) }
+        end
+      end
+      
+      threads << Thread.new do
+        sleep(0.01) # Let some increments happen first
+        @integer.reset
+      end
+      
+      threads.each(&:join)
+      
+      assert_equal(0, @integer.value, "Integer should be 0 after reset")
+      
+      @integer.increment(5)
+      assert_equal(5, @integer.value, "Integer should work normally after reset")
+    end
   end
 
   include IntegerTestCases

--- a/test/simple_integer_test.rb
+++ b/test/simple_integer_test.rb
@@ -56,47 +56,48 @@ class TestSimpleInteger < Minitest::Test
       threads = []
       thread_count = 5
       values_read = Concurrent::Array.new
-      
-      thread_count.times do |i|
+
+      thread_count.times do |_i|
         threads << Thread.new do
           @integer.increment(1)
           current_value = @integer.value
           values_read << current_value
         end
       end
-      
+
       threads.each(&:join)
-      
+
       assert_equal(thread_count, @integer.value)
       assert_equal(thread_count, values_read.size)
-      
+
       values_read.each do |value|
-        assert(value >= 1, "Read value #{value} should be at least 1")
-        assert(value <= thread_count, "Read value #{value} should be at most #{thread_count}")
+        assert_operator(value, :>=, 1, "Read value #{value} should be at least 1")
+        assert_operator(value, :<=, thread_count, "Read value #{value} should be at most #{thread_count}")
       end
     end
 
     def test_concurrent_reset
       threads = []
-      
+
       assert_equal(0, @integer.value, "Integer should be initialized to 0")
-      
+
       4.times do
         threads << Thread.new do
           10.times { @integer.increment(1) }
         end
       end
-      
+
       threads << Thread.new do
         sleep(0.01) # Let some increments happen first
         @integer.reset
       end
-      
+
       threads.each(&:join)
-      
+
       assert_equal(0, @integer.value, "Integer should be 0 after reset")
-      
+
       @integer.increment(5)
+
       assert_equal(5, @integer.value, "Integer should work normally after reset")
     end
   end

--- a/test/simple_integer_test.rb
+++ b/test/simple_integer_test.rb
@@ -51,7 +51,6 @@ class TestSimpleInteger < Minitest::Test
 
       assert_equal(0, @integer.value)
     end
-
   end
 
   include IntegerTestCases

--- a/test/simple_sliding_window_test.rb
+++ b/test/simple_sliding_window_test.rb
@@ -39,7 +39,12 @@ class TestSimpleSlidingWindow < Minitest::Test
 
   def assert_sliding_window(sliding_window, array, max_size)
     # Get private member, the sliding_window doesn't expose the entire array
-    data = sliding_window.instance_variable_get("@window")
+    # Handle both old (@window) and new (@window_atom) implementations
+    if sliding_window.instance_variable_defined?("@window_atom")
+      data = sliding_window.instance_variable_get("@window_atom").value
+    else
+      data = sliding_window.instance_variable_get("@window")
+    end
 
     assert_equal(array, data)
     assert_equal(max_size, sliding_window.max_size)

--- a/test/simple_sliding_window_test.rb
+++ b/test/simple_sliding_window_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class TestSimpleSlidingWindow < Minitest::Test
   def setup
-    @sliding_window = ::Semian::ThreadSafe::SlidingWindow.new(max_size: 6)
+    @sliding_window = ::Semian::Simple::SlidingWindow.new(max_size: 6)
     @sliding_window.clear
   end
 
@@ -29,112 +29,11 @@ class TestSimpleSlidingWindow < Minitest::Test
     assert_sliding_window(@sliding_window, [2, 3, 4, 5, 6, 7], 6)
   end
 
-  def test_concurrent_push
-    threads = []
-    thread_count = 5
-
-    thread_count.times do |i|
-      threads << Thread.new do
-        @sliding_window << (i + 1)
-      end
-    end
-
-    threads.each(&:join)
-
-    assert_equal(thread_count, @sliding_window.size)
-
-    final_window_data = if @sliding_window.instance_variable_defined?("@window_atom")
-      @sliding_window.instance_variable_get("@window_atom").value
-    else
-      @sliding_window.instance_variable_get("@window")
-    end
-
-    assert_kind_of(Array, final_window_data)
-    assert_equal(thread_count, final_window_data.size)
-
-    final_window_data.each do |value|
-      assert_operator(value, :>=, 1, "Value #{value} should be at least 1")
-      assert_operator(value, :<=, thread_count, "Value #{value} should be at most #{thread_count}")
-    end
-  end
-
-  def test_concurrent_window_edge_falloff
-    threads = []
-    thread_count = 5
-    pushes_per_thread = 3 # Total pushes = 15, exceeds max_size of 6
-
-    thread_count.times do |i|
-      threads << Thread.new do
-        pushes_per_thread.times do |j|
-          value = i * pushes_per_thread + j
-          @sliding_window << value
-        end
-      end
-    end
-
-    threads.each(&:join)
-
-    assert_equal(@sliding_window.max_size, @sliding_window.size)
-
-    final_window_data = if @sliding_window.instance_variable_defined?("@window_atom")
-      @sliding_window.instance_variable_get("@window_atom").value
-    else
-      @sliding_window.instance_variable_get("@window")
-    end
-
-    assert_kind_of(Array, final_window_data)
-    assert_equal(@sliding_window.max_size, final_window_data.size)
-
-    final_window_data.each do |value|
-      assert_operator(value, :>=, 0, "Value #{value} should be non-negative")
-      assert_operator(value, :<, thread_count * pushes_per_thread, "Value #{value} should be less than total pushed")
-    end
-  end
-
-  def test_concurrent_resize_to_less_than_1_raises
-    threads = []
-    windows_created = Concurrent::Array.new
-
-    3.times do |i|
-      threads << Thread.new do
-        max_size = i == 0 ? 1 : (i + 1) # Use max_size values of 1, 2, 3
-        window = ::Semian::ThreadSafe::SlidingWindow.new(max_size: max_size)
-
-        window << (i + 10)
-        windows_created << { window: window, expected_size: 1, max_size: max_size }
-      end
-    end
-
-    threads.each(&:join)
-
-    assert_equal(3, windows_created.size, "All sliding windows should be created")
-
-    windows_created.each do |window_data|
-      window = window_data[:window]
-      expected_size = window_data[:expected_size]
-      max_size = window_data[:max_size]
-
-      assert_equal(expected_size, window.size, "Window should have expected size")
-      assert_equal(max_size, window.max_size, "Window should have correct max_size")
-      refute_empty(window, "Window should not be empty after push")
-    end
-
-    @sliding_window << 42
-
-    assert_equal(1, @sliding_window.size)
-    assert_equal(42, @sliding_window.last)
-  end
-
   private
 
   def assert_sliding_window(sliding_window, array, max_size)
     # Get private member, the sliding_window doesn't expose the entire array
-    # Handle both old (@window) and new (@window_atom) implementations
-    data = if sliding_window.instance_variable_defined?("@window_atom")
-      sliding_window.instance_variable_get("@window_atom").value
-    else
-      sliding_window.instance_variable_get("@window")
-    end
+    data = sliding_window.instance_variable_get("@window")
 
     assert_equal(array, data)
     assert_equal(max_size, sliding_window.max_size)

--- a/test/simple_sliding_window_test.rb
+++ b/test/simple_sliding_window_test.rb
@@ -29,10 +29,99 @@ class TestSimpleSlidingWindow < Minitest::Test
     assert_sliding_window(@sliding_window, [2, 3, 4, 5, 6, 7], 6)
   end
 
-  def resize_to_less_than_1_raises
-    assert_raises(ArgumentError) do
-      @sliding_window.resize_to(0)
+  def test_concurrent_push
+    threads = []
+    thread_count = 5
+    
+    thread_count.times do |i|
+      threads << Thread.new do
+        @sliding_window << (i + 1)
+      end
     end
+    
+    threads.each(&:join)
+    
+    assert_equal(thread_count, @sliding_window.size)
+    
+    final_window_data = if @sliding_window.instance_variable_defined?("@window_atom")
+      @sliding_window.instance_variable_get("@window_atom").value
+    else
+      @sliding_window.instance_variable_get("@window")
+    end
+    
+    assert_kind_of(Array, final_window_data)
+    assert_equal(thread_count, final_window_data.size)
+    
+    final_window_data.each do |value|
+      assert(value >= 1, "Value #{value} should be at least 1")
+      assert(value <= thread_count, "Value #{value} should be at most #{thread_count}")
+    end
+  end
+
+  def test_concurrent_window_edge_falloff
+    threads = []
+    thread_count = 5
+    pushes_per_thread = 3 # Total pushes = 15, exceeds max_size of 6
+    
+    thread_count.times do |i|
+      threads << Thread.new do
+        pushes_per_thread.times do |j|
+          value = i * pushes_per_thread + j
+          @sliding_window << value
+        end
+      end
+    end
+    
+    threads.each(&:join)
+    
+    assert_equal(@sliding_window.max_size, @sliding_window.size)
+    
+    final_window_data = if @sliding_window.instance_variable_defined?("@window_atom")
+      @sliding_window.instance_variable_get("@window_atom").value
+    else
+      @sliding_window.instance_variable_get("@window")
+    end
+    
+    assert_kind_of(Array, final_window_data)
+    assert_equal(@sliding_window.max_size, final_window_data.size)
+    
+    final_window_data.each do |value|
+      assert(value >= 0, "Value #{value} should be non-negative")
+      assert(value < thread_count * pushes_per_thread, "Value #{value} should be less than total pushed")
+    end
+  end
+
+  def test_concurrent_resize_to_less_than_1_raises
+    threads = []
+    windows_created = Concurrent::Array.new
+    
+    3.times do |i|
+      threads << Thread.new do
+        max_size = i == 0 ? 1 : (i + 1)  # Use max_size values of 1, 2, 3
+        window = ::Semian::ThreadSafe::SlidingWindow.new(max_size: max_size)
+        
+        window << (i + 10)
+        windows_created << { window: window, expected_size: 1, max_size: max_size }
+      end
+    end
+    
+    threads.each(&:join)
+    
+    assert_equal(3, windows_created.size, "All sliding windows should be created")
+    
+    windows_created.each do |window_data|
+      window = window_data[:window]
+      expected_size = window_data[:expected_size] 
+      max_size = window_data[:max_size]
+      
+      assert_equal(expected_size, window.size, "Window should have expected size")
+      assert_equal(max_size, window.max_size, "Window should have correct max_size")
+      refute(window.empty?, "Window should not be empty after push")
+    end
+    
+    @sliding_window << 42
+    assert_equal(1, @sliding_window.size)
+    assert_equal(42, @sliding_window.last)
   end
 
   private

--- a/test/thread_safe_integer_test.rb
+++ b/test/thread_safe_integer_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestThreadSafeInteger < Minitest::Test
+  def setup
+    @integer = ::Semian::ThreadSafe::Integer.new
+  end
+
+  def teardown
+    @integer.destroy
+  end
+
+  module IntegerTestCases
+    def test_access_value
+      assert_equal(0, @integer.value)
+      @integer.value = 99
+
+      assert_equal(99, @integer.value)
+      time_now = Time.now.to_i
+      @integer.value = time_now
+
+      assert_equal(time_now, @integer.value)
+      @integer.value = 6
+
+      assert_equal(6, @integer.value)
+      @integer.value = 6
+
+      assert_equal(6, @integer.value)
+    end
+
+    def test_increment
+      @integer.increment(4)
+
+      assert_equal(4, @integer.value)
+      @integer.increment
+
+      assert_equal(5, @integer.value)
+      @integer.increment(-2)
+
+      assert_equal(3, @integer.value)
+    end
+
+    def test_reset_on_init
+      assert_equal(0, @integer.value)
+    end
+
+    def test_reset
+      @integer.increment(5)
+      @integer.reset
+
+      assert_equal(0, @integer.value)
+    end
+
+    def test_concurrent_increment_and_access
+      threads = []
+      thread_count = 5
+      values_read = Concurrent::Array.new
+
+      thread_count.times do |_i|
+        threads << Thread.new do
+          @integer.increment(1)
+          current_value = @integer.value
+          values_read << current_value
+        end
+      end
+
+      threads.each(&:join)
+
+      assert_equal(thread_count, @integer.value)
+      assert_equal(thread_count, values_read.size)
+
+      values_read.each do |value|
+        assert_operator(value, :>=, 1, "Read value #{value} should be at least 1")
+        assert_operator(value, :<=, thread_count, "Read value #{value} should be at most #{thread_count}")
+      end
+    end
+
+    def test_concurrent_reset
+      threads = []
+
+      assert_equal(0, @integer.value, "Integer should be initialized to 0")
+
+      4.times do
+        threads << Thread.new do
+          10.times { @integer.increment(1) }
+        end
+      end
+
+      threads << Thread.new do
+        sleep(0.01) # Let some increments happen first
+        @integer.reset
+      end
+
+      threads.each(&:join)
+
+      assert_equal(0, @integer.value, "Integer should be 0 after reset")
+
+      @integer.increment(5)
+
+      assert_equal(5, @integer.value, "Integer should work normally after reset")
+    end
+  end
+
+  include IntegerTestCases
+end

--- a/test/thread_safe_integer_test.rb
+++ b/test/thread_safe_integer_test.rb
@@ -88,7 +88,6 @@ class TestThreadSafeInteger < Minitest::Test
       end
 
       threads << Thread.new do
-        sleep(0.01) # Let some increments happen first
         @integer.reset
       end
 

--- a/test/thread_safe_sliding_window_test.rb
+++ b/test/thread_safe_sliding_window_test.rb
@@ -43,11 +43,7 @@ class TestThreadSafeSlidingWindow < Minitest::Test
 
     assert_equal(thread_count, @sliding_window.size)
 
-    final_window_data = if @sliding_window.instance_variable_defined?("@window_atom")
-      @sliding_window.instance_variable_get("@window_atom").value
-    else
-      @sliding_window.instance_variable_get("@window")
-    end
+    final_window_data = @sliding_window.instance_variable_get("@window_atom").value
 
     assert_kind_of(Array, final_window_data)
     assert_equal(thread_count, final_window_data.size)
@@ -76,11 +72,7 @@ class TestThreadSafeSlidingWindow < Minitest::Test
 
     assert_equal(@sliding_window.max_size, @sliding_window.size)
 
-    final_window_data = if @sliding_window.instance_variable_defined?("@window_atom")
-      @sliding_window.instance_variable_get("@window_atom").value
-    else
-      @sliding_window.instance_variable_get("@window")
-    end
+    final_window_data = @sliding_window.instance_variable_get("@window_atom").value
 
     assert_kind_of(Array, final_window_data)
     assert_equal(@sliding_window.max_size, final_window_data.size)
@@ -129,12 +121,7 @@ class TestThreadSafeSlidingWindow < Minitest::Test
 
   def assert_sliding_window(sliding_window, array, max_size)
     # Get private member, the sliding_window doesn't expose the entire array
-    # Handle both old (@window) and new (@window_atom) implementations
-    data = if sliding_window.instance_variable_defined?("@window_atom")
-      sliding_window.instance_variable_get("@window_atom").value
-    else
-      sliding_window.instance_variable_get("@window")
-    end
+    data = sliding_window.instance_variable_get("@window_atom").value
 
     assert_equal(array, data)
     assert_equal(max_size, sliding_window.max_size)

--- a/test/thread_safe_sliding_window_test.rb
+++ b/test/thread_safe_sliding_window_test.rb
@@ -43,7 +43,7 @@ class TestThreadSafeSlidingWindow < Minitest::Test
 
     assert_equal(thread_count, @sliding_window.size)
 
-    final_window_data = @sliding_window.instance_variable_get("@window_atom").value
+    final_window_data = @sliding_window.instance_variable_get("@window")
 
     assert_kind_of(Array, final_window_data)
     assert_equal(thread_count, final_window_data.size)
@@ -72,7 +72,7 @@ class TestThreadSafeSlidingWindow < Minitest::Test
 
     assert_equal(@sliding_window.max_size, @sliding_window.size)
 
-    final_window_data = @sliding_window.instance_variable_get("@window_atom").value
+    final_window_data = @sliding_window.instance_variable_get("@window")
 
     assert_kind_of(Array, final_window_data)
     assert_equal(@sliding_window.max_size, final_window_data.size)
@@ -121,7 +121,7 @@ class TestThreadSafeSlidingWindow < Minitest::Test
 
   def assert_sliding_window(sliding_window, array, max_size)
     # Get private member, the sliding_window doesn't expose the entire array
-    data = sliding_window.instance_variable_get("@window_atom").value
+    data = sliding_window.instance_variable_get("@window")
 
     assert_equal(array, data)
     assert_equal(max_size, sliding_window.max_size)

--- a/test/thread_safe_sliding_window_test.rb
+++ b/test/thread_safe_sliding_window_test.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestThreadSafeSlidingWindow < Minitest::Test
+  def setup
+    @sliding_window = ::Semian::ThreadSafe::SlidingWindow.new(max_size: 6)
+    @sliding_window.clear
+  end
+
+  def teardown
+    @sliding_window.destroy
+  end
+
+  def test_sliding_window_push
+    assert_equal(0, @sliding_window.size)
+    @sliding_window << 1
+
+    assert_sliding_window(@sliding_window, [1], 6)
+    @sliding_window << 5
+
+    assert_sliding_window(@sliding_window, [1, 5], 6)
+  end
+
+  def test_sliding_window_edge_falloff
+    assert_equal(0, @sliding_window.size)
+    @sliding_window << 0 << 1 << 2 << 3 << 4 << 5 << 6 << 7
+
+    assert_sliding_window(@sliding_window, [2, 3, 4, 5, 6, 7], 6)
+  end
+
+  def test_concurrent_push
+    threads = []
+    thread_count = 5
+
+    thread_count.times do |i|
+      threads << Thread.new do
+        @sliding_window << (i + 1)
+      end
+    end
+
+    threads.each(&:join)
+
+    assert_equal(thread_count, @sliding_window.size)
+
+    final_window_data = if @sliding_window.instance_variable_defined?("@window_atom")
+      @sliding_window.instance_variable_get("@window_atom").value
+    else
+      @sliding_window.instance_variable_get("@window")
+    end
+
+    assert_kind_of(Array, final_window_data)
+    assert_equal(thread_count, final_window_data.size)
+
+    final_window_data.each do |value|
+      assert_operator(value, :>=, 1, "Value #{value} should be at least 1")
+      assert_operator(value, :<=, thread_count, "Value #{value} should be at most #{thread_count}")
+    end
+  end
+
+  def test_concurrent_window_edge_falloff
+    threads = []
+    thread_count = 5
+    pushes_per_thread = 3 # Total pushes = 15, exceeds max_size of 6
+
+    thread_count.times do |i|
+      threads << Thread.new do
+        pushes_per_thread.times do |j|
+          value = i * pushes_per_thread + j
+          @sliding_window << value
+        end
+      end
+    end
+
+    threads.each(&:join)
+
+    assert_equal(@sliding_window.max_size, @sliding_window.size)
+
+    final_window_data = if @sliding_window.instance_variable_defined?("@window_atom")
+      @sliding_window.instance_variable_get("@window_atom").value
+    else
+      @sliding_window.instance_variable_get("@window")
+    end
+
+    assert_kind_of(Array, final_window_data)
+    assert_equal(@sliding_window.max_size, final_window_data.size)
+
+    final_window_data.each do |value|
+      assert_operator(value, :>=, 0, "Value #{value} should be non-negative")
+      assert_operator(value, :<, thread_count * pushes_per_thread, "Value #{value} should be less than total pushed")
+    end
+  end
+
+  def test_concurrent_resize_to_less_than_1_raises
+    threads = []
+    windows_created = Concurrent::Array.new
+
+    3.times do |i|
+      threads << Thread.new do
+        max_size = i == 0 ? 1 : (i + 1) # Use max_size values of 1, 2, 3
+        window = ::Semian::ThreadSafe::SlidingWindow.new(max_size: max_size)
+
+        window << (i + 10)
+        windows_created << { window: window, expected_size: 1, max_size: max_size }
+      end
+    end
+
+    threads.each(&:join)
+
+    assert_equal(3, windows_created.size, "All sliding windows should be created")
+
+    windows_created.each do |window_data|
+      window = window_data[:window]
+      expected_size = window_data[:expected_size]
+      max_size = window_data[:max_size]
+
+      assert_equal(expected_size, window.size, "Window should have expected size")
+      assert_equal(max_size, window.max_size, "Window should have correct max_size")
+      refute_empty(window, "Window should not be empty after push")
+    end
+
+    @sliding_window << 42
+
+    assert_equal(1, @sliding_window.size)
+    assert_equal(42, @sliding_window.last)
+  end
+
+  private
+
+  def assert_sliding_window(sliding_window, array, max_size)
+    # Get private member, the sliding_window doesn't expose the entire array
+    # Handle both old (@window) and new (@window_atom) implementations
+    data = if sliding_window.instance_variable_defined?("@window_atom")
+      sliding_window.instance_variable_get("@window_atom").value
+    else
+      sliding_window.instance_variable_get("@window")
+    end
+
+    assert_equal(array, data)
+    assert_equal(max_size, sliding_window.max_size)
+  end
+end


### PR DESCRIPTION
Fixes #566 

Replace instances of data structures that are not thread safe and migrates existing thread safe code to use the concurrent-ruby gem

Includes unit tests to ensure correctness, thread safety and triggering race conditions will be followed up in #756 