### PR TITLE
Making `consumers` and `resources` private in Semian

### DIFF
--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -298,6 +298,8 @@ module Semian
     end
   end
 
+  private
+
   def create_circuit_breaker(name, **options)
     return if ENV.key?("SEMIAN_CIRCUIT_BREAKER_DISABLED")
     return unless options.fetch(:circuit_breaker, true)


### PR DESCRIPTION
As discussed with @brendo, we want to have these fields private to prevent cases like `Semian.resources = "foo"`. We should only have interaction with these fields through public methods