### PR TITLE
Set error rates deterministically

### DIFF
--- a/lib/semian.rb
+++ b/lib/semian.rb
@@ -324,6 +324,7 @@ module Semian
       ping_interval: 1.0,           # 1 second between health checks
       thread_safe: Semian.thread_safe?,
       enable_background_ping: true, # Always enabled for proper recovery detection
+      seed_error_rate: options[:seed_error_rate] || 0.01, # Allow customization via Semian options
     )
   end
 

--- a/lib/semian/adaptive_circuit_breaker.rb
+++ b/lib/semian/adaptive_circuit_breaker.rb
@@ -9,7 +9,8 @@ module Semian
 
     def initialize(name:, kp: 1.0, ki: 0.1, kd: 0.01,
       window_size: 10, history_duration: 3600,
-      ping_interval: 1.0, thread_safe: true, enable_background_ping: true)
+      ping_interval: 1.0, thread_safe: true, enable_background_ping: true,
+      seed_error_rate: 0.01)
       @name = name
       @window_size = window_size
       @ping_interval = ping_interval
@@ -28,6 +29,7 @@ module Semian
           kd: kd,
           window_size: window_size,
           history_duration: history_duration,
+          seed_error_rate: seed_error_rate,
         )
       else
         PIDController.new(
@@ -37,6 +39,7 @@ module Semian
           kd: kd,
           window_size: window_size,
           history_duration: history_duration,
+          seed_error_rate: seed_error_rate,
         )
       end
 

--- a/lib/semian/pid_controller.rb
+++ b/lib/semian/pid_controller.rb
@@ -12,7 +12,7 @@ module Semian
     attr_reader :name, :rejection_rate
 
     def initialize(name:, kp: 1.0, ki: 0.1, kd: 0.0, target_error_rate: nil,
-      window_size: 10, history_duration: 3600)
+      window_size: 10, history_duration: 3600, seed_error_rate: 0.01)
       @name = name
 
       # PID coefficients
@@ -30,8 +30,9 @@ module Semian
       @target_error_rate = target_error_rate
 
       # Metrics tracking
-      @error_rate_history = []
       @max_history_size = history_duration / window_size # Number of windows to keep
+      # Prefill history with baseline error rate for immediate p90 calculation
+      @error_rate_history = Array.new(@max_history_size, seed_error_rate)
 
       # Discrete window tracking
       @window_size = window_size # Time window in seconds


### PR DESCRIPTION
fixes [#6553](https://github.com/Shopify/resiliency/issues/6553)
### Changes
- **Added `deterministic_errors` parameter** (default: `false`)
- **Phase-synchronized error injection** that precisely targets error rates
- **Smart failure logic**: calculates error rate for fail/pass options, chooses whichever gets closer to target
- **Counter tracking**: `@current_phase_requests` and `@current_phase_failures` reset on error rate changes
- **PID error rate history prefilling**: Initialize the entire `error_rate_history` array with the `seed_error_rate value`

### How It Works

- **Deterministic errors**: Instead of `rand < error_rate`, calculates which decision (fail/pass) produces an error rate closest to target. Resets counters between test phases for perfect synchronization.

- **PID prefilling**: Fills error rate history with baseline values so p90 calculations work immediately instead of waiting to accumulate real data.

- **Result**: Reproducible experiments with exact error rate targeting and immediate PID controller responsiveness.

### Future Work
- I will also work on adding a config map to store error rate history from all web workers to prefill new instances with real world data instead of a arbitrary value.
