### PR TITLE
Add `concurrent-ruby` runtime dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,7 @@ PATH
   remote: .
   specs:
     semian (0.26.5)
+      concurrent-ruby
 
 GEM
   remote: https://rubygems.org/

--- a/semian.gemspec
+++ b/semian.gemspec
@@ -27,6 +27,8 @@ Gem::Specification.new do |s|
     "source_code_uri" => "https://github.com/Shopify/semian",
   }
 
+  s.add_runtime_dependency("concurrent-ruby")
+
   s.required_ruby_version = ">= 3.2.0"
 
   s.files = Dir["{lib,ext}/**/**/*.{rb,h,c}"]


### PR DESCRIPTION
It was brought to my attention that some repositories using Semian don't have `concurrent-ruby`. This PR adds the gem as a runtime dependency so that these repositories don't have to install it themselves