### PR TITLE
Remove force_config log

### DIFF
--- a/lib/semian/configuration_validator.rb
+++ b/lib/semian/configuration_validator.rb
@@ -7,12 +7,6 @@ module Semian
       @configuration = configuration
       @adapter = configuration[:adapter]
       @force_config_validation = force_config_validation?
-
-      unless @force_config_validation
-        Semian.logger.info(
-          "Semian Resource #{@name} is running in log-mode for configuration validation. This means that Semian will not raise an error if the configuration is invalid. This is not recommended for production environments.\n\n[IMPORTANT] PLEASE UPDATE YOUR CONFIGURATION TO USE `force_config_validation: true` TO ENABLE STRICT CONFIGURATION VALIDATION.\n---\n",
-        )
-      end
     end
 
     def validate!


### PR DESCRIPTION
Fixes [#6567](https://github.com/Shopify/resiliency/issues/6567)
Delete info message about force_config_validation not being set in Semian configurations. This log got too spammy and was deemed ineffective.

Tested by running `dev server` locally in the Shopify repo and pointing its Semian gem to this branch. Everything looks good!