### PR TITLE
Add thread timing utilization metrics for experiments

### DIFF
--- a/experiments/test_helpers.rb
+++ b/experiments/test_helpers.rb
@@ -163,7 +163,6 @@ module Semian
               if semian_resource&.circuit_breaker
                 metrics = semian_resource.circuit_breaker.pid_controller.metrics
 
-                # Calculate total time spent making requests across all threads
                 total_request_time = @thread_timings.values.sum { |t| t[:samples].sum { |s| s[:duration] } }
 
                 @pid_mutex.synchronize do
@@ -347,7 +346,6 @@ module Semian
           bucket_end = bucket_start + small_bucket_size
           bucket_data = @outcomes.select { |time, _| time >= bucket_start && time < bucket_end }
 
-          # Calculate sum of request durations from all samples in this bucket
           bucket_samples = []
           @thread_timings.each_value do |thread_data|
             bucket_samples.concat(thread_data[:samples].select { |s| s[:timestamp] >= bucket_start && s[:timestamp] < bucket_end })


### PR DESCRIPTION
Add a summary which captures the amount of time spent making requests per thread, which looks like this:

```
=== Thread Timing Statistics ===
Total threads: 60
Test wall clock duration: 180.00s

Time spent making requests per thread:
  Min:     45.23s
  Max:     52.17s
  Average: 48.50s
  Total (all threads): 2910.00s

Thread utilization:
  Average: 26.94% (time in requests / wall clock time)

Requests per thread:
  Average: 8000 requests
  Average time per request: 0.0061s
```

Additionally, a second graph is created to visualize the total time spent making requests, with `duration-` as a filename prefix (the rest of the filename is re-used). Duration graph:
 
<img width="1400" height="1050" alt="duration-sudden_error_spike_20_adaptive" src="https://github.com/user-attachments/assets/3f1b0be2-4f12-4da5-83d0-691cb950673e" />
