### PR TITLE
expose rejection_rate attribute

### DIFF
--- a/lib/semian/pid_controller.rb
+++ b/lib/semian/pid_controller.rb
@@ -10,6 +10,8 @@ module Semian
   # Note: P increases when error_rate increases
   #       P decreases when rejection_rate increases (providing feedback)
   class PIDController
+    attr_reader :name, :rejection_rate
+
     def initialize(kp:, ki:, kd:, window_size:, initial_history_duration:, initial_error_rate:)
       # PID coefficients
       @kp = kp  # Proportional gain


### PR DESCRIPTION
Expose rejection_rate attribute so experiments can report on the rejection rate.

Fixes this error from https://github.com/Shopify/semian/pull/820/files.

```
/Users/adriangudas/src/github.com/Shopify/semian/lib/semian/adaptive_circuit_breaker.rb:50:in 'Semian::AdaptiveCircuitBreaker#acquire': undefined method 'rejection_rate' for an instance of Semian::ThreadSafePIDController (NoMethodError)

        raise OpenCircuitError, "Rejected by adaptive circuit breaker (rejection_rate: #{@pid_controller.rejection_rate})"
                                                                                                        ^^^^^^^^^^^^^^^
```
