### PR TITLE
Add option to run a specific example

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,9 @@ For the `Net::HTTP` specific Semian adapter, since many external libraries may c
 HTTP connections on the user's behalf, the parameters are instead provided
 by associating callback functions with `Semian::NetHTTP`, perhaps in an initialization file.
 
+Example cases for `net-http` can be run using
+`BUNDLE_GEMFILE=gemfiles/net_http.gemfile bundle exec rake examples:net_http`. The filename of an example can also be passed optionally as an argument to run a specific example (e.g., `examples:net_http[03_circuit_open]`).
+
 ##### Naming and Options
 
 To give Semian parameters, assign a `proc` to `Semian::NetHTTP.semian_configuration`
@@ -394,7 +397,7 @@ default: &default
 ```
 
 Example cases for `activerecord-trilogy-adapter` can be run using
-`BUNDLE_GEMFILE=gemfiles/activerecord_trilogy_adapter.gemfile bundle exec rake examples:activerecord_trilogy_adapter`
+`BUNDLE_GEMFILE=gemfiles/activerecord_trilogy_adapter.gemfile bundle exec rake examples:activerecord_trilogy_adapter`. The filename of an example can also be passed optionally as an argument to run a specific example (e.g., `examples:activerecord_trilogy_adapter[03_circuit_open]`).
 
 # Understanding Semian
 

--- a/Rakefile
+++ b/Rakefile
@@ -107,8 +107,14 @@ end
 
 namespace :examples do
   desc "Run examples for net_http"
-  task :net_http do
-    Dir["examples/net_http/*.rb"].entries.each do |f|
+  task :net_http, [:file] do |_, args|
+    files = if args[:file]
+      ["examples/net_http/#{args[:file]}.rb"]
+    else
+      Dir["examples/net_http/*.rb"]
+    end
+
+    files.each do |f|
       ruby f do |ok, status|
         if !ok && status.respond_to?(:signaled?) && status.signaled?
           raise SignalException, status.termsig
@@ -123,8 +129,14 @@ namespace :examples do
   end
 
   desc "Run examples for activerecord-trilogy-adapter"
-  task :activerecord_trilogy_adapter do
-    Dir["examples/activerecord_trilogy_adapter/*.rb"].entries.each do |f|
+  task :activerecord_trilogy_adapter, [:file] do |_, args|
+    files = if args[:file]
+      ["examples/activerecord_trilogy_adapter/#{args[:file]}.rb"]
+    else
+      Dir["examples/activerecord_trilogy_adapter/*.rb"]
+    end
+
+    files.each do |f|
       ruby f do |ok, status|
         if !ok && status.respond_to?(:signaled?) && status.signaled?
           raise SignalException, status.termsig


### PR DESCRIPTION
It's currently not possible to run a specific example without manually modifying the `Rakefile`. But it would be helpful to have that option in cases where someone is only interested in running a single example. This PR adds an optional argument to the tasks in the `:examples` namespace to allow users to run a single example by specifying its filename.