### PR TITLE
Remove @name from error log in PIDControllerThread

### DIFF
--- a/lib/semian/pid_controller_thread.rb
+++ b/lib/semian/pid_controller_thread.rb
@@ -29,7 +29,7 @@ module Semian
             circuit_breaker.pid_controller_update
           end
         rescue => e
-          Semian.logger&.warn("[#{@name}] PID controller update thread error: #{e.message}")
+          Semian.logger&.warn("PID controller update thread error: #{e.message}")
         end
       end
 


### PR DESCRIPTION
The PIDControllerThread does not have a `@name` property since it is shared among all adaptive circuit breakers. This must be a left-over from when we moved things around. I'm surprised the linter didn't catch this though