### PR TITLE
No-op - Pinning github actions to commit SHAs

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -93,7 +93,7 @@ jobs:
             "${{ needs.read-version.outputs.current_version }}"
       -
         name: Create pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676  # v7
         with:
           token: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
           branch: release/v${{ needs.read-version.outputs.new_version }}


### PR DESCRIPTION
## Why?

By using `some-org/some-action@v3` you are trusting a mutable tag. If the upstream repo is compromised, a force-pushed `v3` ships malicious code into your workflow on the next run — see [tj-actions/changed-files (March 2025)](https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-github-action-cve-2025-30066) for recent real-world cases that leaked secrets across thousands of downstream workflows.

Pinning to a full 40-char SHA (`uses: tj-actions/changed-files@<sha> # v45.0.3`) makes the reference immutable and helps to mitigate this type of supply chain attacks.


cc @beepubapu @michaelherold for review.