### PR TITLE
Fix Semian resource allocator pairing

### DIFF
--- a/ext/semian/resource.c
+++ b/ext/semian/resource.c
@@ -234,7 +234,7 @@ semian_resource_initialize(VALUE self, VALUE id, VALUE tickets, VALUE quota, VAL
 
   // Populate struct fields
   ms_to_timespec(c_timeout * 1000, &res->timeout);
-  res->name = strdup(c_id_str);
+  res->name = ruby_strdup(c_id_str);
   res->quota = c_quota;
   res->wait_time = -1;
 
@@ -370,11 +370,18 @@ static void
 semian_resource_free(void *ptr)
 {
   semian_resource_t *res = (semian_resource_t *) ptr;
+
   if (res->name) {
-    free(res->name);
+    xfree(res->name); // ruby_strdup
     res->name = NULL;
   }
-  xfree(res);
+
+  if (res->strkey) {
+    free(res->strkey); // malloc
+    res->strkey = NULL;
+  }
+
+  xfree(res); // TypedData_Make_Struct
 }
 
 static size_t

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -424,6 +424,15 @@ class TestResource < Minitest::Test
     assert_equal("0x874714f2", resource.key)
   end
 
+  def test_resource_native_memory_can_be_reclaimed_by_gc
+    # Regression coverage for Semian::Resource's native free callback. ASAN/LSAN
+    # builds catch allocator mismatches and leaked native fields when GC runs it.
+    10.times do |i|
+      create_and_destroy_untracked_resource("testing_gc_#{Process.pid}_#{i}")
+      GC.start(full_mark: true, immediate_sweep: true)
+    end
+  end
+
   def test_count
     resource = create_resource(:testing, tickets: 2)
     acquired = false
@@ -598,6 +607,13 @@ class TestResource < Minitest::Test
     resource = Semian::Resource.new(name, **kwargs)
     @resources << resource
     resource
+  end
+
+  def create_and_destroy_untracked_resource(name)
+    resource = create_resource(name, tickets: 1)
+    resource.destroy
+    @resources.delete(resource)
+    nil
   end
 
   def destroy_resources


### PR DESCRIPTION
Ruby headers redefine [strdup to ruby_strdup](https://github.com/ruby/ruby/blob/8e5cf5cecaa59a8409d0ac21ac33d5b16f2cdbbf/include/ruby/util.h#L168-L187), so res->name was allocated with Ruby's allocator even though it looked like libc strdup. Free it with xfree instead of free, and make the allocation explicit with ruby_strdup.

Also release the malloc'd strkey field and add GC regression coverage for native resource cleanup.